### PR TITLE
DC-72(Chore): Only run pre-commit hook against relevant changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -21,7 +21,7 @@ cd "$PROJECT_ROOT"
 
 # Check if there are backend changes in staged files
 has_backend_changes() {
-  git diff --cached --name-only | grep -qE '^SEBT\.Portal\.sln$|^src/SEBT\.Portal\.(Api|Core|Infrastructure|Kernel|Kernel\.AspNetCore|UseCases)/|\.(csproj|sln)$' || return 1
+  git diff --cached --name-only | grep -vE '^src/SEBT\.Portal\.Web' | grep -qE '^SEBT\.Portal\.sln$|^src/SEBT\.Portal\.|\.(csproj|sln)$' || return 1
 }
 
 # Check if there are frontend changes in staged files


### PR DESCRIPTION
The changes in this PR is the following

* Updates the Husky pre-commit hook to run checks only for changed code. 
* Separates the steps so it only does the relevant step a developer would care about (Doesn't run backend checks/build if the relevant changes never touched those spots.

Previously, it ran all checks on every commit, even for a one-line typo fix. Now it detects backend (`.cs`, `.csproj`, `.sln` in backend directories) and frontend (`src/SEBT.Portal.Web/`) changes via `git diff --cached`, and conditionally runs only the relevant checks: 
 * Backend changes trigger .NET formatting, build, and tests.  
 * Frontend changes trigger lint-staged, build, and tests related to the Node.js project in particular
 * It will do **neither** of them if there's only staged file changes outside of the scope of things related to building or linters (for example, `README.md`)
 
These changes also includes a mildly annoying directory navigation fix by ensuring the script returns to the project root after operations, and dynamically adjusts step numbering based on which checks run to make it easier to debug as needed.