### PR TITLE
DC(Fix): Make standalone output conditional to fix local build 404s

### DIFF
--- a/.github/workflows/scripts/build-frontend.sh
+++ b/.github/workflows/scripts/build-frontend.sh
@@ -124,9 +124,9 @@ build_frontend() {
 
   # Build uses Next.js with automatic prebuild hook
   # prebuild runs: pnpm tokens:all (generates design tokens for all states)
-  # build runs: next build (outputs to .next/standalone)
+  # build runs: next build (standalone output for CI/Docker deployments)
   log_info "Running Next.js build (includes token generation via prebuild hook)..."
-  pnpm build
+  BUILD_STANDALONE=true pnpm build
 
   log_success "Frontend build complete"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY src/SEBT.Portal.Web/ ./src/SEBT.Portal.Web/
 # Build frontend with state-specific configuration
 ENV STATE=${STATE}
 ENV NODE_ENV=production
+ENV BUILD_STANDALONE=true
 RUN pnpm --filter @sebt/web build
 
 # ============================================

--- a/src/SEBT.Portal.Web/next.config.ts
+++ b/src/SEBT.Portal.Web/next.config.ts
@@ -50,7 +50,9 @@ const nextConfig: NextConfig = {
       }
     }
   },
-  output: 'standalone', // For multi-state deployments
+  // Standalone output for Docker/CI deployments only (set BUILD_STANDALONE=true)
+  // Local dev uses standard output so `next start` serves public/ and static/ correctly
+  ...(process.env.BUILD_STANDALONE === 'true' && { output: 'standalone' as const }),
   poweredByHeader: false,
   reactStrictMode: true
 }


### PR DESCRIPTION
This pull request improves the build process for the frontend application, making it more flexible and better suited for different deployment environments (local development vs. Docker/CI). The main changes ensure that the Next.js build outputs a standalone bundle only when needed, controlled by the `BUILD_STANDALONE` environment variable.

**Build and deployment improvements:**

* Added the `BUILD_STANDALONE=true` environment variable to the Docker build process to ensure the Next.js build outputs a standalone bundle for Docker/CI deployments.
* Updated the frontend build script (`build-frontend.sh`) to set `BUILD_STANDALONE=true` when running `pnpm build`, ensuring the correct output format for CI/Docker environments.
* Modified `next.config.ts` to conditionally set the Next.js `output: 'standalone'` option only when `BUILD_STANDALONE` is set to `'true'`, allowing local development to use the standard output for better compatibility.