### PR TITLE
Fix prebuild to generate tokens for target STATE only

### DIFF
--- a/src/SEBT.Portal.Web/package.json
+++ b/src/SEBT.Portal.Web/package.json
@@ -14,7 +14,7 @@
     "postinstall": "pnpm copy-uswds-assets",
     "predev": "node design/scripts/state-banner.js && pnpm --silent tokens && pnpm --silent tokens:sass && pnpm --silent tokens:fonts && pnpm --silent copy:generate",
     "dev": "next dev --turbopack",
-    "prebuild": "node design/scripts/state-banner.js && pnpm --silent tokens:all && pnpm --silent copy:generate",
+    "prebuild": "node design/scripts/state-banner.js && pnpm --silent tokens && pnpm --silent tokens:sass && pnpm --silent tokens:fonts && pnpm --silent copy:generate",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
### Changes
- Fix `prebuild` script to generate design tokens for only the target `STATE` instead of all states                                               
  - The previous `tokens:all` script generated SASS settings for every state sequentially, causing the last state (CO) to overwrite DC's            
  `_uswds-settings.scss`                                                                                                                          
  - Replaces `tokens:all` with individual `tokens`, `tokens:sass`, and `tokens:fonts` calls which respect the `STATE` environment variable          
                                                                                                                                                    
### Context
The DC deployed environment was rendering with CO's red theme colors because `generate-all-tokens.js` loops through all states (`dc`, then `co`), and each iteration overwrites the same `_uswds-settings.scss` file. Since CO runs last, its theme was active when `next build` compiled the SASS.
