### PR TITLE
Enable UseMockHoldholdData

### DIFF
--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -85,6 +85,7 @@ module "app" {
   image_tags_mutable     = true
   enable_execute_command = true
 
-  seeding_enabled       = "true"
-  seeding_email_pattern = "sebt.co+{0}@codeforamerica.org"
+  seeding_enabled         = "true"
+  seeding_email_pattern   = "sebt.co+{0}@codeforamerica.org"
+  use_mock_household_data = "true"
 }

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -85,6 +85,7 @@ module "app" {
   image_tags_mutable     = true
   enable_execute_command = true
 
-  seeding_enabled       = "true"
-  seeding_email_pattern = "sebt.dc+{0}@codeforamerica.org"
+  seeding_enabled         = "true"
+  seeding_email_pattern   = "sebt.dc+{0}@codeforamerica.org"
+  use_mock_household_data = "true"
 }

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -51,6 +51,7 @@ module "api" {
     "EmailOtpSenderServiceSettings__SenderEmail" = module.ses.sender_email
     "Seeding__Enabled"                           = var.seeding_enabled
     "Seeding__EmailPattern"                      = var.seeding_email_pattern
+    "UseMockHouseholdData"                       = var.use_mock_household_data
   }
 
   environment_secrets = {

--- a/tofu/modules/sebt_application/variables.tf
+++ b/tofu/modules/sebt_application/variables.tf
@@ -177,6 +177,12 @@ variable "seeding_email_pattern" {
   default     = ""
 }
 
+variable "use_mock_household_data" {
+  type        = string
+  description = "Enable mock household data seeding to create all test user scenarios."
+  default     = "false"
+}
+
 variable "secret_recovery_period" {
   type        = number
   description = "Number of days to retain a secret before permanent deletion."


### PR DESCRIPTION
- Add `UseMockHouseholdData` environment variable to ECS API task definition                                                                    
- Set to `true` in dev-dc and dev-co environments so the database seeder creates all 13 test user scenarios instead of only 3  

Without this flag, the seeder takes a simplified code path that only creates 3 users. With it enabled, all 13 `SeedScenarios` are seeded using the configured `Seeding__EmailPattern`.