### PR TITLE
feat: add MCP server configuration for coding agent dev tooling

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,11 @@
   "mcpServers": {
     "next-devtools": {
       "command": "npx",
-      "args": ["-y", "next-devtools-mcp@latest"]
+      "args": ["-y", "next-devtools-mcp@0.3.10"]
     },
     "docker": {
       "command": "npx",
-      "args": ["-y", "mcp-server-docker"]
+      "args": ["-y", "mcp-server-docker@1.0.0"]
     },
     "figma-remote-mcp": {
       "url": "https://mcp.figma.com/mcp"


### PR DESCRIPTION
This pull request introduces a new `.mcp.json` configuration file to the project. The file defines settings for multiple MCP servers, specifying commands and arguments for local servers and a URL for a remote server.

Configuration updates:

* Added `.mcp.json` file to configure MCP servers, including `next-devtools` and `docker` (with `npx` commands and arguments), and a remote `figma-remote-mcp` server with its URL.