### PR TITLE
DC-190(Bug) Fix: Add missing standalone flag

### DIFF
--- a/src/SEBT.Portal.Web/Dockerfile
+++ b/src/SEBT.Portal.Web/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /workspace
 # Build arg controls which state is embedded at build-time.
 ARG STATE=dc
 ENV STATE=$STATE
+ENV BUILD_STANDALONE=true
 
 # Install dependencies (root workspace)
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
This PR is a bugfix.  It fixes the following issue: 
- `main` branch isn't able to deploy due to not finding Web-related artifacts.

This PR does the following:
- Add `ENV BUILD_STANDALONE=true` flag to web Dockerfile.