### PR TITLE
DC-190 Fix: pin .net core version to 1.00.200 to get around Github Action Bug

### DIFF
--- a/.github/config/states/_template.yaml
+++ b/.github/config/states/_template.yaml
@@ -28,7 +28,7 @@ infrastructure:
 versions:
   node: "24"            # Node.js (Docker: node:24, Native: 24.x)
   pnpm: "10"            # pnpm (Docker: pnpm@10, Native: 10.x)
-  dotnet: "10.0"        # .NET SDK (Docker: sdk:10.0, Native: 10.0.x)
+  dotnet: "10.0.200"    # .NET SDK (Docker: sdk:10.0.200, Native: 10.0.200)
 
 # Build configuration
 build:

--- a/.github/config/states/co.yaml
+++ b/.github/config/states/co.yaml
@@ -16,7 +16,7 @@ infrastructure:
 versions:
   node: "24"
   pnpm: "10"
-  dotnet: "10.0"
+  dotnet: "10.0.200"
 
 build:
   configuration: "Release"

--- a/.github/config/states/dc.yaml
+++ b/.github/config/states/dc.yaml
@@ -16,7 +16,7 @@ infrastructure:
 versions:
   node: "24"
   pnpm: "10"
-  dotnet: "10.0"
+  dotnet: "10.0.200"
 
 build:
   configuration: "Release"

--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -126,9 +126,9 @@ jobs:
           fi
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v5.2.0
         with:
-          dotnet-version: "10.0"
+          dotnet-version: "10.0.200"
 
       - name: Checkout state-connector
         uses: actions/checkout@v6

--- a/.github/workflows/state-ci.yaml
+++ b/.github/workflows/state-ci.yaml
@@ -165,7 +165,7 @@ jobs:
       # Native Build Path
       - name: Setup .NET (Native)
         if: steps.config.outputs.use_docker != 'true'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ steps.config.outputs.dotnet_version }}
 


### PR DESCRIPTION
This PR does the following:

* Pin .NET Core version to 1.00.200.  

This is needed because one of our third-party Github Actions is fetching a .dotnet patch version that doesn't exist.  We plan to pin this to get around the issue for now until it's fixed or Microsoft updates their manifest.

Related build where the bug occurs: https://github.com/codeforamerica/sebt-self-service-portal/actions/runs/22917992564