### PR TITLE
POC: Add ability to get Household Data by Phone Number for CO

### DIFF
--- a/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
+++ b/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
@@ -20,4 +20,14 @@ internal sealed class DefaultSummerEbtCaseService : ISummerEbtCaseService
     {
         return Task.FromResult<HouseholdData?>(null);
     }
+
+    /// <inheritdoc />
+    public Task<HouseholdData?> GetHouseholdByGuardianPhoneAsync(
+        string guardianPhone,
+        PiiVisibility piiVisibility,
+        IdentityAssuranceLevel identityAssuranceLevel,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<HouseholdData?>(null);
+    }
 }

--- a/src/SEBT.Portal.Core/AppSettings/StateHouseholdIdSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/StateHouseholdIdSettings.cs
@@ -14,5 +14,5 @@ public class StateHouseholdIdSettings
     /// Ordered list of household ID types for authorization/linking.
     /// The first type that can be resolved from the user is used for lookup.
     /// </summary>
-    public List<PreferredHouseholdIdType> PreferredHouseholdIdTypes { get; set; } = [PreferredHouseholdIdType.Email];
+    public List<PreferredHouseholdIdType> PreferredHouseholdIdTypes { get; set; } = [];
 }

--- a/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
@@ -34,13 +34,18 @@ public class HouseholdRepository : IHouseholdRepository
         UserIalLevel userIalLevel,
         CancellationToken cancellationToken = default)
     {
-        if (identifier.Type != PreferredHouseholdIdType.Email)
+        if (identifier.Type == PreferredHouseholdIdType.Email)
         {
-            _logger.LogDebug("State plugin lookup supports only email identifier; ignoring type {Type}", identifier.Type);
-            return Task.FromResult<HouseholdData?>(null);
+            return GetHouseholdByEmailAsync(identifier.Value, piiVisibility, userIalLevel, cancellationToken);
         }
 
-        return GetHouseholdByEmailAsync(identifier.Value, piiVisibility, userIalLevel, cancellationToken);
+        if (identifier.Type == PreferredHouseholdIdType.Phone)
+        {
+            return GetHouseholdByPhoneAsync(identifier.Value, piiVisibility, userIalLevel, cancellationToken);
+        }
+
+        _logger.LogDebug("State plugin lookup does not support identifier type {Type}", identifier.Type);
+        return Task.FromResult<HouseholdData?>(null);
     }
 
     /// <inheritdoc />
@@ -115,6 +120,49 @@ public class HouseholdRepository : IHouseholdRepository
                     }
                     : null
         };
+    }
+
+    private async Task<HouseholdData?> GetHouseholdByPhoneAsync(
+        string phone,
+        PiiVisibility piiVisibility,
+        UserIalLevel userIalLevel,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(piiVisibility);
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return null;
+        }
+
+        _logger.LogDebug("Querying state plugin for household data by guardian phone");
+
+        var pluginPii = new PluginPiiVisibility(
+            piiVisibility.IncludeAddress,
+            piiVisibility.IncludeEmail,
+            piiVisibility.IncludePhone);
+        var pluginIal = (PluginIdentityAssuranceLevel)(int)userIalLevel;
+        var pluginHousehold = await _summerEbtCaseService.GetHouseholdByGuardianPhoneAsync(
+            phone,
+            pluginPii,
+            pluginIal,
+            cancellationToken);
+
+        if (pluginHousehold == null)
+        {
+            _logger.LogInformation("No household data found for guardian phone");
+            return null;
+        }
+
+        _logger.LogInformation(
+            "Retrieved household data for guardian by phone with {ApplicationCount} application(s)",
+            pluginHousehold.Applications.Count);
+
+        var core = PluginHouseholdDataMapper.ToCore(pluginHousehold);
+        if (core == null)
+        {
+            return null;
+        }
+        return ApplyPiiVisibility(core, piiVisibility);
     }
 
     /// <inheritdoc />

--- a/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
@@ -217,7 +217,56 @@ public class HouseholdRepositoryTests
     }
 
     [Fact]
-    public async Task GetHouseholdByIdentifierAsync_WhenNonEmailIdentifier_ReturnsNullWithoutCallingPlugin()
+    public async Task GetHouseholdByIdentifierAsync_WhenPhoneIdentifier_DelegatesToPlugin()
+    {
+        var phone = "555-123-4567";
+        var pluginData = new PluginHouseholdData
+        {
+            Email = "guardian@example.com",
+            Phone = phone,
+            BenefitIssuanceType = PluginBenefitIssuanceType.SummerEbt,
+            Applications = new List<PluginApplication>()
+        };
+        _summerEbtCaseService
+            .GetHouseholdByGuardianPhoneAsync(phone, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>())
+            .Returns(pluginData);
+
+        var result = await _repository.GetHouseholdByIdentifierAsync(
+            HouseholdIdentifier.Phone(phone), FullPii, UserIalLevel.IAL1plus);
+
+        Assert.NotNull(result);
+        await _summerEbtCaseService.Received(1)
+            .GetHouseholdByGuardianPhoneAsync(phone, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>());
+        await _summerEbtCaseService.DidNotReceive()
+            .GetHouseholdByGuardianEmailAsync(Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHouseholdByIdentifierAsync_WhenPhoneIdentifierAndPluginReturnsNull_ReturnsNull()
+    {
+        _summerEbtCaseService
+            .GetHouseholdByGuardianPhoneAsync(Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>())
+            .Returns((PluginHouseholdData?)null);
+
+        var result = await _repository.GetHouseholdByIdentifierAsync(
+            HouseholdIdentifier.Phone("555-000-0000"), FullPii, UserIalLevel.IAL1plus);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetHouseholdByIdentifierAsync_WhenPhoneIdentifierIsWhitespace_ReturnsNull()
+    {
+        var result = await _repository.GetHouseholdByIdentifierAsync(
+            HouseholdIdentifier.Phone("   "), FullPii, UserIalLevel.IAL1plus);
+
+        Assert.Null(result);
+        await _summerEbtCaseService.DidNotReceive()
+            .GetHouseholdByGuardianPhoneAsync(Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetHouseholdByIdentifierAsync_WhenNonEmailNonPhoneIdentifier_ReturnsNullWithoutCallingPlugin()
     {
         var result = await _repository.GetHouseholdByIdentifierAsync(
             HouseholdIdentifier.SnapId("SNAP123"), FullPii, UserIalLevel.IAL1plus);
@@ -225,6 +274,8 @@ public class HouseholdRepositoryTests
         Assert.Null(result);
         await _summerEbtCaseService.DidNotReceive()
             .GetHouseholdByGuardianEmailAsync(Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>());
+        await _summerEbtCaseService.DidNotReceive()
+            .GetHouseholdByGuardianPhoneAsync(Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
POC PR from Claude with fix for exception we were seeing where GetHouseholdByGuardianEmailAsync was not implemented for Colorado, because CO householding is by guardian phone #.

Dependent PRs: 
- [State connector](https://github.com/codeforamerica/sebt-self-service-portal-state-connector/pull/11)
- [Colorado](https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/10)
- [DC](https://github.com/codeforamerica/sebt-self-service-portal-dc-connector/pull/10)
