### PR TITLE
DC-267: Fix Datadog log severity by outputting structured JSON in deployed enviroments

### DIFF
--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -11,6 +11,7 @@ using SEBT.Portal.Api.Composition;
 using SEBT.Portal.Api.Filters;
 using SEBT.Portal.Api.Models;
 using Serilog;
+using Serilog.Templates;
 using Microsoft.FeatureManagement;
 using SEBT.Portal.Api.Middleware;
 using SEBT.Portal.Api.Options;
@@ -30,10 +31,30 @@ using SEBT.Portal.Core.Utilities;
 var builder = WebApplication.CreateBuilder(args);
 
 // Configure Serilog early so that configuration providers can log.
-Log.Logger = new LoggerConfiguration()
+// Console sink is configured in code (not appsettings) so we can use
+// human-readable text locally and structured JSON in deployed environments.
+// The JSON format uses field names that Datadog auto-recognizes (level,
+// message, timestamp) so log severity maps correctly without custom pipelines.
+// Set LOG_FORMAT=json in ECS task definitions to enable structured output.
+var useJsonLogs = string.Equals(
+    Environment.GetEnvironmentVariable("LOG_FORMAT"), "json", StringComparison.OrdinalIgnoreCase);
+
+var logConfig = new LoggerConfiguration()
     .ReadFrom.Configuration(builder.Configuration)
-    .Enrich.FromLogContext()
-    .CreateLogger();
+    .Enrich.FromLogContext();
+
+if (useJsonLogs)
+{
+    logConfig.WriteTo.Console(new ExpressionTemplate(
+        "{ {timestamp: @t, level: @l, message: @m, exception: @x, ..@p} }\n"));
+}
+else
+{
+    logConfig.WriteTo.Console(
+        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+}
+
+Log.Logger = logConfig.CreateLogger();
 
 builder.Host.UseSerilog();
 

--- a/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
+++ b/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
@@ -98,6 +98,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -11,12 +11,6 @@
     },
     "WriteTo": [
       {
-        "Name": "Console",
-        "Args": {
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}"
-        }
-      },
-      {
         "Name": "File",
         "Args": {
           "path": "logs/sebt-portal-.log",

--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -97,6 +97,7 @@ module "app" {
   vpc_id                     = module.vpc.vpc_id
   waf_log_group              = module.logging.log_groups["waf"]
   passive_waf                = true
+  log_as_json                = true
 
   api_image_url      = data.aws_ecr_repository.api.repository_url
   api_repository_arn = data.aws_ecr_repository.api.arn

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -77,6 +77,7 @@ module "app" {
   waf_log_group              = module.logging.log_groups["waf"]
   passive_waf                = true
   enable_appconfig           = true
+  log_as_json                = true
 
   api_image_url      = data.aws_ecr_repository.api.repository_url
   api_repository_arn = data.aws_ecr_repository.api.arn

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -58,6 +58,7 @@ module "api" {
 
   environment_variables = merge({
     ASPNETCORE_ENVIRONMENT                       = var.environment
+    LOG_FORMAT                                   = var.log_as_json ? "json" : "text"
     STATE                                        = var.state
     DB_HOST                                      = module.database.endpoint
     DB_NAME                                      = "SebtPortal"

--- a/tofu/modules/sebt_application/variables.tf
+++ b/tofu/modules/sebt_application/variables.tf
@@ -193,6 +193,12 @@ variable "use_mock_household_data" {
   default     = "false"
 }
 
+variable "log_as_json" {
+  type        = bool
+  description = "Output API logs as structured JSON. Enable in deployed environments so Datadog can parse log severity."
+  default     = false
+}
+
 variable "state_api_environment_variables" {
   type        = map(string)
   description = "State-specific environment variables to inject into the API container."


### PR DESCRIPTION
- Datadog displayed all API logs as `info` regardless of actual severity because Serilog's plain-text console output couldn't be parsed for log level
- Console sink now outputs structured JSON with Datadog-native field names (`level`, `message`, `timestamp`) in deployed environments, using `Serilog.Expressions` `ExpressionTemplate`
- New `log_as_json` tofu variable (default `false`) sets `LOG_FORMAT=json` on the API container enabled in dev-dc and dev-co
- Local development is unaffected (text output when `LOG_FORMAT` is unset)

## Test plan
- [x] Run locally with `pnpm dev` — verify human-readable text logs
- [x] Run locally with `LOG_FORMAT=json dotnet run --project src/SEBT.Portal.Api` — verify JSON output with `level`, `message`, `timestamp` fields
- [x] Deploy to dev environment and confirm Datadog shows correct WARN/ERROR severity levels
- [x] Verify Datadog "Preprocessing for JSON logs" auto-parses the fields (no custom pipeline needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)