### PR TITLE
DC-273: Fix dashboard error caused by empty card status from CBMS

### DIFF
--- a/packages/design-system/design/scripts/generate-sass-tokens.js
+++ b/packages/design-system/design/scripts/generate-sass-tokens.js
@@ -265,6 +265,11 @@ function generateSettingsContent(state, variables, timestamp) {
   settingsLines.push('  $theme-alert-icon-size: 3,')
   settingsLines.push('')
 
+  // Suppress USWDS release notes printed on every compile
+  settingsLines.push('  // Suppress verbose USWDS compile notifications')
+  settingsLines.push('  $theme-show-notifications: false,')
+  settingsLines.push('')
+
   // Add utility settings - ensures utility classes override component styles
   settingsLines.push('  // Utility settings')
   settingsLines.push('  $utilities-use-important: true')

--- a/src/SEBT.Portal.Web/src/api/client.ts
+++ b/src/SEBT.Portal.Web/src/api/client.ts
@@ -106,6 +106,8 @@ export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions<T> 
   if (schema && data !== undefined) {
     const result = schema.safeParse(data)
     if (!result.success) {
+      console.error(`[apiFetch] Validation failed for ${endpoint}:`, result.error.issues)
+      console.error(`[apiFetch] Raw response data:`, data)
       throw new ApiValidationError(
         `Response validation failed for ${endpoint}`,
         result.error.issues

--- a/src/SEBT.Portal.Web/src/features/household/api/schema.test.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/schema.test.ts
@@ -34,6 +34,10 @@ describe('CardStatusSchema', () => {
   it('passes through string values unchanged', () => {
     expect(CardStatusSchema.parse('Active')).toBe('Active')
   })
+
+  it('maps empty string to Unknown (CBMS returns "" for denied/pending children)', () => {
+    expect(CardStatusSchema.parse('')).toBe('Unknown')
+  })
 })
 
 describe('ApplicationStatusSchema', () => {

--- a/src/SEBT.Portal.Web/src/features/household/api/schema.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/schema.ts
@@ -64,7 +64,7 @@ export const CardStatusSchema = z.preprocess(
     typeof val === 'number'
       ? (CARD_STATUS_MAP[val as keyof typeof CARD_STATUS_MAP] ?? 'Unknown')
       : typeof val === 'string'
-        ? (CARD_STATUS_STRING_MAP[val.toUpperCase()] ?? val)
+        ? (CARD_STATUS_STRING_MAP[val.toUpperCase()] ?? (val || 'Unknown'))
         : val,
   z.enum([
     'Unknown',


### PR DESCRIPTION
## Summary

- **CardStatusSchema** Zod preprocess now maps empty strings to `'Unknown'` instead of passing them through to fail enum validation. CBMS returns `""` for `ebtCardSts` on children without cards (denied/pending), which broke the dashboard.
- Added **console.error logging** in `apiFetch` for schema validation failures to aid future debugging.
- Suppressed verbose **USWDS compile notifications** (`$theme-show-notifications: false`) in the SASS token generator.

**Companion PR:** See codeforamerica/sebt-self-service-portal-co-connector#17 — the backend fix routes `EbtCardStatus` through `MapCardStatus()` instead of passing the raw CBMS string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)