### PR TITLE
DC-276 Fix: Duplicate Row error on DocVerificationChallenges table

### DIFF
--- a/src/SEBT.Portal.Infrastructure/Repositories/DatabaseDocVerificationChallengeRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/DatabaseDocVerificationChallengeRepository.cs
@@ -86,6 +86,20 @@ public class DatabaseDocVerificationChallengeRepository(PortalDbContext dbContex
             throw new ArgumentNullException(nameof(challenge));
         }
 
+        var now = DateTime.UtcNow;
+
+        await dbContext.DocVerificationChallenges
+            .Where(c => c.UserId == challenge.UserId
+                && (c.Status == (int)DocVerificationStatus.Created
+                    || c.Status == (int)DocVerificationStatus.Pending)
+                && c.ExpiresAt != null
+                && c.ExpiresAt <= now)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(e => e.Status, (int)DocVerificationStatus.Expired)
+                    .SetProperty(e => e.UpdatedAt, now),
+                cancellationToken);
+
         var entity = MapToEntity(challenge);
         dbContext.DocVerificationChallenges.Add(entity);
         await dbContext.SaveChangesAsync(cancellationToken);

--- a/src/SEBT.Portal.Infrastructure/Repositories/DatabaseDocVerificationChallengeRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/DatabaseDocVerificationChallengeRepository.cs
@@ -88,21 +88,39 @@ public class DatabaseDocVerificationChallengeRepository(PortalDbContext dbContex
 
         var now = DateTime.UtcNow;
 
-        await dbContext.DocVerificationChallenges
-            .Where(c => c.UserId == challenge.UserId
-                && (c.Status == (int)DocVerificationStatus.Created
-                    || c.Status == (int)DocVerificationStatus.Pending)
-                && c.ExpiresAt != null
-                && c.ExpiresAt <= now)
-            .ExecuteUpdateAsync(
-                setters => setters
-                    .SetProperty(e => e.Status, (int)DocVerificationStatus.Expired)
-                    .SetProperty(e => e.UpdatedAt, now),
-                cancellationToken);
+        // Single transaction: bulk expire + insert commit together. Without this, a failure after
+        // ExecuteUpdateAsync could leave stale rows expired with no new challenge (recoverable on
+        // retry but inconsistent until then).
+        await using var transaction =
+            await dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            // Bulk expire via SQL: does not use RowVersion optimistic concurrency or
+            // DocVerificationChallenge.TransitionTo (same Created→Expired transition as the domain).
+            // The predicate limits rows to stale Created/Pending; revisit if concurrent writers race here.
+            await dbContext.DocVerificationChallenges
+                .Where(c => c.UserId == challenge.UserId
+                    && (c.Status == (int)DocVerificationStatus.Created
+                        || c.Status == (int)DocVerificationStatus.Pending)
+                    && c.ExpiresAt != null
+                    && c.ExpiresAt <= now)
+                .ExecuteUpdateAsync(
+                    setters => setters
+                        .SetProperty(e => e.Status, (int)DocVerificationStatus.Expired)
+                        .SetProperty(e => e.UpdatedAt, now),
+                    cancellationToken);
 
-        var entity = MapToEntity(challenge);
-        dbContext.DocVerificationChallenges.Add(entity);
-        await dbContext.SaveChangesAsync(cancellationToken);
+            var entity = MapToEntity(challenge);
+            dbContext.DocVerificationChallenges.Add(entity);
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
     }
 
     public async Task UpdateAsync(

--- a/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseDocVerificationChallengeRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseDocVerificationChallengeRepositoryTests.cs
@@ -131,6 +131,34 @@ public class DatabaseDocVerificationChallengeRepositoryTests : IClassFixture<Sql
     }
 
     [Fact]
+    public async Task CreateAsync_ShouldExpireTimeElapsedRow_ThenInsertNew()
+    {
+        using var context = _fixture.CreateContext();
+        var userId = await SeedChallengeAsync(context,
+            status: (int)DocVerificationStatus.Created,
+            expiresAt: DateTime.UtcNow.AddMinutes(-10));
+
+        var repo = new DatabaseDocVerificationChallengeRepository(context);
+        var challenge = new DocVerificationChallenge
+        {
+            UserId = userId,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30)
+        };
+
+        await repo.CreateAsync(challenge);
+
+        var rows = await context.DocVerificationChallenges
+            .AsNoTracking()
+            .Where(c => c.UserId == userId)
+            .OrderBy(c => c.Id)
+            .ToListAsync();
+
+        Assert.Equal(2, rows.Count);
+        Assert.Single(rows, r => r.Status == (int)DocVerificationStatus.Expired);
+        Assert.Single(rows, r => r.Status == (int)DocVerificationStatus.Created && r.PublicId == challenge.PublicId);
+    }
+
+    [Fact]
     public async Task CreateAsync_ShouldAllowNewChallenge_WhenExistingIsTerminal()
     {
         using var context = _fixture.CreateContext();


### PR DESCRIPTION
This PR adds the following: 

* Before inserting a new Doc Verification challenge, expire any created/pending rows for the same user with non-null (`ExpiresAt` ≤ `UtcNow`), so they no longer satisfy the partial unique index.
* Unit test in `DatabaseDocVerificationChallengeRepositoryTests` added to cover this scenario 