### PR TITLE
DC-81 feat: minimum IAL determination based on case origin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,9 @@ This is a .NET 10 + Next.js 16 application following Clean Architecture. For det
 - **Web** — Next.js 16 frontend (React 19, USWDS 3.13, i18next)
 - **Tests** — xUnit + NSubstitute + Bogus + Testcontainers (MSSQL)
 
+### Layer boundaries
+- Inner layers (Kernel, Core, UseCases) must not reference web/HTTP concepts (ProblemDetails, status codes, headers, controllers). They define abstractions; outer layers (Api, Web) decide how to serialize and transport them.
+
 ### Multi-State Plugin System
 State-specific behavior uses MEF (System.Composition) plugins loaded at runtime from `plugins-{state}/` directories. Plugin contracts live in the separate `sebt-self-service-portal-state-connector` repo; implementations live in per-state repos (`-dc-connector`, `-co-connector`). The `STATE` env var controls which state config overlay loads. See ADR-0007 for the design rationale.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,11 @@ We follow a test-driven development (TDD) approach: write tests first to fail, t
 - Apply CORS and rate-limiting where applicable; return safe error messages.
 - In React, avoid 'dangerouslySetInnerHtml'. If rendering HTML, sanitize it first.
 
+### Data boundary enforcement
+- Enforce access control at the data boundary (the API endpoint that returns the data), not at the UI layer. Client-side guards are UX conveniences, not security controls.
+- When an authenticated user lacks sufficient authorization for a specific resource (e.g., insufficient IAL for their household's cases), return a 403 with structured ProblemDetails — not a 200 with filtered/empty data. The client needs to know *why* access was denied and *what to do about it* (e.g., `requiredIal` in the ProblemDetails extensions).
+- Auth claims in JWTs can go stale (e.g., household composition changes after login). Server-side checks that re-evaluate on every request are safer than trusting a token's claims about what the user is allowed to see.
+
 ## Common Commands
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ docker compose up
 
 Only include sections you want to override; other settings fall back to `appsettings.json`!
 
+### Minimum IAL requirements
+
+Each state must configure the minimum Identity Assurance Level (IAL) required based on case origin. The app will fail to start if these values are missing — there is no state-agnostic default.
+
+See [`appsettings.dc.example.json`](src/SEBT.Portal.Api/appsettings.dc.example.json) and [`appsettings.co.example.json`](src/SEBT.Portal.Api/appsettings.co.example.json) for example values.
+
 ### OIDC support
 
 States can use an external [OpenID Connect (OIDC)](https://openid.net/developers/how-connect-works/) provider for sign-in. OIDC is configured in the API under flat `Oidc` keys (`DiscoveryEndpoint`, `ClientId`, `CallbackRedirectUri`); the portal uses generic endpoints and config rather than state-specific auth code paths. Code exchange and id_token validation run in the Next.js server; the .NET API performs "complete-login" (validates a short-lived callback token and returns a portal JWT that includes IdP claims such as phone and name).

--- a/docs/tdd/minimum-ial-determination.md
+++ b/docs/tdd/minimum-ial-determination.md
@@ -1,0 +1,188 @@
+# Minimum IAL Determination
+
+## Problem Statement / Intent
+
+Different users need different levels of identity proofing depending on
+how their children's benefits were issued. In DC:
+
+- **Application-based cases** (guardian submitted an application): the
+  guardian already proved their identity through the application process.
+  IAL1 (basic login) is sufficient.
+- **Streamline-certified, co-loaded cases** (bulk-imported from state
+  systems like SNAP/TANF): the guardian's record was pre-populated. Data
+  matching (DOB + SSN/SNAP/TANF ID) is needed, but not full document
+  verification. IAL1 is sufficient.
+- **Streamline-certified, non-co-loaded cases** (auto-certified but not
+  bulk-imported): no prior identity linkage exists. The user must
+  complete Socure document verification to reach IAL1+.
+
+The "highest wins" rule applies: if a user has even one non-co-loaded
+streamline case among many co-loaded ones, they must reach IAL1+.
+
+Each state may have different policies. CO currently requires IAL1 for
+all case types (elevated proofing is per-operation, not per-case-origin).
+CO will begin co-loading in 2027.
+
+---
+
+## Design Decisions
+
+### Facts vs. Policy
+
+The core design splits the problem into two concerns:
+
+1. **Facts** (reported by state plugins): each `SummerEbtCase` carries
+   two booleans — `IsCoLoaded` and `IsStreamlineCertified`. These are
+   objective statements about the case's origin. Plugins set them based
+   on state-specific data:
+   - **DC**: `IsCoLoaded` = eligibility type is SNAP or TANF;
+     `IsStreamlineCertified` = ApplicationId is null.
+   - **CO**: `IsCoLoaded` = false (CO doesn't co-load yet);
+     `IsStreamlineCertified` = `!IsApplicationBased(EligSrc)` via the
+     existing `EligibilitySourceClassifier`.
+
+2. **Policy** (owned by Core, configured per state): `MinimumIalSettings`
+   maps each case origin to an IAL requirement. `MinimumIalService`
+   evaluates all cases and returns the highest. Policy changes don't
+   require code changes — only config updates.
+
+This means the DC plugin never needs to change when IAL requirements
+change, and when CO starts co-loading in 2027, they add `IsCoLoaded`
+logic to their mapper and configure the policy — no core changes needed.
+
+### Required configuration (no defaults)
+
+`MinimumIalSettings` has no defaults. The app fails to start if the
+section is missing from the state overlay. This is intentional: there is
+no sensible state-agnostic default, and silently falling back to a
+permissive default could be a security issue.
+
+## Data Structures
+
+### Plugin Boundary (`SummerEbtCase`)
+
+Two boolean properties added to the existing model:
+
+```csharp
+public bool IsCoLoaded { get; init; }            // default false
+public bool IsStreamlineCertified { get; init; }  // default false
+```
+
+Defaults are `false` (application-based, not co-loaded) — the
+lowest-privilege assumption for plugins that don't set them.
+
+### Configuration (`MinimumIalSettings`)
+
+```csharp
+public class MinimumIalSettings
+{
+    public static readonly string SectionName = "MinimumIal";
+    public IalLevel? ApplicationCases { get; set; }
+    public IalLevel? CoLoadedStreamlineCases { get; set; }
+    public IalLevel? NonCoLoadedStreamlineCases { get; set; }
+}
+```
+
+All properties are nullable and validated at startup. Example configs:
+
+**DC** (`appsettings.dc.example.json`):
+
+```json
+{
+  "MinimumIal": {
+    "ApplicationCases": "IAL1",
+    "CoLoadedStreamlineCases": "IAL1",
+    "NonCoLoadedStreamlineCases": "IAL1plus"
+  }
+}
+```
+
+**CO** (`appsettings.co.example.json`):
+
+```json
+{
+  "MinimumIal": {
+    "ApplicationCases": "IAL1",
+    "CoLoadedStreamlineCases": "IAL1",
+    "NonCoLoadedStreamlineCases": "IAL1"
+  }
+}
+```
+
+### Service Interface
+
+```csharp
+public interface IMinimumIalService
+{
+    UserIalLevel GetMinimumIal(IReadOnlyList<SummerEbtCase> cases);
+}
+```
+
+Returns `UserIalLevel.IAL1` when the cases list is empty.
+
+---
+
+## Integration: Server-Side IAL Gate
+
+### Security constraint
+
+Household case data must never be returned to a user who has not met
+the minimum IAL for their cases. The determination and enforcement
+must happen server-side — the frontend cannot be trusted to gate access.
+
+### Approach: 403 with ProblemDetails
+
+`GetHouseholdDataQueryHandler` is the integration point. It already has
+the user's current IAL, the full list of cases, and PII visibility
+computation. After fetching household data:
+
+1. Compute `minimumIal` via `IMinimumIalService.GetMinimumIal(cases)`
+2. Compare against the user's current IAL from JWT claims
+3. If insufficient: return an `InsufficientIalResult` (new result type)
+4. If sufficient: return household data as before
+
+The controller maps the new result type to a **403 Forbidden** using
+the standard `ProblemDetails` format with a `requiredIal` extension:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+  "title": "Insufficient identity assurance level",
+  "status": 403,
+  "detail": "This household requires IAL1plus. Complete identity verification to access this data.",
+  "extensions": {
+    "requiredIal": "IAL1plus"
+  }
+}
+```
+
+This is consistent with how other 403 responses are already declared
+in `HouseholdController` (e.g., `UpdateAddress`, `RequestCardReplacement`).
+
+### Frontend handling
+
+The dashboard's `useHouseholdData` hook handles the 403:
+
+1. Check response status — if 403, extract `requiredIal` from body
+2. Redirect to `/login/id-proofing` (the existing proofing flow)
+3. The existing `VerifyOtpForm` post-login routing for first-time users
+   (`idProofingStatus === 0`) continues to work for the initial gate
+
+### Why not a JWT claim or separate endpoint?
+
+- A JWT claim (`minimumIal`) would go stale if household composition
+  changes after login (e.g., a co-loaded case is added while the user
+  is in-session). The 403 check runs on every request.
+- A separate endpoint would need its own authorization and still
+  require fetching household data internally — duplicating work.
+- The 403 approach enforces security at the data boundary: you cannot
+  get the data without meeting the IAL. No client-side bypass possible.
+
+---
+
+## What's Not in Scope
+
+- **Data matching for co-loaded households** (DOB + SSN/SNAP/TANF ID
+  verification mechanism) — separate ticket
+- **Socure challenge trigger** (redirecting user to document verification
+  when below minimum IAL) — separate ticket

--- a/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
@@ -27,11 +27,13 @@ public class HouseholdController : ControllerBase
     /// <returns>An OK result with household data if found; otherwise, NotFound or Unauthorized.</returns>
     /// <response code="200">Household data retrieved successfully.</response>
     /// <response code="401">User is not authorized or no household identifier could be resolved from token.</response>
+    /// <response code="403">User's identity assurance level is below the minimum required by their cases.</response>
     /// <response code="404">Household data not found for the authenticated user.</response>
     [HttpGet("data")]
     [Authorize]
     [ProducesResponseType(typeof(HouseholdDataResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetHouseholdData(
         [FromServices] IQueryHandler<GetHouseholdDataQuery, Core.Models.Household.HouseholdData> queryHandler,
@@ -45,6 +47,11 @@ public class HouseholdController : ControllerBase
             failureMap: r => r switch
             {
                 UnauthorizedResult<Core.Models.Household.HouseholdData> unauthorized => Unauthorized(new ErrorResponse(unauthorized.Message)),
+                ForbiddenResult<Core.Models.Household.HouseholdData> forbidden => Problem(
+                    detail: forbidden.Message,
+                    title: "Insufficient identity assurance level",
+                    statusCode: StatusCodes.Status403Forbidden,
+                    extensions: forbidden.Extensions),
                 PreconditionFailedResult<Core.Models.Household.HouseholdData> preconditionFailed => NotFound(new ErrorResponse(preconditionFailed.Message)),
                 _ => StatusCode(StatusCodes.Status500InternalServerError, new ErrorResponse("An unexpected error occurred."))
             });

--- a/src/SEBT.Portal.Api/appsettings.co.example.json
+++ b/src/SEBT.Portal.Api/appsettings.co.example.json
@@ -40,9 +40,7 @@
     "AllowGeneralDelivery": true
   },
   "AddressValidationData": {
-    "BlockedAddresses": [
-      "1575 Sherman St"
-    ],
+    "BlockedAddresses": ["1575 Sherman St"],
     "StreetAbbreviations": {},
     "MaxStreetAddressLength": 0
   },
@@ -53,6 +51,11 @@
   },
   "Socure": {
     "Enabled": false
+  },
+  "MinimumIal": {
+    "ApplicationCases": "IAL1",
+    "CoLoadedStreamlineCases": "IAL1",
+    "NonCoLoadedStreamlineCases": "IAL1plus"
   },
   "IdProofingRequirements": {
     "address+view": "IAL1plus",

--- a/src/SEBT.Portal.Api/appsettings.co.example.json
+++ b/src/SEBT.Portal.Api/appsettings.co.example.json
@@ -55,7 +55,7 @@
   "MinimumIal": {
     "ApplicationCases": "IAL1",
     "CoLoadedStreamlineCases": "IAL1",
-    "NonCoLoadedStreamlineCases": "IAL1plus"
+    "NonCoLoadedStreamlineCases": "IAL1"
   },
   "IdProofingRequirements": {
     "address+view": "IAL1plus",

--- a/src/SEBT.Portal.Api/appsettings.dc.example.json
+++ b/src/SEBT.Portal.Api/appsettings.dc.example.json
@@ -52,6 +52,11 @@
     "Workflow": "consumer_onboarding",
     "DocvEnrichmentName": "SocureDocRequest"
   },
+  "MinimumIal": {
+    "ApplicationCases": "IAL1",
+    "CoLoadedStreamlineCases": "IAL1",
+    "NonCoLoadedStreamlineCases": "IAL1plus"
+  },
   "FeatureManagement": {
     "email_dob_opt_in": false,
     "show_application_number": false,

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -68,11 +68,6 @@
     "email+view": "IAL1",
     "phone+view": "IAL1"
   },
-  "MinimumIal": {
-    "ApplicationCases": "IAL1",
-    "CoLoadedStreamlineCases": "IAL1",
-    "NonCoLoadedStreamlineCases": "IAL1plus"
-  },
   "Oidc": {
     "CompleteLoginSigningKey": "AT_LEAST_32_CHARACTERS_FOR_HMAC_SHA256_SIGNING"
   },

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -68,6 +68,11 @@
     "email+view": "IAL1",
     "phone+view": "IAL1"
   },
+  "MinimumIal": {
+    "ApplicationCases": "IAL1",
+    "CoLoadedStreamlineCases": "IAL1",
+    "NonCoLoadedStreamlineCases": "IAL1plus"
+  },
   "Oidc": {
     "CompleteLoginSigningKey": "AT_LEAST_32_CHARACTERS_FOR_HMAC_SHA256_SIGNING"
   },

--- a/src/SEBT.Portal.Core/AppSettings/MinimumIalSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/MinimumIalSettings.cs
@@ -13,18 +13,21 @@ public class MinimumIalSettings
 
     /// <summary>
     /// Minimum IAL required for cases that originated from guardian-submitted applications.
+    /// Required — the app will fail to start if not configured in the state overlay.
     /// </summary>
-    public IalLevel ApplicationCases { get; set; } = IalLevel.IAL1;
+    public IalLevel? ApplicationCases { get; set; }
 
     /// <summary>
     /// Minimum IAL required for streamline-certified cases that were co-loaded
     /// (bulk-imported from the state system).
+    /// Required — the app will fail to start if not configured in the state overlay.
     /// </summary>
-    public IalLevel CoLoadedStreamlineCases { get; set; } = IalLevel.IAL1;
+    public IalLevel? CoLoadedStreamlineCases { get; set; }
 
     /// <summary>
     /// Minimum IAL required for streamline-certified cases that were NOT co-loaded
     /// (added through the portal, not bulk-imported).
+    /// Required — the app will fail to start if not configured in the state overlay.
     /// </summary>
-    public IalLevel NonCoLoadedStreamlineCases { get; set; } = IalLevel.IAL1plus;
+    public IalLevel? NonCoLoadedStreamlineCases { get; set; }
 }

--- a/src/SEBT.Portal.Core/AppSettings/MinimumIalSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/MinimumIalSettings.cs
@@ -1,0 +1,30 @@
+using SEBT.Portal.Core.Models.Auth;
+
+namespace SEBT.Portal.Core.AppSettings;
+
+/// <summary>
+/// State-configurable minimum IAL requirements based on case origin.
+/// The service evaluates each case against these thresholds and returns the
+/// highest required level across all cases ("highest wins").
+/// </summary>
+public class MinimumIalSettings
+{
+    public static readonly string SectionName = "MinimumIal";
+
+    /// <summary>
+    /// Minimum IAL required for cases that originated from guardian-submitted applications.
+    /// </summary>
+    public IalLevel ApplicationCases { get; set; } = IalLevel.IAL1;
+
+    /// <summary>
+    /// Minimum IAL required for streamline-certified cases that were co-loaded
+    /// (bulk-imported from the state system).
+    /// </summary>
+    public IalLevel CoLoadedStreamlineCases { get; set; } = IalLevel.IAL1;
+
+    /// <summary>
+    /// Minimum IAL required for streamline-certified cases that were NOT co-loaded
+    /// (added through the portal, not bulk-imported).
+    /// </summary>
+    public IalLevel NonCoLoadedStreamlineCases { get; set; } = IalLevel.IAL1plus;
+}

--- a/src/SEBT.Portal.Core/Models/Household/SummerEbtCase.cs
+++ b/src/SEBT.Portal.Core/Models/Household/SummerEbtCase.cs
@@ -57,6 +57,18 @@ public class SummerEbtCase
     public IssuanceType IssuanceType { get; set; } = IssuanceType.Unknown;
 
     /// <summary>
+    /// Whether this case was bulk-imported (co-loaded) from the state system
+    /// rather than created through the application flow.
+    /// </summary>
+    public bool IsCoLoaded { get; set; }
+
+    /// <summary>
+    /// Whether this case was automatically certified (streamline certification)
+    /// rather than originating from a guardian-submitted application.
+    /// </summary>
+    public bool IsStreamlineCertified { get; set; }
+
+    /// <summary>
     /// The application date.
     /// </summary>
     public DateTime? ApplicationDate { get; set; }

--- a/src/SEBT.Portal.Core/Models/Household/SummerEbtCase.cs
+++ b/src/SEBT.Portal.Core/Models/Household/SummerEbtCase.cs
@@ -57,8 +57,7 @@ public class SummerEbtCase
     public IssuanceType IssuanceType { get; set; } = IssuanceType.Unknown;
 
     /// <summary>
-    /// Whether this case was bulk-imported (co-loaded) from the state system
-    /// rather than created through the application flow.
+    /// Whether this case has benefits co-loaded to an existing EBT card.
     /// </summary>
     public bool IsCoLoaded { get; set; }
 

--- a/src/SEBT.Portal.Core/Services/IMinimumIalService.cs
+++ b/src/SEBT.Portal.Core/Services/IMinimumIalService.cs
@@ -1,0 +1,21 @@
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Models.Household;
+
+namespace SEBT.Portal.Core.Services;
+
+/// <summary>
+/// Determines the minimum Identity Assurance Level a user must achieve
+/// based on the co-loading and streamline-certification status of their cases.
+/// </summary>
+public interface IMinimumIalService
+{
+    /// <summary>
+    /// Computes the minimum IAL required across all of a user's Summer EBT cases.
+    /// The "highest wins" rule applies: if any case requires a higher IAL,
+    /// the user must meet that level.
+    /// </summary>
+    /// <param name="cases">The user's Summer EBT cases.</param>
+    /// <returns>The minimum IAL the user must achieve. Returns <see cref="UserIalLevel.IAL1"/>
+    /// when <paramref name="cases"/> is empty (no elevated requirement).</returns>
+    UserIalLevel GetMinimumIal(IReadOnlyList<SummerEbtCase> cases);
+}

--- a/src/SEBT.Portal.Infrastructure/Configuration/MinimumIalSettingsValidator.cs
+++ b/src/SEBT.Portal.Infrastructure/Configuration/MinimumIalSettingsValidator.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
+
+namespace SEBT.Portal.Infrastructure.Configuration;
+
+/// <summary>
+/// Validates MinimumIalSettings at startup.
+/// All three properties are required — there is no sensible state-agnostic default.
+/// Each state must configure these in its appsettings overlay.
+/// </summary>
+public class MinimumIalSettingsValidator : IValidateOptions<MinimumIalSettings>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, MinimumIalSettings options)
+    {
+        if (options.ApplicationCases is null)
+        {
+            return ValidateOptionsResult.Fail(
+                "MinimumIal:ApplicationCases is required. Configure it in your state's appsettings overlay.");
+        }
+
+        if (options.CoLoadedStreamlineCases is null)
+        {
+            return ValidateOptionsResult.Fail(
+                "MinimumIal:CoLoadedStreamlineCases is required. Configure it in your state's appsettings overlay.");
+        }
+
+        if (options.NonCoLoadedStreamlineCases is null)
+        {
+            return ValidateOptionsResult.Fail(
+                "MinimumIal:NonCoLoadedStreamlineCases is required. Configure it in your state's appsettings overlay.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/SEBT.Portal.Infrastructure/Dependencies.cs
+++ b/src/SEBT.Portal.Infrastructure/Dependencies.cs
@@ -202,6 +202,7 @@ public static class Dependencies
         services.AddSingleton<IValidateOptions<IdProofingRequirementsSettings>, IdProofingRequirementsSettingsValidator>();
         services.AddOptionsWithValidateOnStart<IdProofingRequirementsSettings>()
             .BindConfiguration(IdProofingRequirementsSettings.SectionName);
+        services.AddSingleton<IValidateOptions<MinimumIalSettings>, MinimumIalSettingsValidator>();
         services.AddOptionsWithValidateOnStart<MinimumIalSettings>()
             .BindConfiguration(MinimumIalSettings.SectionName);
 

--- a/src/SEBT.Portal.Infrastructure/Dependencies.cs
+++ b/src/SEBT.Portal.Infrastructure/Dependencies.cs
@@ -29,6 +29,9 @@ public static class Dependencies
         // ID Proofing Requirements (state-specific PII visibility)
         services.AddScoped<IIdProofingRequirementsService, IdProofingRequirementsService>();
 
+        // Minimum IAL service (state-configurable identity assurance level requirements)
+        services.AddScoped<IMinimumIalService, MinimumIalService>();
+
         // Enrollment Check logging
         services.AddScoped<IEnrollmentCheckSubmissionLogger, EnrollmentCheckSubmissionLogger>();
 
@@ -199,6 +202,8 @@ public static class Dependencies
         services.AddSingleton<IValidateOptions<IdProofingRequirementsSettings>, IdProofingRequirementsSettingsValidator>();
         services.AddOptionsWithValidateOnStart<IdProofingRequirementsSettings>()
             .BindConfiguration(IdProofingRequirementsSettings.SectionName);
+        services.AddOptionsWithValidateOnStart<MinimumIalSettings>()
+            .BindConfiguration(MinimumIalSettings.SectionName);
 
         services.AddSingleton<IValidateOptions<OidcStepUpSettings>, OidcStepUpSettingsValidator>();
         services.AddOptionsWithValidateOnStart<OidcStepUpSettings>()

--- a/src/SEBT.Portal.Infrastructure/Repositories/PluginHouseholdDataMapper.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/PluginHouseholdDataMapper.cs
@@ -91,6 +91,8 @@ internal static class PluginHouseholdDataMapper
             EbtCardStatus = GetProp<string>(t, source, "EbtCardStatus"),
             EbtCardIssueDate = ToDateTimeOrNull(GetProp(t, source, "EbtCardIssueDate")),
             EbtCardBalance = GetProp<decimal?>(t, source, "EbtCardBalance"),
+            IsCoLoaded = GetProp<bool>(t, source, "IsCoLoaded"),
+            IsStreamlineCertified = GetProp<bool>(t, source, "IsStreamlineCertified"),
             CardRequestedAt = GetProp<DateTime?>(t, source, "CardRequestedAt"),
             BenefitAvailableDate = ToDateTimeOrNull(GetProp(t, source, "BenefitAvailableDate")),
             BenefitExpirationDate = ToDateTimeOrNull(GetProp(t, source, "BenefitExpirationDate"))

--- a/src/SEBT.Portal.Infrastructure/Services/MinimumIalService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/MinimumIalService.cs
@@ -47,12 +47,18 @@ public class MinimumIalService : IMinimumIalService
     {
         if (!c.IsStreamlineCertified)
         {
-            return _settings.ApplicationCases!.Value;
+            return GetRequiredSetting(_settings.ApplicationCases, nameof(_settings.ApplicationCases));
         }
 
         return c.IsCoLoaded
-            ? _settings.CoLoadedStreamlineCases!.Value
-            : _settings.NonCoLoadedStreamlineCases!.Value;
+            ? GetRequiredSetting(_settings.CoLoadedStreamlineCases, nameof(_settings.CoLoadedStreamlineCases))
+            : GetRequiredSetting(_settings.NonCoLoadedStreamlineCases, nameof(_settings.NonCoLoadedStreamlineCases));
+    }
+
+    private static IalLevel GetRequiredSetting(IalLevel? value, string propertyName)
+    {
+        return value ?? throw new InvalidOperationException(
+            $"MinimumIalSettings.{propertyName} is null. Configuration may have been removed during a hot reload.");
     }
 
     private static UserIalLevel ToUserIalLevel(IalLevel level)
@@ -62,7 +68,7 @@ public class MinimumIalService : IMinimumIalService
             IalLevel.IAL1 => UserIalLevel.IAL1,
             IalLevel.IAL1plus => UserIalLevel.IAL1plus,
             IalLevel.IAL2 => UserIalLevel.IAL2,
-            _ => UserIalLevel.IAL1
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown IalLevel value")
         };
     }
 }

--- a/src/SEBT.Portal.Infrastructure/Services/MinimumIalService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/MinimumIalService.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Core.Services;
+
+namespace SEBT.Portal.Infrastructure.Services;
+
+/// <summary>
+/// Determines the minimum IAL a user must achieve based on the co-loading
+/// and streamline-certification status of their Summer EBT cases.
+/// Applies state-configurable policy via <see cref="MinimumIalSettings"/>.
+/// </summary>
+public class MinimumIalService : IMinimumIalService
+{
+    private readonly MinimumIalSettings _settings;
+    private readonly ILogger<MinimumIalService> _logger;
+
+    public MinimumIalService(
+        IOptionsSnapshot<MinimumIalSettings> settingsSnapshot,
+        ILogger<MinimumIalService> logger)
+    {
+        _settings = settingsSnapshot.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public UserIalLevel GetMinimumIal(IReadOnlyList<SummerEbtCase> cases)
+    {
+        if (cases.Count == 0)
+        {
+            _logger.LogDebug("No cases found; minimum IAL is IAL1 (no elevated requirement)");
+            return UserIalLevel.IAL1;
+        }
+
+        var highest = IalLevel.IAL1;
+
+        foreach (var c in cases)
+        {
+            var required = ClassifyCase(c);
+            if (required > highest)
+            {
+                highest = required;
+            }
+        }
+
+        var result = ToUserIalLevel(highest);
+        _logger.LogInformation(
+            "Minimum IAL determined as {MinimumIal} from {CaseCount} case(s)",
+            result,
+            cases.Count);
+        return result;
+    }
+
+    private IalLevel ClassifyCase(SummerEbtCase c)
+    {
+        if (!c.IsStreamlineCertified)
+        {
+            return _settings.ApplicationCases;
+        }
+
+        return c.IsCoLoaded
+            ? _settings.CoLoadedStreamlineCases
+            : _settings.NonCoLoadedStreamlineCases;
+    }
+
+    private static UserIalLevel ToUserIalLevel(IalLevel level)
+    {
+        return level switch
+        {
+            IalLevel.IAL1 => UserIalLevel.IAL1,
+            IalLevel.IAL1plus => UserIalLevel.IAL1plus,
+            IalLevel.IAL2 => UserIalLevel.IAL2,
+            _ => UserIalLevel.IAL1
+        };
+    }
+}

--- a/src/SEBT.Portal.Infrastructure/Services/MinimumIalService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/MinimumIalService.cs
@@ -34,17 +34,7 @@ public class MinimumIalService : IMinimumIalService
             return UserIalLevel.IAL1;
         }
 
-        var highest = IalLevel.IAL1;
-
-        foreach (var c in cases)
-        {
-            var required = ClassifyCase(c);
-            if (required > highest)
-            {
-                highest = required;
-            }
-        }
-
+        var highest = cases.Max(ClassifyCase);
         var result = ToUserIalLevel(highest);
         _logger.LogInformation(
             "Minimum IAL determined as {MinimumIal} from {CaseCount} case(s)",
@@ -57,12 +47,12 @@ public class MinimumIalService : IMinimumIalService
     {
         if (!c.IsStreamlineCertified)
         {
-            return _settings.ApplicationCases;
+            return _settings.ApplicationCases!.Value;
         }
 
         return c.IsCoLoaded
-            ? _settings.CoLoadedStreamlineCases
-            : _settings.NonCoLoadedStreamlineCases;
+            ? _settings.CoLoadedStreamlineCases!.Value
+            : _settings.NonCoLoadedStreamlineCases!.Value;
     }
 
     private static UserIalLevel ToUserIalLevel(IalLevel level)

--- a/src/SEBT.Portal.Kernel.AspNetCore/MvcResultExtensions.cs
+++ b/src/SEBT.Portal.Kernel.AspNetCore/MvcResultExtensions.cs
@@ -67,6 +67,10 @@ public static class MvcResultExtensions
                 => result.ToProblemDetailsResult(HttpStatusCode.Forbidden),
             UnauthorizedResult when !useProblemDetails
                 => new ForbidResult(),
+            ForbiddenResult forbidden when useProblemDetails
+                => forbidden.ToProblemDetailsResult(HttpStatusCode.Forbidden),
+            ForbiddenResult when !useProblemDetails
+                => new StatusCodeResult((int)HttpStatusCode.Forbidden),
             DependencyFailedResult when useProblemDetails
                 => result.ToProblemDetailsResult(HttpStatusCode.BadGateway),
             DependencyFailedResult when !useProblemDetails
@@ -142,6 +146,10 @@ public static class MvcResultExtensions
                 => result.ToProblemDetailsResult(HttpStatusCode.Forbidden),
             UnauthorizedResult<T> when !useProblemDetails
                 => new ForbidResult(),
+            ForbiddenResult<T> forbidden when useProblemDetails
+                => forbidden.ToProblemDetailsWithExtensionsResult(HttpStatusCode.Forbidden),
+            ForbiddenResult<T> when !useProblemDetails
+                => new StatusCodeResult((int)HttpStatusCode.Forbidden),
             DependencyFailedResult<T> when useProblemDetails
                 => result.ToProblemDetailsResult(HttpStatusCode.BadGateway),
             DependencyFailedResult<T> when !useProblemDetails
@@ -168,4 +176,23 @@ public static class MvcResultExtensions
         {
             StatusCode = (int)statusCode,
         };
+
+    /// <summary>
+    /// Converts a <see cref="ForbiddenResult{T}"/> into a <see cref="ObjectResult"/> containing
+    /// <see cref="ProblemDetails"/> with the result's extensions merged in.
+    /// </summary>
+    private static IActionResult ToProblemDetailsWithExtensionsResult<T>(this ForbiddenResult<T> result, HttpStatusCode statusCode)
+    {
+        var problemDetails = new ProblemDetails
+        {
+            Title = "Insufficient identity assurance level",
+            Detail = result.Message,
+            Status = (int)statusCode,
+        };
+        foreach (var (key, value) in result.Extensions)
+        {
+            problemDetails.Extensions[key] = value;
+        }
+        return new ObjectResult(problemDetails) { StatusCode = (int)statusCode };
+    }
 }

--- a/src/SEBT.Portal.Kernel/Result.cs
+++ b/src/SEBT.Portal.Kernel/Result.cs
@@ -29,6 +29,9 @@ public abstract class Result(bool isSuccess)
 
     public static Result DependencyFailed(DependencyFailedReason reason, string? message = null)
         => new DependencyFailedResult(reason, message);
+
+    public static Result Forbidden(string message)
+        => new ForbiddenResult(message);
 }
 
 public abstract class Result<T>(bool isSuccess) : Result(isSuccess)
@@ -53,6 +56,9 @@ public abstract class Result<T>(bool isSuccess) : Result(isSuccess)
 
     public new static Result<T> DependencyFailed(DependencyFailedReason reason, string? message = null)
         => new DependencyFailedResult<T>(reason, message);
+
+    public new static Result<T> Forbidden(string message, IDictionary<string, object?>? extensions = null)
+        => new ForbiddenResult<T>(message, extensions);
 
     public T Value => this switch
     {

--- a/src/SEBT.Portal.Kernel/Result.cs
+++ b/src/SEBT.Portal.Kernel/Result.cs
@@ -57,7 +57,7 @@ public abstract class Result<T>(bool isSuccess) : Result(isSuccess)
     public new static Result<T> DependencyFailed(DependencyFailedReason reason, string? message = null)
         => new DependencyFailedResult<T>(reason, message);
 
-    public new static Result<T> Forbidden(string message, IDictionary<string, object?>? extensions = null)
+    public static Result<T> Forbidden(string message, IDictionary<string, object?>? extensions = null)
         => new ForbiddenResult<T>(message, extensions);
 
     public T Value => this switch

--- a/src/SEBT.Portal.Kernel/Results/ForbiddenResult.cs
+++ b/src/SEBT.Portal.Kernel/Results/ForbiddenResult.cs
@@ -1,0 +1,18 @@
+namespace SEBT.Portal.Kernel.Results;
+
+public class ForbiddenResult(string message) : Result(false)
+{
+    public override string Message => message;
+}
+
+public class ForbiddenResult<T>(string message, IDictionary<string, object?>? extensions = null) : Result<T>(false)
+{
+    /// <summary>
+    /// Additional structured data to include in the ProblemDetails response.
+    /// </summary>
+    public IDictionary<string, object?> Extensions { get; } = extensions ?? new Dictionary<string, object?>();
+
+    public override string Message => message;
+
+    public override Result Map() => new ForbiddenResult(Message);
+}

--- a/src/SEBT.Portal.Kernel/Results/ForbiddenResult.cs
+++ b/src/SEBT.Portal.Kernel/Results/ForbiddenResult.cs
@@ -8,7 +8,8 @@ public class ForbiddenResult(string message) : Result(false)
 public class ForbiddenResult<T>(string message, IDictionary<string, object?>? extensions = null) : Result<T>(false)
 {
     /// <summary>
-    /// Additional structured data to include in the ProblemDetails response.
+    /// Additional structured data describing why access was denied.
+    /// The API layer determines how to serialize this (e.g., as ProblemDetails extensions).
     /// </summary>
     public IDictionary<string, object?> Extensions { get; } = extensions ?? new Dictionary<string, object?>();
 

--- a/src/SEBT.Portal.UseCases/Household/GetHouseholdData/GetHouseholdDataQueryHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/GetHouseholdData/GetHouseholdDataQueryHandler.cs
@@ -16,6 +16,7 @@ public class GetHouseholdDataQueryHandler(
     IHouseholdIdentifierResolver resolver,
     IHouseholdRepository repository,
     IIdProofingRequirementsService idProofingRequirementsService,
+    IMinimumIalService minimumIalService,
     ILogger<GetHouseholdDataQueryHandler> logger)
     : IQueryHandler<GetHouseholdDataQuery, HouseholdData>
 {
@@ -51,6 +52,20 @@ public class GetHouseholdDataQueryHandler(
         {
             logger.LogWarning("Household data not found for authenticated user");
             return Result<HouseholdData>.PreconditionFailed(PreconditionFailedReason.NotFound, "Household data not found.");
+        }
+
+        var minimumIal = minimumIalService.GetMinimumIal(householdData.SummerEbtCases);
+        if (userIalLevel < minimumIal)
+        {
+            // SECURITY: Never return household case data when the user has not met
+            // the minimum IAL required by their cases. See docs/tdd/minimum-ial-determination.md.
+            logger.LogInformation(
+                "Household data access denied: user IAL {UserIal} is below minimum {MinimumIal}",
+                userIalLevel,
+                minimumIal);
+            return Result<HouseholdData>.Forbidden(
+                $"This household requires {minimumIal}. Complete identity verification to access this data.",
+                new Dictionary<string, object?> { ["requiredIal"] = minimumIal.ToString() });
         }
 
         logger.LogDebug("Household data retrieved successfully for identifier type {Type}", identifier.Type);

--- a/src/SEBT.Portal.UseCases/Household/RequestCardReplacement/RequestCardReplacementCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/RequestCardReplacement/RequestCardReplacementCommandHandler.cs
@@ -17,6 +17,7 @@ public class RequestCardReplacementCommandHandler(
     IValidator<RequestCardReplacementCommand> validator,
     IHouseholdIdentifierResolver resolver,
     IHouseholdRepository repository,
+    IMinimumIalService minimumIalService,
     TimeProvider timeProvider,
     ILogger<RequestCardReplacementCommandHandler> logger)
     : ICommandHandler<RequestCardReplacementCommand>
@@ -54,6 +55,19 @@ public class RequestCardReplacementCommandHandler(
         {
             logger.LogWarning("Card replacement attempted but household data not found");
             return Result.PreconditionFailed(PreconditionFailedReason.NotFound, "Household data not found.");
+        }
+
+        // SECURITY: Block write operations when the user has not met the minimum IAL
+        // required by their cases. See docs/tdd/minimum-ial-determination.md.
+        var minimumIal = minimumIalService.GetMinimumIal(household.SummerEbtCases);
+        if (userIalLevel < minimumIal)
+        {
+            logger.LogInformation(
+                "Card replacement denied: user IAL {UserIal} is below minimum {MinimumIal}",
+                userIalLevel,
+                minimumIal);
+            return Result.Forbidden(
+                $"This household requires {minimumIal}. Complete identity verification to request card replacements.");
         }
 
         var cooldownErrors = CheckCooldown(command.CaseIds, household, timeProvider);

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -26,6 +26,7 @@ public class UpdateAddressCommandHandler(
     IHouseholdIdentifierResolver resolver,
     IHouseholdRepository householdRepository,
     IIdProofingRequirementsService idProofingRequirementsService,
+    IMinimumIalService minimumIalService,
     IStateAddressUpdateService stateAddressUpdateService,
     ILogger<UpdateAddressCommandHandler> logger)
     : ICommandHandler<UpdateAddressCommand, AddressValidationResult>
@@ -109,6 +110,23 @@ public class UpdateAddressCommandHandler(
         var piiVisibility = idProofingRequirementsService.GetPiiVisibility(userIalLevel);
         var household = await householdRepository.GetHouseholdByIdentifierAsync(
             identifier, piiVisibility, userIalLevel, cancellationToken);
+
+        if (household != null)
+        {
+            // SECURITY: Block write operations when the user has not met the minimum IAL
+            // required by their cases. See docs/tdd/minimum-ial-determination.md.
+            var minimumIal = minimumIalService.GetMinimumIal(household.SummerEbtCases);
+            if (userIalLevel < minimumIal)
+            {
+                logger.LogInformation(
+                    "Address update denied: user IAL {UserIal} is below minimum {MinimumIal}",
+                    userIalLevel,
+                    minimumIal);
+                return Result<AddressValidationResult>.Forbidden(
+                    $"This household requires {minimumIal}. Complete identity verification to update your address.",
+                    new Dictionary<string, object?> { ["requiredIal"] = minimumIal.ToString() });
+            }
+        }
 
         if (household is { BenefitIssuanceType: BenefitIssuanceType.SnapEbtCard or BenefitIssuanceType.TanfEbtCard })
         {

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
@@ -14,6 +14,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { server } from '@/mocks/server'
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() })
+}))
+
 import { useHouseholdData } from './useHouseholdData'
 
 const TEST_HOUSEHOLD_DATA = {

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -1,4 +1,8 @@
+'use client'
+
 import { useQuery } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 import { ApiError, apiFetch } from '@/api'
 
@@ -15,10 +19,17 @@ async function fetchHouseholdData(): Promise<HouseholdData> {
  * Uses real-time fetching (staleTime: 0) to ensure data freshness
  * per ticket requirement to mitigate stale household/custody data.
  *
- * @returns TanStack Query result with household data
+ * When the API returns 403 with a `requiredIal` extension, the user's IAL is
+ * below the minimum required by their cases. The hook automatically redirects
+ * to `/login/id-proofing` and exposes `requiresProofing` so consumers can
+ * render a loading state during the redirect.
+ *
+ * @returns TanStack Query result with household data, plus `requiresProofing` flag
  */
 export function useHouseholdData() {
-  return useQuery({
+  const router = useRouter()
+
+  const query = useQuery({
     queryKey: ['householdData'],
     queryFn: fetchHouseholdData,
     staleTime: 0,
@@ -34,4 +45,19 @@ export function useHouseholdData() {
     },
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000)
   })
+
+  // A 403 with requiredIal in the response body means the user's IAL is below
+  // the minimum required by their cases. Redirect to ID proofing.
+  const requiresProofing =
+    query.error instanceof ApiError &&
+    query.error.status === 403 &&
+    'requiredIal' in ((query.error.data as Record<string, unknown>) ?? {})
+
+  useEffect(() => {
+    if (requiresProofing) {
+      router.push('/login/id-proofing')
+    }
+  }, [requiresProofing, router])
+
+  return { ...query, requiresProofing }
 }

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -20,13 +20,16 @@ async function fetchHouseholdData(): Promise<HouseholdData> {
  * per ticket requirement to mitigate stale household/custody data.
  *
  * When the API returns 403 with a `requiredIal` extension, the user's IAL is
- * below the minimum required by their cases. The hook automatically redirects
+ * below the minimum required by their cases. By default the hook redirects
  * to `/login/id-proofing` and exposes `requiresProofing` so consumers can
  * render a loading state during the redirect.
  *
+ * @param options.redirectOnInsufficientIal - Whether to auto-redirect on 403.
+ *   Defaults to `true`. Set to `false` to handle the 403 yourself (e.g., show
+ *   an inline prompt instead of redirecting).
  * @returns TanStack Query result with household data, plus `requiresProofing` flag
  */
-export function useHouseholdData() {
+export function useHouseholdData({ redirectOnInsufficientIal = true } = {}) {
   const router = useRouter()
 
   const query = useQuery({
@@ -54,10 +57,10 @@ export function useHouseholdData() {
     'requiredIal' in ((query.error.data as Record<string, unknown>) ?? {})
 
   useEffect(() => {
-    if (requiresProofing) {
+    if (requiresProofing && redirectOnInsufficientIal) {
       router.push('/login/id-proofing')
     }
-  }, [requiresProofing, router])
+  }, [requiresProofing, redirectOnInsufficientIal, router])
 
   return { ...query, requiresProofing }
 }

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -3,6 +3,7 @@
 import { ApiError } from '@/api'
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
 import { Alert } from '@sebt/design-system'
+import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -20,8 +21,18 @@ import { UserProfileCard } from '../UserProfileCard'
 // TODO: Add to CSV: "S2 - Portal Dashboard - Error Heading" and "S2 - Portal Dashboard - Error Description"
 export function DashboardContent() {
   const { t } = useTranslation('dashboard')
+  const router = useRouter()
   const { data, isLoading, isError, error } = useHouseholdData()
   const { setPageData, setUserData, trackEvent } = useDataLayer()
+
+  // 403 means the user's IAL is below the minimum required by their cases.
+  // Redirect to ID proofing so they can reach the required level.
+  const requiresProofing = error instanceof ApiError && error.status === 403
+  useEffect(() => {
+    if (requiresProofing) {
+      router.push('/login/id-proofing')
+    }
+  }, [requiresProofing, router])
 
   useEffect(() => {
     if (isLoading) return
@@ -38,7 +49,7 @@ export function DashboardContent() {
   // Visually hidden h1 for accessibility - provides page structure for screen readers
   const pageHeading = <h1 className="usa-sr-only">{t('pageTitle', 'SUN Bucks Dashboard')}</h1>
 
-  if (isLoading) {
+  if (isLoading || requiresProofing) {
     return (
       <>
         {pageHeading}

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -25,9 +25,12 @@ export function DashboardContent() {
   const { data, isLoading, isError, error } = useHouseholdData()
   const { setPageData, setUserData, trackEvent } = useDataLayer()
 
-  // 403 means the user's IAL is below the minimum required by their cases.
-  // Redirect to ID proofing so they can reach the required level.
-  const requiresProofing = error instanceof ApiError && error.status === 403
+  // A 403 with requiredIal in the response body means the user's IAL is below
+  // the minimum required by their cases. Redirect to ID proofing.
+  const requiresProofing =
+    error instanceof ApiError &&
+    error.status === 403 &&
+    'requiredIal' in ((error.data as Record<string, unknown>) ?? {})
   useEffect(() => {
     if (requiresProofing) {
       router.push('/login/id-proofing')

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -3,7 +3,6 @@
 import { ApiError } from '@/api'
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
 import { Alert } from '@sebt/design-system'
-import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -21,21 +20,8 @@ import { UserProfileCard } from '../UserProfileCard'
 // TODO: Add to CSV: "S2 - Portal Dashboard - Error Heading" and "S2 - Portal Dashboard - Error Description"
 export function DashboardContent() {
   const { t } = useTranslation('dashboard')
-  const router = useRouter()
-  const { data, isLoading, isError, error } = useHouseholdData()
+  const { data, isLoading, isError, error, requiresProofing } = useHouseholdData()
   const { setPageData, setUserData, trackEvent } = useDataLayer()
-
-  // A 403 with requiredIal in the response body means the user's IAL is below
-  // the minimum required by their cases. Redirect to ID proofing.
-  const requiresProofing =
-    error instanceof ApiError &&
-    error.status === 403 &&
-    'requiredIal' in ((error.data as Record<string, unknown>) ?? {})
-  useEffect(() => {
-    if (requiresProofing) {
-      router.push('/login/id-proofing')
-    }
-  }, [requiresProofing, router])
 
   useEffect(() => {
     if (isLoading) return

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
@@ -52,6 +52,9 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
         Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", "plugins-none");
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey",
             "integration-test-key-must-be-at-least-32-bytes-long");
+        Environment.SetEnvironmentVariable("MinimumIal__ApplicationCases", "IAL1");
+        Environment.SetEnvironmentVariable("MinimumIal__CoLoadedStreamlineCases", "IAL1");
+        Environment.SetEnvironmentVariable("MinimumIal__NonCoLoadedStreamlineCases", "IAL1plus");
 
         builder.ConfigureServices(services =>
         {
@@ -97,6 +100,9 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
         Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", null);
         Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", null);
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey", null);
+        Environment.SetEnvironmentVariable("MinimumIal__ApplicationCases", null);
+        Environment.SetEnvironmentVariable("MinimumIal__CoLoadedStreamlineCases", null);
+        Environment.SetEnvironmentVariable("MinimumIal__NonCoLoadedStreamlineCases", null);
         foreach (var key in _envKeysToClean)
         {
             Environment.SetEnvironmentVariable(key, null);

--- a/test/SEBT.Portal.Tests/Integration/PortalWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PortalWebApplicationFactory.cs
@@ -34,7 +34,10 @@ public class PortalWebApplicationFactory : WebApplicationFactory<Program>
         "Oidc__ClientId",
         "Oidc__CallbackRedirectUri",
         "Oidc__CompleteLoginSigningKey",
-        "ConnectionStrings__Redis"
+        "ConnectionStrings__Redis",
+        "MinimumIal__ApplicationCases",
+        "MinimumIal__CoLoadedStreamlineCases",
+        "MinimumIal__NonCoLoadedStreamlineCases"
     ];
 
 
@@ -54,6 +57,11 @@ public class PortalWebApplicationFactory : WebApplicationFactory<Program>
 
         // Disable Redis so HybridCache uses in-memory only (no 5s timeout per op)
         Environment.SetEnvironmentVariable("ConnectionStrings__Redis", "");
+
+        // MinimumIal settings are required — app fails to start without them
+        Environment.SetEnvironmentVariable("MinimumIal__ApplicationCases", "IAL1");
+        Environment.SetEnvironmentVariable("MinimumIal__CoLoadedStreamlineCases", "IAL1");
+        Environment.SetEnvironmentVariable("MinimumIal__NonCoLoadedStreamlineCases", "IAL1plus");
 
         builder.ConfigureServices(services =>
         {

--- a/test/SEBT.Portal.Tests/Unit/Controllers/HouseholdControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/HouseholdControllerTests.cs
@@ -21,12 +21,16 @@ namespace SEBT.Portal.Tests.Unit.Controllers;
 public class HouseholdControllerTests
 {
     private readonly IIdProofingRequirementsService _idProofingRequirementsService;
+    private readonly IMinimumIalService _minimumIalService;
     private readonly HouseholdController _controller;
 
     public HouseholdControllerTests()
     {
         _controller = new HouseholdController();
         _idProofingRequirementsService = Substitute.For<IIdProofingRequirementsService>();
+        _minimumIalService = Substitute.For<IMinimumIalService>();
+        // Default: no elevated IAL requirement, so existing tests pass without per-test mock setup.
+        _minimumIalService.GetMinimumIal(Arg.Any<IReadOnlyList<SummerEbtCase>>()).Returns(UserIalLevel.None);
     }
 
     private IQueryHandler<GetHouseholdDataQuery, HouseholdData> CreateQueryHandler(
@@ -34,7 +38,7 @@ public class HouseholdControllerTests
         IHouseholdRepository repository)
     {
         var logger = NullLogger<GetHouseholdDataQueryHandler>.Instance;
-        return new GetHouseholdDataQueryHandler(resolver, repository, _idProofingRequirementsService, logger);
+        return new GetHouseholdDataQueryHandler(resolver, repository, _idProofingRequirementsService, _minimumIalService, logger);
     }
 
     private void SetupAuthenticatedUser(string email, UserIalLevel userIalLevel = UserIalLevel.None, string claimType = ClaimTypes.Email)

--- a/test/SEBT.Portal.Tests/Unit/Services/MinimumIalServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/MinimumIalServiceTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Infrastructure.Services;
+using Xunit;
+
+namespace SEBT.Portal.Tests.Unit.Services;
+
+public class MinimumIalServiceTests
+{
+    private static MinimumIalService CreateService(MinimumIalSettings? settings = null)
+    {
+        settings ??= new MinimumIalSettings();
+        var snapshot = Substitute.For<IOptionsSnapshot<MinimumIalSettings>>();
+        snapshot.Value.Returns(settings);
+        return new MinimumIalService(snapshot, NullLogger<MinimumIalService>.Instance);
+    }
+
+    private static SummerEbtCase CreateCase(
+        bool isStreamlineCertified = false,
+        bool isCoLoaded = false)
+    {
+        return new SummerEbtCase
+        {
+            ChildFirstName = "Test",
+            ChildLastName = "Child",
+            IsStreamlineCertified = isStreamlineCertified,
+            IsCoLoaded = isCoLoaded
+        };
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenNoCases_ReturnsIal1()
+    {
+        var service = CreateService();
+        var result = service.GetMinimumIal([]);
+        Assert.Equal(UserIalLevel.IAL1, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenOnlyApplicationCases_ReturnsApplicationCasesLevel()
+    {
+        var settings = new MinimumIalSettings { ApplicationCases = IalLevel.IAL1 };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase> { CreateCase(isStreamlineCertified: false, isCoLoaded: false) };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenOnlyCoLoadedStreamlineCases_ReturnsCoLoadedLevel()
+    {
+        var settings = new MinimumIalSettings { CoLoadedStreamlineCases = IalLevel.IAL1 };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase> { CreateCase(isStreamlineCertified: true, isCoLoaded: true) };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenAnyNonCoLoadedStreamlineCase_ReturnsNonCoLoadedLevel()
+    {
+        var settings = new MinimumIalSettings { NonCoLoadedStreamlineCases = IalLevel.IAL1plus };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase> { CreateCase(isStreamlineCertified: true, isCoLoaded: false) };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1plus, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenMixedCases_HighestWins()
+    {
+        var settings = new MinimumIalSettings
+        {
+            CoLoadedStreamlineCases = IalLevel.IAL1,
+            NonCoLoadedStreamlineCases = IalLevel.IAL1plus
+        };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase>
+        {
+            CreateCase(isStreamlineCertified: true, isCoLoaded: true),
+            CreateCase(isStreamlineCertified: true, isCoLoaded: false)
+        };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1plus, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenMixedApplicationAndStreamline_HighestWins()
+    {
+        var settings = new MinimumIalSettings
+        {
+            ApplicationCases = IalLevel.IAL1,
+            NonCoLoadedStreamlineCases = IalLevel.IAL1plus
+        };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase>
+        {
+            CreateCase(isStreamlineCertified: false, isCoLoaded: false),
+            CreateCase(isStreamlineCertified: true, isCoLoaded: false)
+        };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1plus, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenAllThreeTypes_HighestWins()
+    {
+        var settings = new MinimumIalSettings
+        {
+            ApplicationCases = IalLevel.IAL1,
+            CoLoadedStreamlineCases = IalLevel.IAL1,
+            NonCoLoadedStreamlineCases = IalLevel.IAL1plus
+        };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase>
+        {
+            CreateCase(isStreamlineCertified: false, isCoLoaded: false),
+            CreateCase(isStreamlineCertified: true, isCoLoaded: true),
+            CreateCase(isStreamlineCertified: true, isCoLoaded: false)
+        };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1plus, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_WhenApplicationAndCoLoadedOnly_ReturnsIal1()
+    {
+        var settings = new MinimumIalSettings
+        {
+            ApplicationCases = IalLevel.IAL1,
+            CoLoadedStreamlineCases = IalLevel.IAL1,
+            NonCoLoadedStreamlineCases = IalLevel.IAL1plus
+        };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase>
+        {
+            CreateCase(isStreamlineCertified: false, isCoLoaded: false),
+            CreateCase(isStreamlineCertified: true, isCoLoaded: true)
+        };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1, result);
+    }
+
+    [Fact]
+    public void GetMinimumIal_RespectsCustomConfig_WhenCoLoadedRequiresIal1plus()
+    {
+        var settings = new MinimumIalSettings
+        {
+            ApplicationCases = IalLevel.IAL1,
+            CoLoadedStreamlineCases = IalLevel.IAL1plus,
+            NonCoLoadedStreamlineCases = IalLevel.IAL1plus
+        };
+        var service = CreateService(settings);
+        var cases = new List<SummerEbtCase> { CreateCase(isStreamlineCertified: true, isCoLoaded: true) };
+        var result = service.GetMinimumIal(cases);
+        Assert.Equal(UserIalLevel.IAL1plus, result);
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Services/MinimumIalServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/MinimumIalServiceTests.cs
@@ -13,7 +13,12 @@ public class MinimumIalServiceTests
 {
     private static MinimumIalService CreateService(MinimumIalSettings? settings = null)
     {
-        settings ??= new MinimumIalSettings();
+        settings ??= new MinimumIalSettings
+        {
+            ApplicationCases = IalLevel.IAL1,
+            CoLoadedStreamlineCases = IalLevel.IAL1,
+            NonCoLoadedStreamlineCases = IalLevel.IAL1plus
+        };
         var snapshot = Substitute.For<IOptionsSnapshot<MinimumIalSettings>>();
         snapshot.Value.Returns(settings);
         return new MinimumIalService(snapshot, NullLogger<MinimumIalService>.Instance);

--- a/test/SEBT.Portal.Tests/Unit/UseCases/DependenciesTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/DependenciesTests.cs
@@ -23,6 +23,7 @@ public class DependenciesTests
         // Stub infrastructure dependencies that handlers need at construction time
         services.AddSingleton(Substitute.For<IHouseholdIdentifierResolver>());
         services.AddSingleton(Substitute.For<IHouseholdRepository>());
+        services.AddSingleton(Substitute.For<IMinimumIalService>());
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/GetHouseholdDataQueryHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/GetHouseholdDataQueryHandlerTests.cs
@@ -17,7 +17,14 @@ public class GetHouseholdDataQueryHandlerTests
     private readonly IHouseholdIdentifierResolver _resolver = Substitute.For<IHouseholdIdentifierResolver>();
     private readonly IHouseholdRepository _repository = Substitute.For<IHouseholdRepository>();
     private readonly IIdProofingRequirementsService _idProofingRequirementsService = Substitute.For<IIdProofingRequirementsService>();
+    private readonly IMinimumIalService _minimumIalService = Substitute.For<IMinimumIalService>();
     private readonly NullLogger<GetHouseholdDataQueryHandler> _logger = NullLogger<GetHouseholdDataQueryHandler>.Instance;
+
+    public GetHouseholdDataQueryHandlerTests()
+    {
+        // Default: no elevated IAL requirement, so existing tests pass without per-test mock setup.
+        _minimumIalService.GetMinimumIal(Arg.Any<IReadOnlyList<SummerEbtCase>>()).Returns(UserIalLevel.None);
+    }
 
     private static ClaimsPrincipal CreateUser(string email, UserIalLevel ialLevel, string claimType = ClaimTypes.Email)
     {
@@ -64,7 +71,7 @@ public class GetHouseholdDataQueryHandlerTests
         _repository.GetHouseholdByIdentifierAsync(identifier, Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act
@@ -98,7 +105,7 @@ public class GetHouseholdDataQueryHandlerTests
         _repository.GetHouseholdByIdentifierAsync(identifier, Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act
@@ -123,7 +130,7 @@ public class GetHouseholdDataQueryHandlerTests
         _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdIdentifier?)null);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act
@@ -151,7 +158,7 @@ public class GetHouseholdDataQueryHandlerTests
         _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act
@@ -180,7 +187,7 @@ public class GetHouseholdDataQueryHandlerTests
         _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act
@@ -211,7 +218,7 @@ public class GetHouseholdDataQueryHandlerTests
         _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act
@@ -224,6 +231,67 @@ public class GetHouseholdDataQueryHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserIalBelowMinimum_ReturnsForbiddenWithRequiredIal()
+    {
+        // Arrange: user at IAL1, but cases require IAL1+
+        var email = "user@example.com";
+        var user = CreateUser(email, UserIalLevel.IAL1);
+        var identifier = HouseholdIdentifier.Email(EmailNormalizer.Normalize(email));
+        var householdData = new HouseholdData { Email = email };
+
+        _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(identifier);
+        _idProofingRequirementsService.GetPiiVisibility(UserIalLevel.IAL1)
+            .Returns(new PiiVisibility(IncludeAddress: false, IncludeEmail: true, IncludePhone: true));
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
+            .Returns(householdData);
+        _minimumIalService.GetMinimumIal(Arg.Any<IReadOnlyList<SummerEbtCase>>())
+            .Returns(UserIalLevel.IAL1plus);
+
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
+        var query = new GetHouseholdDataQuery { User = user };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var forbidden = Assert.IsType<ForbiddenResult<HouseholdData>>(result);
+        Assert.Contains("IAL1plus", forbidden.Message);
+        Assert.Equal("IAL1plus", forbidden.Extensions["requiredIal"]);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserIalMeetsMinimum_ReturnsSuccess()
+    {
+        // Arrange: user at IAL1+, cases require IAL1+
+        var email = "user@example.com";
+        var user = CreateUser(email, UserIalLevel.IAL1plus);
+        var identifier = HouseholdIdentifier.Email(EmailNormalizer.Normalize(email));
+        var householdData = new HouseholdData { Email = email };
+
+        _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
+            .Returns(identifier);
+        _idProofingRequirementsService.GetPiiVisibility(UserIalLevel.IAL1plus)
+            .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<CancellationToken>())
+            .Returns(householdData);
+        _minimumIalService.GetMinimumIal(Arg.Any<IReadOnlyList<SummerEbtCase>>())
+            .Returns(UserIalLevel.IAL1plus);
+
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
+        var query = new GetHouseholdDataQuery { User = user };
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<HouseholdData>>(result);
+        Assert.Same(householdData, success.Value);
     }
 
     [Fact]
@@ -243,7 +311,7 @@ public class GetHouseholdDataQueryHandlerTests
         _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), token)
             .Returns(householdData);
 
-        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _logger);
+        var handler = new GetHouseholdDataQueryHandler(_resolver, _repository, _idProofingRequirementsService, _minimumIalService, _logger);
         var query = new GetHouseholdDataQuery { User = user };
 
         // Act

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/RequestCardReplacementCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/RequestCardReplacementCommandHandlerTests.cs
@@ -22,11 +22,19 @@ public class RequestCardReplacementCommandHandlerTests
         Substitute.For<IHouseholdIdentifierResolver>();
     private readonly IHouseholdRepository _repository =
         Substitute.For<IHouseholdRepository>();
+    private readonly IMinimumIalService _minimumIalService =
+        Substitute.For<IMinimumIalService>();
     private readonly NullLogger<RequestCardReplacementCommandHandler> _logger =
         NullLogger<RequestCardReplacementCommandHandler>.Instance;
 
+    public RequestCardReplacementCommandHandlerTests()
+    {
+        // Default: IAL gate passes (no elevated requirement)
+        _minimumIalService.GetMinimumIal(Arg.Any<IReadOnlyList<SummerEbtCase>>()).Returns(UserIalLevel.None);
+    }
+
     private RequestCardReplacementCommandHandler CreateHandler(TimeProvider? timeProvider = null) =>
-        new(_validator, _resolver, _repository, timeProvider ?? TimeProvider.System, _logger);
+        new(_validator, _resolver, _repository, _minimumIalService, timeProvider ?? TimeProvider.System, _logger);
 
     private static ClaimsPrincipal CreateUser(string email, string? ialClaim = null)
     {

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
@@ -36,6 +36,8 @@ public class UpdateAddressCommandHandlerTests
         Substitute.For<IIdProofingRequirementsService>();
     private readonly IStateAddressUpdateService _stateAddressUpdateService =
         Substitute.For<IStateAddressUpdateService>();
+    private readonly IMinimumIalService _minimumIalService =
+        Substitute.For<IMinimumIalService>();
     private readonly NullLogger<UpdateAddressCommandHandler> _logger =
         NullLogger<UpdateAddressCommandHandler>.Instance;
 
@@ -64,11 +66,13 @@ public class UpdateAddressCommandHandlerTests
             .Returns(AddressUpdateResult.Success());
         _idProofingRequirementsService.GetPiiVisibility(Arg.Any<UserIalLevel>())
             .Returns(new PiiVisibility(false, false, false));
+        // Default: IAL gate passes (no elevated requirement)
+        _minimumIalService.GetMinimumIal(Arg.Any<IReadOnlyList<SummerEbtCase>>()).Returns(UserIalLevel.None);
     }
 
     private UpdateAddressCommandHandler CreateHandler() =>
         new(_validator, _addressUpdateService, _addressValidationService, _resolver, _householdRepository,
-            _idProofingRequirementsService, _stateAddressUpdateService, _logger);
+            _idProofingRequirementsService, _minimumIalService, _stateAddressUpdateService, _logger);
 
     private static ClaimsPrincipal CreateUser(string email)
     {

--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -118,6 +118,9 @@ module "app" {
     "Oidc__StepUp__AuthorizationEndpoint"              = var.oidc_authorization_endpoint
     "Oidc__StepUp__CallbackRedirectUri"                = "https://${var.domain}/callback"
     "StateHouseholdId__PreferredHouseholdIdTypes__0"   = "Phone"
+    "MinimumIal__ApplicationCases"                     = "IAL1"
+    "MinimumIal__CoLoadedStreamlineCases"               = "IAL1"
+    "MinimumIal__NonCoLoadedStreamlineCases"             = "IAL1"
   }
 
   state_api_environment_secrets = {

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -91,4 +91,10 @@ module "app" {
   seeding_enabled         = "true"
   seeding_email_pattern   = "sebt.dc+{0}@codeforamerica.org"
   use_mock_household_data = "true"
+
+  state_api_environment_variables = {
+    "MinimumIal__ApplicationCases"           = "IAL1"
+    "MinimumIal__CoLoadedStreamlineCases"    = "IAL1"
+    "MinimumIal__NonCoLoadedStreamlineCases" = "IAL1plus"
+  }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-81

#### ✍️ Description
Determine the minimum Identity Assurance Level (IAL) a user must achieve based on the co-loading and streamline-certification status of their Summer EBT cases.

- Add `IsCoLoaded` and `IsStreamlineCertified` boolean facts to Core `SummerEbtCase` model
- Implement `MinimumIalService` with state-configurable policy (`MinimumIalSettings`) — "highest wins" rule across all cases
- Three case-origin buckets: application cases (IAL1), co-loaded streamline cases (IAL1), non-co-loaded streamline cases (IAL1+)
- Update `PluginHouseholdDataMapper` to map new boolean fields from plugin boundary
- Register service and settings in DI, add config to `appsettings.json` and `appsettings.dc.json`

#### 🔗 Links to related PRs
- **state-connector**: codeforamerica/sebt-self-service-portal-state-connector#14
- **dc-connector**: codeforamerica/sebt-self-service-portal-dc-connector#13
- **co-connector**: codeforamerica/sebt-self-service-portal-co-connector#18

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [x] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [x] If appsetttings are changed, update in AWS AppConfig