### PR TITLE
Add Socure SDK env vars for CO and move web builds to deploy jobs

### DIFF
--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -187,30 +187,10 @@ jobs:
             -t sebt-portal-api:${{ steps.tag.outputs.tag }} \
             .
 
-      - name: Build Web DC image
-        run: |
-          docker build \
-            --platform linux/amd64 \
-            -f src/SEBT.Portal.Web/Dockerfile \
-            --build-arg STATE=dc \
-            -t sebt-portal-web-dc:${{ steps.tag.outputs.tag }} \
-            .
-
-      - name: Build Web CO image
-        run: |
-          docker build \
-            --platform linux/amd64 \
-            -f src/SEBT.Portal.Web/Dockerfile \
-            --build-arg STATE=co \
-            -t sebt-portal-web-co:${{ steps.tag.outputs.tag }} \
-            .
-
       - name: Save Docker images
         run: |
           docker save \
             sebt-portal-api:${{ steps.tag.outputs.tag }} \
-            sebt-portal-web-dc:${{ steps.tag.outputs.tag }} \
-            sebt-portal-web-co:${{ steps.tag.outputs.tag }} \
             -o /tmp/docker-images.tar
 
       - name: Upload Docker images
@@ -258,6 +238,15 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Web image
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            -f src/SEBT.Portal.Web/Dockerfile \
+            --build-arg STATE=dc \
+            -t sebt-portal-web-dc:${{ needs.build.outputs.image_tag }} \
+            .
 
       - name: Push images to ECR
         run: |
@@ -332,6 +321,18 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build Web image
+        run: |
+          docker build \
+            --platform linux/amd64 \
+            -f src/SEBT.Portal.Web/Dockerfile \
+            --build-arg STATE=co \
+            --build-arg NEXT_PUBLIC_SOCURE_SDK_KEY=${{ vars.SOCURE_SDK_KEY }} \
+            --build-arg NEXT_PUBLIC_SOCURE_DI_SDK_KEY=${{ vars.SOCURE_DI_SDK_KEY }} \
+            --build-arg NEXT_PUBLIC_MOCK_SOCURE=${{ vars.MOCK_SOCURE }} \
+            -t sebt-portal-web-co:${{ needs.build.outputs.image_tag }} \
+            .
 
       - name: Push images to ECR
         run: |

--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -245,6 +245,9 @@ jobs:
             --platform linux/amd64 \
             -f src/SEBT.Portal.Web/Dockerfile \
             --build-arg STATE=dc \
+            --build-arg NEXT_PUBLIC_SOCURE_SDK_KEY=${{ vars.SOCURE_SDK_KEY }} \
+            --build-arg NEXT_PUBLIC_SOCURE_DI_SDK_KEY=${{ vars.SOCURE_DI_SDK_KEY }} \
+            --build-arg NEXT_PUBLIC_MOCK_SOCURE=${{ vars.MOCK_SOCURE }} \
             -t sebt-portal-web-dc:${{ needs.build.outputs.image_tag }} \
             .
 
@@ -328,9 +331,6 @@ jobs:
             --platform linux/amd64 \
             -f src/SEBT.Portal.Web/Dockerfile \
             --build-arg STATE=co \
-            --build-arg NEXT_PUBLIC_SOCURE_SDK_KEY=${{ vars.SOCURE_SDK_KEY }} \
-            --build-arg NEXT_PUBLIC_SOCURE_DI_SDK_KEY=${{ vars.SOCURE_DI_SDK_KEY }} \
-            --build-arg NEXT_PUBLIC_MOCK_SOCURE=${{ vars.MOCK_SOCURE }} \
             -t sebt-portal-web-co:${{ needs.build.outputs.image_tag }} \
             .
 

--- a/src/SEBT.Portal.Web/Dockerfile
+++ b/src/SEBT.Portal.Web/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /workspace
 
 # Build arg controls which state is embedded at build-time.
 ARG STATE=dc
+ARG NEXT_PUBLIC_SOCURE_SDK_KEY=""
+ARG NEXT_PUBLIC_SOCURE_DI_SDK_KEY=""
+ARG NEXT_PUBLIC_MOCK_SOCURE="false"
 ENV STATE=$STATE
 ENV BUILD_STANDALONE=true
 

--- a/src/SEBT.Portal.Web/src/env.ts
+++ b/src/SEBT.Portal.Web/src/env.ts
@@ -37,6 +37,7 @@ export const env = createEnv({
     NEXT_PUBLIC_GA_ID: z.string().startsWith('G-').optional(),
     NEXT_PUBLIC_SOCURE_SDK_KEY: z.string().min(1).optional(),
     NEXT_PUBLIC_SOCURE_DI_SDK_KEY: z.string().min(1).optional(),
+    NEXT_PUBLIC_MOCK_SOCURE: z.enum(['true', 'false']).optional(),
     /**
      * Development only: when `true`, IalGuard still sends users to OIDC step-up even if the portal JWT already has IAL1+.
      * No effect unless NODE_ENV is `development`.
@@ -56,6 +57,7 @@ export const env = createEnv({
     NEXT_PUBLIC_GA_ID: process.env.NEXT_PUBLIC_GA_ID,
     NEXT_PUBLIC_SOCURE_SDK_KEY: process.env.NEXT_PUBLIC_SOCURE_SDK_KEY,
     NEXT_PUBLIC_SOCURE_DI_SDK_KEY: process.env.NEXT_PUBLIC_SOCURE_DI_SDK_KEY,
+    NEXT_PUBLIC_MOCK_SOCURE: process.env.NEXT_PUBLIC_MOCK_SOCURE,
     NEXT_PUBLIC_DEBUG_REPEAT_OIDC_STEP_UP: process.env.NEXT_PUBLIC_DEBUG_REPEAT_OIDC_STEP_UP
   },
 


### PR DESCRIPTION
- Add `NEXT_PUBLIC_SOCURE_SDK_KEY`, `NEXT_PUBLIC_SOCURE_DI_SDK_KEY`, and      
  `NEXT_PUBLIC_MOCK_SOCURE` as Docker build args so they get baked into the CO  
  web image's client-side JS bundle at build time                               
- Add `NEXT_PUBLIC_MOCK_SOCURE` to the t3-env validation in `env.ts` (the     
  other two already existed)                  
- Move web image builds from the shared `build` job into the per-state        
  `deploy-dc`/`deploy-co` jobs so each build runs with the correct GitHub
  Environment context
  
## Why move the web builds?                                                   
                                          
`NEXT_PUBLIC_*` variables are inlined into the client-side JavaScript bundle  
during `next build`. They must be present as environment variables when       
`docker build` runs. Setting them as ECS task definition env vars at runtime
has no effect on client-side code.                                            
                  
The CO Socure vars come from GitHub Environment variables (`dev-co`), which   
are only available to jobs with `environment: dev-co`. The shared `build` job
had no environment set, so it couldn't access them. Moving each state's web
build into its deploy job gives it the right environment context.             
  
A side benefit: DC and CO web images now build in parallel (one per deploy    
job) instead of sequentially, and the shared artifact is smaller (API image
only).
  
## Test plan                                                                  
                  
- [x] Verify `dev-co` GitHub Environment variables are set before merging     
- [ ] Confirm deploy-ecr workflow completes successfully for both DC and CO
  after merge                                                                   
- [ ] Verify Socure SDK initializes correctly in the CO web app               
- [ ] Verify DC deployment is unaffected (no Socure vars, builds as before)
