### PR TITLE
Update tofu with new secrets

### DIFF
--- a/src/SEBT.Portal.Api/appsettings.co.example.json
+++ b/src/SEBT.Portal.Api/appsettings.co.example.json
@@ -54,8 +54,8 @@
   },
   "Smarty": {
     "Enabled": false,
-    "AuthId": "",
-    "AuthToken": ""
+    "AuthId": "SECRET_STORE_IN_USERSECRETS_OR_AWS_SECRETS_NOT_APP_CONFIG",
+    "AuthToken": "SECRET_STORE_IN_USERSECRETS_OR_AWS_SECRETS_NOT_APP_CONFIG"
   },
   "Socure": {
     "Enabled": false

--- a/src/SEBT.Portal.Api/appsettings.dc.example.json
+++ b/src/SEBT.Portal.Api/appsettings.dc.example.json
@@ -40,8 +40,8 @@
   },
   "Smarty": {
     "Enabled": false,
-    "AuthId": "",
-    "AuthToken": ""
+    "AuthId": "SECRET_STORE_IN_USERSECRETS_OR_AWS_SECRETS_NOT_APP_CONFIG",
+    "AuthToken": "SECRET_STORE_IN_USERSECRETS_OR_AWS_SECRETS_NOT_APP_CONFIG"
   },
   "_socure_comment": [
     "Socure identity verification integration.",
@@ -55,8 +55,8 @@
   "Socure": {
     "Enabled": true,
     "UseStub": false,
-    "ApiKey": "YOUR_SOCURE_API_KEY",
-    "WebhookSecret": "YOUR_WEBHOOK_SECRET",
+    "ApiKey": "SECRET_STORE_IN_USERSECRETS_OR_AWS_SECRETS_NOT_APP_CONFIG",
+    "WebhookSecret": "SECRET_STORE_IN_USERSECRETS_OR_AWS_SECRETS_NOT_APP_CONFIG",
     "BaseUrl": "https://riskos.sandbox.socure.com",
     "ChallengeExpirationMinutes": 30,
     "ApiVersion": "2025-01-01.orion",

--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -57,7 +57,7 @@ data "aws_route53_zone" "main" {
 }
 
 # Store Colorado-specific secrets in Secrets Manager. Each block represents a
-# separate secret for a specific service or integration.
+# separate set of secrets for a specific service or integration.
 module "state_secrets" {
   source = "github.com/codeforamerica/tofu-modules-aws-secrets?ref=2.0.0"
 

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -56,6 +56,23 @@ data "aws_route53_zone" "main" {
   name = "dc.sebt-portal.codeforamerica.app"
 }
 
+# Store DC-specific secrets in Secrets Manager. Each block represents a
+# separate set of secrets for a specific service or integration.
+module "state_secrets" {
+  source = "github.com/codeforamerica/tofu-modules-aws-secrets?ref=2.0.0"
+
+  project     = "${var.project}-${var.state}"
+  environment = var.environment
+  service     = "state-secrets"
+
+  secrets = {
+    "socure" = {
+      description     = "Socure API credentials for identity verification."
+      recovery_window = 7
+    }
+  }
+}
+
 # Deploy the application services (API + Web) using the shared wrapper module.
 module "app" {
   source = "../../modules/sebt_application"
@@ -96,5 +113,10 @@ module "app" {
     "MinimumIal__ApplicationCases"           = "IAL1"
     "MinimumIal__CoLoadedStreamlineCases"    = "IAL1"
     "MinimumIal__NonCoLoadedStreamlineCases" = "IAL1plus"
+  }
+
+  state_api_environment_secrets = {
+    "Socure__ApiKey"        = "${module.state_secrets.secrets["socure"].secret_arn}:api_key"
+    "Socure__WebhookSecret" = "${module.state_secrets.secrets["socure"].secret_arn}:webhook_secret"
   }
 }

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -119,4 +119,7 @@ module "app" {
     "Socure__ApiKey"        = "${module.state_secrets.secrets["socure"].secret_arn}:api_key"
     "Socure__WebhookSecret" = "${module.state_secrets.secrets["socure"].secret_arn}:webhook_secret"
   }
+
+  state_web_environment_variables = {}
+  state_web_environment_secrets   = {}
 }

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -85,8 +85,10 @@ module "api" {
     DB_PASSWORD                    = "${module.database.secret_arn}:password"
     "SmtpClientSettings__UserName" = "${module.ses.secret_arn}:username"
     "SmtpClientSettings__Password" = "${module.ses.secret_arn}:password"
-    "JwtSettings__SecretKey"       = "${module.secrets.secrets["app"].secret_arn}:jwt_secret_key"
-    "IdentifierHasher__SecretKey"  = "${module.secrets.secrets["app"].secret_arn}:identifier_hasher_secret_key"
+    "JwtSettings__SecretKey"       = "${module.secrets.secrets["auth"].secret_arn}:jwt_secret_key"
+    "IdentifierHasher__SecretKey"  = "${module.secrets.secrets["auth"].secret_arn}:identifier_hasher_secret_key"
+    "Smarty__AuthId"               = "${module.secrets.secrets["smarty"].secret_arn}:auth_id"
+    "Smarty__AuthToken"            = "${module.secrets.secrets["smarty"].secret_arn}:auth_token"
   }, var.state_api_environment_secrets)
 }
 
@@ -150,8 +152,12 @@ module "secrets" {
   service     = "api"
 
   secrets = {
-    "app" = {
-      description     = "Application secrets for the SEBT Portal API."
+    "auth" = {
+      description     = "JWT and identifier hashing secrets for the SEBT Portal API."
+      recovery_window = var.secret_recovery_period
+    }
+    "smarty" = {
+      description     = "Smarty address validation API credentials."
       recovery_window = var.secret_recovery_period
     }
   }


### PR DESCRIPTION
- Split shared `app` secret for the main portal secrets into logical groupings: `auth` (JWT + identifier hasher) and `smarty` (address validation credentials)
- Add Smarty credentials (`auth_id`, `auth_token`) to shared application secrets in Secrets Manager
- Add DC `state_secrets` module with `socure` secret for API key and webhook secret
- Add empty `state_web_environment_variables` and `state_web_environment_secrets` to DC config for symmetry with CO
- Update example appsettings to clarify that secrets should be stored in user-secrets or AWS Secrets Manager, not AppConfig

## Why                                                                                                                                          
                                                                                                                                                  
Socure API credentials were configured in AppConfig (plaintext) without the required `ApiKey`, causing the API to crash on startup. Moving secrets to Secrets Manager resolves the startup errors and places the secrets in our tofu controlled secrets manager where they should be. Smarty credentials were also in plaintext appsettings and should be treated as secrets.

Splitting the monolithic `app` secret into `auth` and `smarty` improves discoverability and follows the same logical grouping pattern used by `state_secrets`.