### PR TITLE
Add masked phone logging to auth events

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -7,6 +7,7 @@ using SEBT.Portal.Api.Models;
 using SEBT.Portal.Api.Services;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.Kernel.AspNetCore;
 using SEBT.Portal.Kernel.Results;
@@ -41,7 +42,8 @@ public class AuthController(
     {
         var email = GetUserEmail();
 
-        logger.LogInformation("Authorization status check successful for user {Email}", email ?? "unknown");
+        logger.LogInformation("Authorization status check successful for user {Email}, Phone={MaskedPhone}",
+            email ?? "unknown", GetMaskedPhone());
 
         return Ok(new AuthorizationStatusResponse(
             IsAuthorized: true,
@@ -94,14 +96,16 @@ public class AuthController(
             return Unauthorized(new ErrorResponse("Unable to identify user from token."));
         }
 
-        logger.LogInformation("Token refresh request received for email {Email}", email);
+        logger.LogInformation("Token refresh request received for email {Email}, Phone={MaskedPhone}",
+            email, GetMaskedPhone());
 
         var command = new RefreshTokenCommand { Email = email, CurrentPrincipal = User };
         var result = await handler.Handle(command);
 
         if (result.IsSuccess)
         {
-            logger.LogInformation("Token refreshed successfully for email {Email}", email);
+            logger.LogInformation("Token refreshed successfully for email {Email}, Phone={MaskedPhone}",
+                email, GetMaskedPhone());
             var expiresAt = DateTimeOffset.UtcNow.AddMinutes(jwtSettingsOptions.Value.ExpirationMinutes);
             AuthCookies.SetAuthCookie(Response, result.Value, expiresAt);
             return NoContent();
@@ -140,6 +144,16 @@ public class AuthController(
             ?? User.FindFirst("email")?.Value
             ?? User.FindFirst("sub")?.Value
             ?? User.Identity?.Name;
+    }
+
+    /// <summary>
+    /// Extracts and masks the phone number from the authenticated user's JWT claims.
+    /// Returns a masked value like "***-***-1234", or null if no phone claim is present.
+    /// </summary>
+    private string? GetMaskedPhone()
+    {
+        var phone = User.FindFirst("phone")?.Value ?? User.FindFirst("phone_number")?.Value;
+        return PiiMasker.MaskPhone(phone);
     }
 }
 

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -330,8 +330,6 @@ public class OidcController(
 
         // Extract the phone claim for diagnostic logging (masked).
         additionalClaims.TryGetValue("phone", out var phoneClaim);
-        if (phoneClaim == null)
-            additionalClaims.TryGetValue("phone_number", out phoneClaim);
         var maskedPhone = MaskPhone(phoneClaim);
 
         if (phoneClaim == null)

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -13,6 +13,8 @@ using SEBT.Portal.Core.Services;
 using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Infrastructure.Services;
 
+using static SEBT.Portal.Core.Utilities.PiiMasker;
+
 namespace SEBT.Portal.Api.Controllers.Auth;
 
 /// <summary>
@@ -195,6 +197,12 @@ public class OidcController(
             return BadRequest(new ErrorResponse("Pre-auth session has already been used."));
         }
 
+        logger.LogInformation(
+            "OIDC Callback exchange succeeded: IsStepUp={IsStepUp}, Phone={MaskedPhone}, SessionId={SessionId}",
+            session.IsStepUp,
+            MaskPhone(result.PhoneClaim),
+            sessionId);
+
         return Ok(new { callbackToken = result.CallbackToken });
     }
 
@@ -315,7 +323,13 @@ public class OidcController(
 
         logger.LogInformation("Additional OIDC claim types: {Claims}", string.Join(", ", additionalClaims.Select(c => c.Key).ToArray()));
 
-        if (!additionalClaims.Select(c => c.Key).Contains("phone"))
+        // Extract the phone claim for diagnostic logging (masked).
+        additionalClaims.TryGetValue("phone", out var phoneClaim);
+        if (phoneClaim == null)
+            additionalClaims.TryGetValue("phone_number", out phoneClaim);
+        var maskedPhone = MaskPhone(phoneClaim);
+
+        if (phoneClaim == null)
         {
             logger.LogWarning("OIDC incoming claims missing 'phone'");
         }
@@ -348,11 +362,12 @@ public class OidcController(
 
             var safeStateKey = SanitizeForLog(stateKey);
             logger.LogInformation(
-                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel {IalLevel}, IdProofingStatus {IdProofingStatus}",
+                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel {IalLevel}, IdProofingStatus {IdProofingStatus}, Phone={MaskedPhone}",
                 user.Id,
                 safeStateKey,
                 user.IalLevel,
-                user.IdProofingStatus);
+                user.IdProofingStatus,
+                maskedPhone);
         }
         else
         {
@@ -386,6 +401,13 @@ public class OidcController(
         var token = jwtService.GenerateToken(user, additionalClaims);
         var expiresAt = DateTimeOffset.UtcNow.AddMinutes(jwtSettingsOptions.Value.ExpirationMinutes);
         AuthCookies.SetAuthCookie(Response, token, expiresAt);
+
+        if (!session.IsStepUp)
+        {
+            logger.LogInformation(
+                "OIDC login complete: UserId {UserId}, IalLevel {IalLevel}, Phone={MaskedPhone}",
+                user.Id, user.IalLevel, maskedPhone);
+        }
 
         string? safeReturnUrl = null;
         if (session.IsStepUp)

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -92,6 +92,10 @@ public class OidcController(
             stateCode, state, codeVerifier, redirectUri, stepUp, cancellationToken);
         OidcSessionCookie.Set(Response, session.Id);
 
+        logger.LogInformation(
+            "OIDC GetConfig succeeded: StateCode={StateCode}, IsStepUp={IsStepUp}, SessionId={SessionId}",
+            stateCode, stepUp, session.Id);
+
         return Ok(new
         {
             authorizationEndpoint,
@@ -276,7 +280,7 @@ public class OidcController(
         var signingKey = config["Oidc:CompleteLoginSigningKey"];
         if (string.IsNullOrEmpty(signingKey))
         {
-            logger.LogWarning("Oidc:CompleteLoginSigningKey is not configured.");
+            logger.LogWarning("Oidc:CompleteLoginSigningKey is not configured (SessionId={SessionId}).", sessionId);
             var hint = environment.IsDevelopment() ? "Set Oidc:CompleteLoginSigningKey in appsettings." : "";
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Complete-login not configured.", hint });
         }
@@ -306,8 +310,8 @@ public class OidcController(
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Invalid or expired callback token for state {StateCode}",
-                SanitizeForLog(requestedStateCode));
+            logger.LogWarning(ex, "Invalid or expired callback token for state {StateCode} (SessionId={SessionId})",
+                SanitizeForLog(requestedStateCode), sessionId);
             return BadRequest(new ErrorResponse("Invalid or expired callback token."));
         }
 
@@ -321,7 +325,8 @@ public class OidcController(
             }
         }
 
-        logger.LogInformation("Additional OIDC claim types: {Claims}", string.Join(", ", additionalClaims.Select(c => c.Key).ToArray()));
+        logger.LogInformation("Additional OIDC claim types: {Claims} (SessionId={SessionId})",
+            string.Join(", ", additionalClaims.Select(c => c.Key).ToArray()), sessionId);
 
         // Extract the phone claim for diagnostic logging (masked).
         additionalClaims.TryGetValue("phone", out var phoneClaim);
@@ -331,13 +336,13 @@ public class OidcController(
 
         if (phoneClaim == null)
         {
-            logger.LogWarning("OIDC incoming claims missing 'phone'");
+            logger.LogWarning("OIDC incoming claims missing 'phone' (SessionId={SessionId})", sessionId);
         }
 
         var email = GetEmailFromClaims(principal);
         if (string.IsNullOrWhiteSpace(email))
         {
-            logger.LogWarning("Callback token had no email or sub claim");
+            logger.LogWarning("Callback token had no email or sub claim (SessionId={SessionId})", sessionId);
             return BadRequest(new ErrorResponse("Callback token must contain an email or sub claim."));
         }
 
@@ -349,7 +354,7 @@ public class OidcController(
             var existingUser = await userRepository.GetUserByEmailAsync(normalizedEmail, cancellationToken);
             if (existingUser == null)
             {
-                logger.LogWarning("Step-up complete-login: no existing portal user for callback token; sign-in required first.");
+                logger.LogWarning("Step-up complete-login: no existing portal user for callback token; sign-in required first (SessionId={SessionId}).", sessionId);
                 return BadRequest(new { error = "Step-up requires an existing session. Please sign in again." });
             }
 
@@ -362,12 +367,13 @@ public class OidcController(
 
             var safeStateKey = SanitizeForLog(stateKey);
             logger.LogInformation(
-                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel {IalLevel}, IdProofingStatus {IdProofingStatus}, Phone={MaskedPhone}",
+                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel {IalLevel}, IdProofingStatus {IdProofingStatus}, Phone={MaskedPhone}, SessionId={SessionId}",
                 user.Id,
                 safeStateKey,
                 user.IalLevel,
                 user.IdProofingStatus,
-                maskedPhone);
+                maskedPhone,
+                sessionId);
         }
         else
         {
@@ -393,8 +399,8 @@ public class OidcController(
                 await userRepository.UpdateUserAsync(user, cancellationToken);
 
                 logger.LogInformation(
-                    "OIDC verification claim reconciled: UserId {UserId}, IalLevel {IalLevel}, IsExpired {IsExpired}, VerifiedAt {VerifiedAt}",
-                    user.Id, user.IalLevel, verification.IsExpired, verification.VerifiedAt);
+                    "OIDC verification claim reconciled: UserId {UserId}, IalLevel {IalLevel}, IsExpired {IsExpired}, VerifiedAt {VerifiedAt}, SessionId={SessionId}",
+                    user.Id, user.IalLevel, verification.IsExpired, verification.VerifiedAt, sessionId);
             }
         }
 
@@ -405,8 +411,8 @@ public class OidcController(
         if (!session.IsStepUp)
         {
             logger.LogInformation(
-                "OIDC login complete: UserId {UserId}, IalLevel {IalLevel}, Phone={MaskedPhone}",
-                user.Id, user.IalLevel, maskedPhone);
+                "OIDC login complete: UserId {UserId}, IalLevel {IalLevel}, Phone={MaskedPhone}, SessionId={SessionId}",
+                user.Id, user.IalLevel, maskedPhone, sessionId);
         }
 
         string? safeReturnUrl = null;

--- a/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
+++ b/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
@@ -46,6 +46,9 @@ public sealed record OidcExchangeResult
     /// <summary>Signed callback token (short-lived JWT containing IdP claims). Null on failure.</summary>
     public string? CallbackToken { get; init; }
 
+    /// <summary>Phone claim value extracted during the exchange (for diagnostic logging). Null when absent or on failure.</summary>
+    public string? PhoneClaim { get; init; }
+
     /// <summary>Human-readable error message for the client. Null on success.</summary>
     public string? Error { get; init; }
 
@@ -53,10 +56,11 @@ public sealed record OidcExchangeResult
     public int StatusCode { get; init; } = 200;
 
     /// <summary>Creates a successful result with the given callback token.</summary>
-    public static OidcExchangeResult Ok(string callbackToken) => new()
+    public static OidcExchangeResult Ok(string callbackToken, string? phoneClaim = null) => new()
     {
         Success = true,
         CallbackToken = callbackToken,
+        PhoneClaim = phoneClaim,
         StatusCode = 200
     };
 
@@ -299,12 +303,17 @@ public sealed class OidcExchangeService : IOidcExchangeService
             signingCredentials: credentials);
         var callbackToken = handler.WriteToken(callbackJwt);
 
+        // Surface the phone claim for diagnostic logging by the caller (masked before logging).
+        claims.TryGetValue("phone", out var phoneClaim);
+        if (phoneClaim == null)
+            claims.TryGetValue("phone_number", out phoneClaim);
+
         _logger.LogInformation(
             "OIDC exchange succeeded: claim types={ClaimTypes} (reason=exchange_success, isStepUp={IsStepUp})",
             string.Join(", ", claims.Keys),
             isStepUp);
 
-        return OidcExchangeResult.Ok(callbackToken);
+        return OidcExchangeResult.Ok(callbackToken, phoneClaim);
     }
 
     private async Task EnrichClaimsFromUserInfo(

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
+using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.Kernel.Results;
 
@@ -54,10 +55,14 @@ public class RefreshTokenCommandHandler(
                 .ToDictionary(c => c.Type, c => c.Value);
             var token = jwtTokenService.GenerateToken(user, additionalClaims);
 
+            var maskedPhone = PiiMasker.MaskPhone(
+                command.CurrentPrincipal.FindFirst("phone")?.Value
+                ?? command.CurrentPrincipal.FindFirst("phone_number")?.Value);
             logger.LogInformation(
-                "Token refreshed successfully for email {Email} with IAL level {IalLevel}",
+                "Token refreshed successfully for email {Email} with IAL level {IalLevel}, Phone={MaskedPhone}",
                 command.Email,
-                user.IalLevel);
+                user.IalLevel,
+                maskedPhone);
 
             return Result<string>.Success(token);
         }


### PR DESCRIPTION
## Summary
- Logs a masked phone number (`***-***-1234` via `PiiMasker.MaskPhone`) with all key authentication and step-up events: OIDC callback, complete-login (initial + step-up), token refresh, and session status checks
- Adds `PhoneClaim` to `OidcExchangeResult` so the Callback endpoint can log the phone without re-decoding the callback token
- Adds a new `OIDC login complete` log for initial (non-step-up) OIDC logins, which previously had no success log

## Test plan
- [x] Verify portal builds cleanly (`dotnet build`)
- [ ] Deploy to UAT and trigger OIDC login — confirm `Phone=***-***-XXXX` appears in structured logs for Callback and CompleteLogin events
- [ ] Trigger step-up flow — confirm masked phone appears in step-up completion log
- [x] Trigger token refresh — confirm masked phone in refresh logs
- [ ] Verify OTP login still works (phone will be null in OTP flow, no phone log expected there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)