### PR TITLE
DC-260: Fix enrollment checker CORS in deployed environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Summer EBT (SUN Bucks) Self-Service Portal - Root package for convenience scripts",
   "scripts": {
     "dev": "pnpm dev:kill-port && concurrently -n \"API,Web\" -c \"blue,green\" \"pnpm api:dev\" \"pnpm web:dev\"",
-    "dev:co": "export STATE=co && pnpm api:build-co && pnpm dev",
+    "dev:co": "export STATE=co && export ENROLLMENT_CHECKER_ORIGIN=http://localhost:3001 && pnpm api:build-co && pnpm dev",
     "dev:dc": "export STATE=dc && pnpm api:build-dc && pnpm dev",
     "dev:kill-port": "lsof -ti :5280 | xargs kill 2>/dev/null; sleep 2 || true",
     "web:dev": "pnpm --filter @sebt/web dev",

--- a/src/SEBT.Portal.Web/.env.example
+++ b/src/SEBT.Portal.Web/.env.example
@@ -17,6 +17,12 @@ STATE=dc
 # Backend API URL - requests are proxied through Next.js API routes
 BACKEND_URL=http://localhost:5280
 
+# Origin of the enrollment checker static site (e.g. https://dev.co.sebt-enrollment.codeforamerica.app).
+# When set, the portal returns CORS headers on /api/enrollment/* responses so the SSG-deployed
+# enrollment checker can call the portal API cross-origin. Leave unset if the checker is not in use
+# or is served same-origin. The `pnpm dev:co` script sets this automatically for local development.
+# ENROLLMENT_CHECKER_ORIGIN=http://localhost:3001
+
 # OIDC (state IdP sign-in; used when STATE is set to a state that uses OIDC).
 # Must match the API's Oidc:* values — in particular OIDC_COMPLETE_LOGIN_SIGNING_KEY
 # must equal Oidc:CompleteLoginSigningKey in appsettings.

--- a/src/SEBT.Portal.Web/next.config.ts
+++ b/src/SEBT.Portal.Web/next.config.ts
@@ -13,10 +13,6 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === 'true'
 })
 
-// Origin of the enrollment checker static site. When set, CORS headers are
-// returned on /api/enrollment/* so the SSG-deployed checker can call the portal API.
-const enrollmentCheckerOrigin = process.env.ENROLLMENT_CHECKER_ORIGIN
-
 const nextConfig: NextConfig = {
   // NOTE: @sebt/design-system is NOT in transpilePackages. Turbopack handles
   // TypeScript natively. Using transpilePackages caused the entire barrel to
@@ -69,22 +65,6 @@ const nextConfig: NextConfig = {
         as: '*.css'
       }
     }
-  },
-  // CORS headers for the enrollment checker SSG site. Only applied when the
-  // ENROLLMENT_CHECKER_ORIGIN env var is set (i.e. in deployed environments
-  // where the enrollment checker is on a separate domain).
-  headers: async () => {
-    if (!enrollmentCheckerOrigin) return []
-    return [
-      {
-        source: '/api/enrollment/:path*',
-        headers: [
-          { key: 'Access-Control-Allow-Origin', value: enrollmentCheckerOrigin },
-          { key: 'Access-Control-Allow-Methods', value: 'GET, POST, OPTIONS' },
-          { key: 'Access-Control-Allow-Headers', value: 'Content-Type' }
-        ]
-      }
-    ]
   },
   // Standalone output for Docker/CI deployments only (set BUILD_STANDALONE=true)
   // Local dev uses standard output so `next start` serves public/ and static/ correctly

--- a/src/SEBT.Portal.Web/src/app/api/[[...path]]/route.ts
+++ b/src/SEBT.Portal.Web/src/app/api/[[...path]]/route.ts
@@ -93,14 +93,5 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
 }
 
 export async function OPTIONS(request: NextRequest, context: RouteContext) {
-  // CORS preflight requests are handled by Next.js headers config (next.config.ts).
-  // Return 204 so the browser accepts the preflight — the CORS headers are added
-  // automatically by the headers config for matching routes.
-  const { path } = await context.params
-  const pathname = path ? path.join('/') : ''
-  if (pathname.startsWith('enrollment/')) {
-    return new NextResponse(null, { status: 204 })
-  }
-
   return proxyRequest(request, context)
 }

--- a/src/SEBT.Portal.Web/src/proxy.ts
+++ b/src/SEBT.Portal.Web/src/proxy.ts
@@ -10,6 +10,32 @@ import { NextRequest, NextResponse } from 'next/server'
  * @see https://nextjs.org/docs/app/guides/content-security-policy
  */
 export function proxy(request: NextRequest) {
+  // CORS for the enrollment checker static site. Read at runtime so it works
+  // in standalone Docker containers where ENROLLMENT_CHECKER_ORIGIN is set as
+  // a container env var (not available at build time).
+  const enrollmentCheckerOrigin = process.env.ENROLLMENT_CHECKER_ORIGIN
+  if (enrollmentCheckerOrigin && /^\/api\/enrollment(\/|$)/.test(request.nextUrl.pathname)) {
+    // Preflight: return 204 with CORS headers (don't proxy to the .NET backend,
+    // which would return 405 since the controller only defines HttpPost)
+    if (request.method === 'OPTIONS') {
+      return new NextResponse(null, {
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': enrollmentCheckerOrigin,
+          'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type'
+        }
+      })
+    }
+
+    // Actual request: continue to the route handler, then add CORS headers
+    const response = NextResponse.next()
+    response.headers.set('Access-Control-Allow-Origin', enrollmentCheckerOrigin)
+    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type')
+    return response
+  }
+
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
   const isDev = process.env.NODE_ENV === 'development'
   const proto =


### PR DESCRIPTION
#### 🔗 Jira ticket
DC-260

#### ✍️ Description
Fixes CORS not being applied in deployed environments for the enrollment checker static site calling `/api/enrollment/*`.

**Root cause:** CORS headers were configured via `next.config.ts`'s `headers` export, which reads env vars at **build time**. In standalone Docker deployments, `ENROLLMENT_CHECKER_ORIGIN` is injected as a container env var at **runtime**, so the `headers` config always saw it as undefined and emitted no CORS headers.

**Fix:** Move CORS handling into the proxy middleware (`src/proxy.ts`), which runs per-request and reads env vars at runtime:
- Preflight `OPTIONS` requests return 204 directly with CORS headers. Previously these were being short-circuited in the `/api/[[...path]]` route handler — now unnecessary since the middleware handles them before the route runs. (The .NET backend would return 405 for `OPTIONS` anyway, since the enrollment controller only defines `HttpPost`.)
- Actual requests pass through to the route handler, with CORS headers appended to the response.
- Gated behind `ENROLLMENT_CHECKER_ORIGIN` — no CORS headers emitted when unset (local dev without the checker, or environments where the checker is same-origin).

**Also in this PR:**
- Adds `ENROLLMENT_CHECKER_ORIGIN=http://localhost:3001` to the `dev:co` script so the CO enrollment checker can be exercised locally.
- Documents `ENROLLMENT_CHECKER_ORIGIN` in `src/SEBT.Portal.Web/.env.example` (commented, optional) for discoverability.

**Note on DC:** DC Tofu config does not set `ENROLLMENT_CHECKER_ORIGIN` — this is correct today since DC has no enrollment checker deployed. When DC onboards one, the var will need to be added to `tofu/config/dev-dc/main.tf`.

#### 🔗 Links to related PRs
https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/26

#### ✅ Completion tasks

- [ ] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig