### PR TITLE
DC-292: IdP claims as source of truth for IAL

### DIFF
--- a/docs/superpowers/plans/2026-04-17-oidc-user-claims-source-of-truth.md
+++ b/docs/superpowers/plans/2026-04-17-oidc-user-claims-source-of-truth.md
@@ -1,0 +1,1198 @@
+# OIDC User: IdP Claims as Source of Truth
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix stale IAL bug for OIDC users by making IdP claims the sole source of truth for identity attributes, and reducing the DB footprint for OIDC users to just an identity anchor (Id, ExternalProviderId, timestamps).
+
+**Architecture:** OIDC users (Colorado) currently store IAL, email, and ID proofing state in the portal DB, which goes stale between logins. This change makes the IdP authoritative: the portal DB stores only a minimal record linking the user to the IdP's `sub` claim. IAL, email, and verification state all flow from IdP claims at login time and are carried in the portal JWT — never read back from the DB. OTP users (DC) are unaffected; the DB remains their source of truth.
+
+**Tech Stack:** C# / .NET 10 / EF Core / xUnit / NSubstitute / Bogus
+
+---
+
+## Root Cause (for partner communication)
+
+Two code paths read IAL from the portal database instead of from the identity provider:
+
+1. **OIDC re-login when verification claims are absent:** If the IdP stops sending verification claims for a user (e.g., verification expires at the IdP, claim format changes), `OidcVerificationClaimTranslator.Translate()` returns `null` and the reconciliation block is skipped. The user retains whatever IAL was stored in the portal DB from a prior login — even though the IdP no longer asserts that level.
+
+2. **Token refresh always reads DB:** `RefreshTokenCommandHandler` fetches the user from the DB and passes it to `JwtTokenService.GenerateToken()`, which hard-codes the IAL claim from `user.IalLevel`. The IAL from the existing JWT (which was correct at login time) is in `additionalClaims` but gets shadowed because `GenerateToken` sets the IAL claim from the User object first, and the dedup guard prevents the claims-based value from overriding it.
+
+**Net effect:** A user whose IdP verification status changes (upgraded, expired, revoked) retains their old IAL in the portal until they complete a fresh OIDC login where the IdP happens to include the verification claims.
+
+---
+
+## Resolved Questions
+
+1. **Household identifiers for CO:** Phone is always read from user claims (IdP), not stored in the DB for OIDC users. No DB column needed.
+
+2. **Existing CO users in production DB:** Handled via in-flight migration: on OIDC login, if no user found by `sub` but one exists by email, adopt that record by setting `ExternalProviderId = sub`. Migration code will be marked for removal in a future release.
+
+3. **IsCoLoaded for CO:** Irrelevant for CO. May not belong in the DB at all — revisit separately.
+
+## Design Principles
+
+- **For OIDC users, `sub` is the username.** The IdP subject claim is the identity anchor used for user lookup, creation, and correlation — stored as `ExternalProviderId`. Email, phone, IAL, and all other attributes flow from IdP claims and live only in the JWT.
+- **For OTP users, email is the username.** No change to the existing DC/OTP flow.
+- **Phone comes from claims, not DB.** For OIDC users, the phone claim from the IdP is passed through to the JWT. No phone storage in the Users table for OIDC users.
+
+---
+
+## File Structure
+
+### New files
+- `src/SEBT.Portal.Infrastructure/Migrations/{timestamp}_AddExternalProviderIdToUsers.cs` — EF migration
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs` | Add `ExternalProviderId`, make `Email` nullable |
+| `src/SEBT.Portal.Core/Models/Auth/User.cs` | Add `ExternalProviderId`, make `Email` nullable |
+| `src/SEBT.Portal.Infrastructure/Data/PortalDbContext.cs` | Configure `ExternalProviderId` column + unique filtered index |
+| `src/SEBT.Portal.Core/Repositories/IUserRepository.cs` | Add `GetOrCreateUserByExternalIdAsync` |
+| `src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs` | Implement new method |
+| `src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs` | Use `sub` for lookup, stop persisting IAL/email to DB |
+| `src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs` | Allow additionalClaims to provide email/sub, make IAL source configurable |
+| `src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs` | For OIDC users, populate user fields from JWT claims |
+| `src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs` | May need ExternalProviderId field for lookup |
+| `src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs` | Extract ExternalProviderId for refresh lookup |
+| `src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs` | Handle nullable Email |
+| `test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs` | Update for new lookup method |
+| `test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs` | Add OIDC user tests |
+| `test/SEBT.Portal.Tests/Unit/Services/JwtTokenServiceTests.cs` | Test claims-based email/IAL override |
+| `test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs` | Test ExternalProviderId lookup |
+
+---
+
+## Task 1: Add ExternalProviderId to Domain Model and Entity
+
+**Files:**
+- Modify: `src/SEBT.Portal.Core/Models/Auth/User.cs`
+- Modify: `src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs`
+
+- [ ] **Step 1: Add ExternalProviderId to User domain model**
+
+```csharp
+// In src/SEBT.Portal.Core/Models/Auth/User.cs, add after the Email property:
+
+/// <summary>
+/// The subject identifier from the external identity provider (e.g., PingOne sub claim).
+/// Set for OIDC users; null for OTP-authenticated users.
+/// </summary>
+public string? ExternalProviderId { get; set; }
+```
+
+Also make `Email` nullable to support OIDC users who don't store email:
+
+```csharp
+// Change:
+public string Email { get; set; } = string.Empty;
+// To:
+public string? Email { get; set; }
+```
+
+- [ ] **Step 2: Add ExternalProviderId to UserEntity**
+
+```csharp
+// In src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs, add after Email:
+
+/// <summary>
+/// The subject identifier from the external identity provider (e.g., PingOne sub claim).
+/// Null for OTP-authenticated users.
+/// </summary>
+public string? ExternalProviderId { get; set; }
+```
+
+Make Email nullable:
+
+```csharp
+// Change:
+public string Email { get; set; } = string.Empty;
+// To:
+public string? Email { get; set; }
+```
+
+- [ ] **Step 3: Verify the project compiles**
+
+Run: `dotnet build src/SEBT.Portal.Api/SEBT.Portal.Api.csproj`
+Expected: Compilation errors in places that assume Email is non-null. Note them — we'll fix in subsequent tasks.
+
+- [ ] **Step 4: Commit**
+
+```
+feat: add ExternalProviderId to User model, make Email nullable
+
+Supports OIDC users where the IdP subject claim is the identity anchor
+and email is carried only in JWT claims, not stored in the DB.
+```
+
+---
+
+## Task 2: Database Schema — Migration and DbContext Configuration
+
+**Files:**
+- Modify: `src/SEBT.Portal.Infrastructure/Data/PortalDbContext.cs`
+- Create: EF migration (auto-generated)
+
+- [ ] **Step 1: Update PortalDbContext model configuration**
+
+In `PortalDbContext.OnModelCreating`, update the `UserEntity` configuration:
+
+```csharp
+// Change Email from required to optional:
+entity.Property(e => e.Email)
+    .HasMaxLength(255);
+// (Remove .IsRequired() — Email is now nullable for OIDC users)
+
+// Keep the existing unique index but make it filtered (only for non-null emails):
+entity.HasIndex(e => e.Email)
+    .IsUnique()
+    .HasDatabaseName("IX_Users_Email")
+    .HasFilter("[Email] IS NOT NULL");
+
+// Add ExternalProviderId configuration:
+entity.Property(e => e.ExternalProviderId)
+    .HasMaxLength(255);
+entity.HasIndex(e => e.ExternalProviderId)
+    .IsUnique()
+    .HasDatabaseName("IX_Users_ExternalProviderId")
+    .HasFilter("[ExternalProviderId] IS NOT NULL");
+```
+
+- [ ] **Step 2: Generate the EF migration**
+
+Run:
+```bash
+dotnet ef migrations add AddExternalProviderIdToUsers \
+  --project src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj \
+  --startup-project src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
+```
+
+Expected: Migration file created in `src/SEBT.Portal.Infrastructure/Migrations/`.
+
+- [ ] **Step 3: Review the generated migration**
+
+Verify it:
+- Adds `ExternalProviderId` column (nullable, max 255)
+- Creates filtered unique index `IX_Users_ExternalProviderId`
+- Alters `Email` to be nullable
+- Updates the `IX_Users_Email` index with the filter
+
+- [ ] **Step 4: Verify migration applies cleanly**
+
+Run:
+```bash
+docker compose up -d mssql
+dotnet ef database update \
+  --project src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj \
+  --startup-project src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
+```
+
+Expected: Migration applied successfully.
+
+- [ ] **Step 5: Commit**
+
+```
+feat: add ExternalProviderId column and make Email nullable
+
+EF migration adds ExternalProviderId with filtered unique index,
+makes Email nullable with filtered unique index for OIDC user support.
+```
+
+---
+
+## Task 3: Repository — ExternalProviderId Lookup with Email Migration
+
+**Files:**
+- Modify: `src/SEBT.Portal.Core/Repositories/IUserRepository.cs`
+- Modify: `src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs`
+- Test: `test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs` (or integration test)
+
+The key design here: `GetOrCreateUserByExternalIdAsync` accepts an optional `email` parameter. If no user is found by `externalProviderId`, it falls back to an email-based lookup and **adopts** that record by setting its `ExternalProviderId`. This migrates pre-existing email-only users to the new identity model on their next login.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+// In a new or existing repository test file:
+
+[Fact]
+public async Task GetOrCreateUserByExternalIdAsync_WhenUserDoesNotExist_CreatesMinimalRecord()
+{
+    var externalId = "pingone-sub-12345";
+
+    var (user, isNew) = await repository.GetOrCreateUserByExternalIdAsync(externalId);
+
+    Assert.True(isNew);
+    Assert.Equal(externalId, user.ExternalProviderId);
+    Assert.Null(user.Email);
+    Assert.Equal(UserIalLevel.None, user.IalLevel);
+    Assert.True(user.Id > 0);
+}
+
+[Fact]
+public async Task GetOrCreateUserByExternalIdAsync_WhenUserExists_ReturnsExisting()
+{
+    var externalId = "pingone-sub-12345";
+    await repository.GetOrCreateUserByExternalIdAsync(externalId);
+
+    var (user, isNew) = await repository.GetOrCreateUserByExternalIdAsync(externalId);
+
+    Assert.False(isNew);
+    Assert.Equal(externalId, user.ExternalProviderId);
+}
+
+[Fact]
+public async Task GetOrCreateUserByExternalIdAsync_WhenLegacyEmailUserExists_AdoptsRecord()
+{
+    // Pre-existing user created by the old email-based flow (no ExternalProviderId)
+    var legacyUser = new User { Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
+    await repository.CreateUserAsync(legacyUser);
+
+    var externalId = "pingone-sub-12345";
+    var (user, isNew) = await repository.GetOrCreateUserByExternalIdAsync(
+        externalId, email: "user@example.com");
+
+    // Should adopt the existing record, not create a new one
+    Assert.False(isNew);
+    Assert.Equal(externalId, user.ExternalProviderId);
+    Assert.Null(user.Email); // email cleared — OIDC users derive it from IdP claims
+    Assert.Equal(legacyUser.Id, user.Id); // same DB record
+}
+
+[Fact]
+public async Task GetOrCreateUserByExternalIdAsync_WhenNoEmailProvided_DoesNotFallBackToEmail()
+{
+    // Pre-existing email user, but no email hint provided
+    var legacyUser = new User { Email = "user@example.com" };
+    await repository.CreateUserAsync(legacyUser);
+
+    var externalId = "pingone-sub-12345";
+    var (user, isNew) = await repository.GetOrCreateUserByExternalIdAsync(externalId);
+
+    // Should create a new record, not find the legacy one
+    Assert.True(isNew);
+    Assert.NotEqual(legacyUser.Id, user.Id);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetOrCreateUserByExternalIdAsync"`
+Expected: Compilation error — method doesn't exist yet.
+
+- [ ] **Step 3: Add interface methods**
+
+```csharp
+// In IUserRepository.cs, add:
+
+/// <summary>
+/// Gets or creates a user by their external identity provider subject ID.
+/// Used for OIDC-authenticated users whose identity is anchored by the IdP's sub claim.
+/// Creates a minimal record (no email, no IAL) — those attributes come from IdP claims.
+///
+/// When <paramref name="email"/> is provided and no user exists for the given
+/// <paramref name="externalProviderId"/>, falls back to an email-based lookup and
+/// adopts that record by setting its ExternalProviderId. This migrates pre-existing
+/// email-only user records to the new sub-based identity model.
+/// TODO: Remove email fallback migration once all existing users have logged in
+/// under the new flow.
+/// </summary>
+Task<(User user, bool isNewUser)> GetOrCreateUserByExternalIdAsync(
+    string externalProviderId,
+    string? email = null,
+    CancellationToken cancellationToken = default);
+
+/// <summary>
+/// Retrieves a user by their external identity provider subject ID.
+/// </summary>
+Task<User?> GetUserByExternalIdAsync(
+    string externalProviderId, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 4: Implement in DatabaseUserRepository**
+
+```csharp
+public async Task<User?> GetUserByExternalIdAsync(
+    string externalProviderId, CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(externalProviderId))
+    {
+        return null;
+    }
+
+    var entity = await dbContext.Users
+        .AsNoTracking()
+        .FirstOrDefaultAsync(u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+    return entity == null ? null : MapToDomainModel(entity);
+}
+
+public async Task<(User user, bool isNewUser)> GetOrCreateUserByExternalIdAsync(
+    string externalProviderId,
+    string? email = null,
+    CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(externalProviderId))
+    {
+        throw new ArgumentException(
+            "External provider ID cannot be null or empty.", nameof(externalProviderId));
+    }
+
+    // Primary lookup: by ExternalProviderId (the steady-state path)
+    var entity = await dbContext.Users
+        .FirstOrDefaultAsync(u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+    if (entity != null)
+    {
+        return (MapToDomainModel(entity), false);
+    }
+
+    // Migration fallback: if an email hint is provided, check for a legacy
+    // email-only record and adopt it by setting ExternalProviderId.
+    // TODO: Remove this fallback once all existing users have logged in
+    // under the new sub-based identity flow.
+    if (!string.IsNullOrWhiteSpace(email))
+    {
+        var normalizedEmail = NormalizeEmail(email);
+        var legacyEntity = await dbContext.Users
+            .FirstOrDefaultAsync(
+                u => u.Email == normalizedEmail && u.ExternalProviderId == null,
+                cancellationToken);
+
+        if (legacyEntity != null)
+        {
+            legacyEntity.ExternalProviderId = externalProviderId;
+            legacyEntity.Email = null; // OIDC users derive email from IdP claims, not DB
+            legacyEntity.UpdatedAt = DateTime.UtcNow;
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return (MapToDomainModel(legacyEntity), false);
+        }
+    }
+
+    // No existing record found — create a new minimal one
+    var newEntity = new UserEntity
+    {
+        ExternalProviderId = externalProviderId,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow
+    };
+
+    dbContext.Users.Add(newEntity);
+
+    try
+    {
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+    catch (DbUpdateException ex)
+    {
+        if (ex.InnerException?.Message.Contains("UNIQUE") == true ||
+            ex.InnerException?.Message.Contains("duplicate key") == true)
+        {
+            entity = await dbContext.Users
+                .FirstOrDefaultAsync(
+                    u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+            if (entity != null)
+            {
+                return (MapToDomainModel(entity), false);
+            }
+        }
+        throw;
+    }
+
+    return (MapToDomainModel(newEntity), true);
+}
+```
+
+- [ ] **Step 5: Update MapToDomainModel and MapToEntity**
+
+Add `ExternalProviderId` to both mapping methods in `DatabaseUserRepository`:
+
+```csharp
+// In MapToDomainModel:
+ExternalProviderId = entity.ExternalProviderId,
+
+// In MapToEntity:
+ExternalProviderId = user.ExternalProviderId,
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~GetOrCreateUserByExternalIdAsync"`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```
+feat: add ExternalProviderId user lookup with email migration fallback
+
+OIDC users are looked up by IdP sub claim (ExternalProviderId).
+When no match exists but a legacy email-only record does, the record
+is adopted by setting ExternalProviderId — migrating it in-flight.
+The email fallback is marked for removal in a future release.
+```
+
+---
+
+## Task 4: JwtTokenService — Claims-Based Email and IAL
+
+This is the core bug fix. `GenerateToken` currently hard-codes email from `user.Email` and IAL from `user.IalLevel`. For OIDC users, these need to come from `additionalClaims`.
+
+**Files:**
+- Modify: `src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs`
+- Test: `test/SEBT.Portal.Tests/Unit/Services/JwtTokenServiceTests.cs`
+
+- [ ] **Step 1: Write failing test — additionalClaims email overrides user.Email**
+
+```csharp
+[Fact]
+public void GenerateToken_WhenAdditionalClaimsContainEmail_UsesClaimsEmail()
+{
+    var user = new User { Id = 1, Email = null }; // OIDC user, no stored email
+    var claims = new Dictionary<string, string>
+    {
+        ["email"] = "oidc-user@example.com",
+        ["sub"] = "pingone-sub-123"
+    };
+
+    var token = _service.GenerateToken(user, claims);
+
+    var handler = new JwtSecurityTokenHandler();
+    var jwt = handler.ReadJwtToken(token);
+    var emailClaim = jwt.Claims.First(c => c.Type == "email");
+    Assert.Equal("oidc-user@example.com", emailClaim.Value);
+}
+```
+
+- [ ] **Step 2: Write failing test — additionalClaims IAL overrides user.IalLevel**
+
+```csharp
+[Fact]
+public void GenerateToken_WhenAdditionalClaimsContainIal_UsesClaimsIal()
+{
+    var user = new User { Id = 1, IalLevel = UserIalLevel.None }; // OIDC user, no stored IAL
+    var claims = new Dictionary<string, string>
+    {
+        ["email"] = "user@example.com",
+        [JwtClaimTypes.Ial] = "1plus"
+    };
+
+    var token = _service.GenerateToken(user, claims);
+
+    var handler = new JwtSecurityTokenHandler();
+    var jwt = handler.ReadJwtToken(token);
+    var ialClaim = jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial);
+    Assert.Equal("1plus", ialClaim.Value);
+}
+```
+
+- [ ] **Step 3: Write test — OTP user still uses user object values (no additionalClaims)**
+
+```csharp
+[Fact]
+public void GenerateToken_WhenNoAdditionalClaims_UsesUserProperties()
+{
+    var user = new User
+    {
+        Id = 1,
+        Email = "otp-user@example.com",
+        IalLevel = UserIalLevel.IAL1plus
+    };
+
+    var token = _service.GenerateToken(user);
+
+    var handler = new JwtSecurityTokenHandler();
+    var jwt = handler.ReadJwtToken(token);
+    Assert.Equal("otp-user@example.com", jwt.Claims.First(c => c.Type == "email").Value);
+    Assert.Equal("1plus", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~JwtTokenServiceTests"`
+Expected: First two tests FAIL (email and IAL still come from user object, ignoring claims).
+
+- [ ] **Step 5: Refactor GenerateToken to prefer additionalClaims**
+
+The key change: derive email, sub, IAL, and IdProofing claims from additionalClaims when available, falling back to user properties.
+
+```csharp
+public string GenerateToken(User user, IReadOnlyDictionary<string, string>? additionalClaims = null)
+{
+    var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.SecretKey));
+    var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+    var now = DateTimeOffset.UtcNow;
+    var unixTimeSeconds = now.ToUnixTimeSeconds();
+
+    // For OIDC users, email and sub come from IdP claims (via additionalClaims).
+    // For OTP users, they come from user.Email (the DB value).
+    var email = additionalClaims?.GetValueOrDefault("email") ?? user.Email ?? "";
+    var sub = additionalClaims?.GetValueOrDefault("sub") ?? email;
+
+    // For OIDC users, IAL comes from IdP claims carried in additionalClaims.
+    // For OTP users, it comes from user.IalLevel (the DB value).
+    var ialValue = additionalClaims?.GetValueOrDefault(JwtClaimTypes.Ial)
+        ?? user.IalLevel switch
+        {
+            UserIalLevel.IAL1 => "1",
+            UserIalLevel.IAL1plus => "1plus",
+            UserIalLevel.IAL2 => "2",
+            _ => "0"
+        };
+
+    var idProofingStatusValue = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingStatus)
+        ?? ((int)user.IdProofingStatus).ToString();
+
+    var claims = new List<Claim>
+    {
+        new Claim(ClaimTypes.Email, email),
+        new Claim(JwtRegisteredClaimNames.Sub, sub),
+        new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+        new Claim(JwtRegisteredClaimNames.Iat, unixTimeSeconds.ToString(), ClaimValueTypes.Integer64),
+        new Claim(JwtRegisteredClaimNames.Nbf, unixTimeSeconds.ToString(), ClaimValueTypes.Integer64),
+        new Claim(JwtRegisteredClaimNames.Aud, "SEBT.Portal.Web"),
+        new Claim(JwtRegisteredClaimNames.Iss, "SEBT.Portal.Api"),
+        new Claim(JwtClaimTypes.IdProofingStatus, idProofingStatusValue, ClaimValueTypes.Integer32),
+        new Claim(JwtClaimTypes.Ial, ialValue)
+    };
+
+    // Add optional ID proofing claims — prefer additionalClaims, fall back to user properties
+    var sessionId = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingSessionId)
+        ?? user.IdProofingSessionId;
+    if (!string.IsNullOrWhiteSpace(sessionId))
+    {
+        claims.Add(new Claim(JwtClaimTypes.IdProofingSessionId, sessionId));
+    }
+
+    var completedAtStr = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingCompletedAt);
+    if (completedAtStr != null)
+    {
+        claims.Add(new Claim(JwtClaimTypes.IdProofingCompletedAt, completedAtStr, ClaimValueTypes.Integer64));
+    }
+    else if (user.IdProofingCompletedAt.HasValue)
+    {
+        var completedAtOffset = new DateTimeOffset(user.IdProofingCompletedAt.Value, TimeSpan.Zero);
+        claims.Add(new Claim(JwtClaimTypes.IdProofingCompletedAt,
+            completedAtOffset.ToUnixTimeSeconds().ToString(),
+            ClaimValueTypes.Integer64));
+    }
+
+    // Compute expiration from completedAt + validity, regardless of source
+    var expiresAtStr = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingExpiresAt);
+    if (expiresAtStr != null)
+    {
+        claims.Add(new Claim(JwtClaimTypes.IdProofingExpiresAt, expiresAtStr, ClaimValueTypes.Integer64));
+    }
+    else if (user.IdProofingCompletedAt.HasValue)
+    {
+        var expiresAt = user.IdProofingCompletedAt.Value.AddDays(_validitySettings.ValidityDays);
+        var expiresAtOffset = new DateTimeOffset(expiresAt, TimeSpan.Zero);
+        claims.Add(new Claim(JwtClaimTypes.IdProofingExpiresAt,
+            expiresAtOffset.ToUnixTimeSeconds().ToString(),
+            ClaimValueTypes.Integer64));
+    }
+
+    // Add remaining additionalClaims that weren't already set above
+    var reservedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        JwtRegisteredClaimNames.Sub,
+        ClaimTypes.Email,
+        JwtRegisteredClaimNames.Email,
+        "email",
+        JwtRegisteredClaimNames.Jti,
+        JwtRegisteredClaimNames.Iat,
+        JwtRegisteredClaimNames.Nbf,
+        JwtRegisteredClaimNames.Aud,
+        JwtRegisteredClaimNames.Iss,
+        JwtClaimTypes.Ial,
+        JwtClaimTypes.IdProofingStatus,
+        JwtClaimTypes.IdProofingSessionId,
+        JwtClaimTypes.IdProofingCompletedAt,
+        JwtClaimTypes.IdProofingExpiresAt,
+    };
+
+    if (additionalClaims != null)
+    {
+        foreach (var (name, value) in additionalClaims)
+        {
+            if (!string.IsNullOrEmpty(name) &&
+                value != null &&
+                !reservedNames.Contains(name) &&
+                !claims.Select(c => c.Type).Contains(name))
+            {
+                claims.Add(new Claim(name, value));
+            }
+        }
+    }
+
+    var token = new JwtSecurityToken(
+        issuer: _settings.Issuer,
+        audience: _settings.Audience,
+        claims: claims,
+        expires: DateTime.UtcNow.AddMinutes(_settings.ExpirationMinutes),
+        signingCredentials: credentials
+    );
+
+    return new JwtSecurityTokenHandler().WriteToken(token);
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~JwtTokenServiceTests"`
+Expected: All PASS
+
+- [ ] **Step 7: Commit**
+
+```
+fix: JwtTokenService prefers additionalClaims over DB for email/IAL
+
+For OIDC users, email and IAL come from IdP claims (passed via
+additionalClaims). For OTP users, the user object (DB) values are
+used as before. This is the core fix for stale IAL on OIDC logins.
+```
+
+---
+
+## Task 5: OidcController.CompleteLogin — Use ExternalProviderId, Stop Persisting IAL
+
+**Files:**
+- Modify: `src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs`
+- Test: `test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs`
+
+- [ ] **Step 1: Write failing test — CompleteLogin looks up by sub, passes email for migration**
+
+```csharp
+[Fact]
+public async Task CompleteLogin_WhenValidOidcLogin_LooksUpUserByExternalProviderId()
+{
+    SetupPreAuthSession();
+    const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+    _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+    var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+        new Claim("email", "user@example.com"),
+        new Claim("sub", "pingone-sub-12345"));
+    var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+    var user = new User { Id = 1, ExternalProviderId = "pingone-sub-12345" };
+    _userRepository.GetOrCreateUserByExternalIdAsync(
+            "pingone-sub-12345", "user@example.com", Arg.Any<CancellationToken>())
+        .Returns((user, false));
+    _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+        .Returns("portal-jwt");
+
+    await _controller.CompleteLogin(body, CancellationToken.None);
+
+    // Should use ExternalProviderId lookup with email hint, NOT email-only lookup
+    await _userRepository.Received(1)
+        .GetOrCreateUserByExternalIdAsync(
+            "pingone-sub-12345", "user@example.com", Arg.Any<CancellationToken>());
+    await _userRepository.DidNotReceive()
+        .GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+}
+```
+
+- [ ] **Step 2: Write failing test — CompleteLogin does NOT persist IAL to DB**
+
+```csharp
+[Fact]
+public async Task CompleteLogin_WhenOidcVerificationPresent_DoesNotPersistIalToDb()
+{
+    const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+    _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+    var controller = CreateControllerWithTranslator();
+    SetupPreAuthSessionForController(controller);
+
+    var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+        new Claim("email", "user@example.com"),
+        new Claim("sub", "pingone-sub-12345"),
+        new Claim("socureIdVerificationLevel", "1.5"),
+        new Claim("socureIdVerificationDate", DateTime.UtcNow.AddDays(-30).ToString("o")));
+    var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+    var user = new User { Id = 1, ExternalProviderId = "pingone-sub-12345" };
+    _userRepository.GetOrCreateUserByExternalIdAsync(
+            "pingone-sub-12345", "user@example.com", Arg.Any<CancellationToken>())
+        .Returns((user, false));
+    _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+        .Returns("portal-jwt");
+
+    await controller.CompleteLogin(body, CancellationToken.None);
+
+    // IAL reconciliation should NOT trigger a DB update for OIDC users
+    await _userRepository.DidNotReceive()
+        .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+}
+```
+
+- [ ] **Step 3: Write test — IAL from verification claims is passed to GenerateToken via additionalClaims**
+
+```csharp
+[Fact]
+public async Task CompleteLogin_WhenOidcVerificationPresent_PassesIalInAdditionalClaims()
+{
+    const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+    _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+    var controller = CreateControllerWithTranslator();
+    SetupPreAuthSessionForController(controller);
+
+    var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+        new Claim("email", "user@example.com"),
+        new Claim("sub", "pingone-sub-12345"),
+        new Claim("socureIdVerificationLevel", "1.5"),
+        new Claim("socureIdVerificationDate", DateTime.UtcNow.AddDays(-30).ToString("o")));
+    var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+    var user = new User { Id = 1, ExternalProviderId = "pingone-sub-12345" };
+    _userRepository.GetOrCreateUserByExternalIdAsync(
+            "pingone-sub-12345", "user@example.com", Arg.Any<CancellationToken>())
+        .Returns((user, false));
+    _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+        .Returns("portal-jwt");
+
+    await controller.CompleteLogin(body, CancellationToken.None);
+
+    // Verify IAL was passed in additionalClaims to GenerateToken
+    _jwtService.Received(1).GenerateToken(
+        Arg.Any<User>(),
+        Arg.Is<IReadOnlyDictionary<string, string>>(c =>
+            c.ContainsKey(JwtClaimTypes.Ial) && c[JwtClaimTypes.Ial] == "1plus"));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `dotnet test --filter "FullyQualifiedName~OidcControllerTests"`
+Expected: New tests FAIL — controller still uses email-based lookup and persists IAL.
+
+- [ ] **Step 5: Refactor CompleteLogin non-step-up flow**
+
+In `OidcController.CompleteLogin`, replace the non-step-up block (lines 469-496) with:
+
+```csharp
+else
+{
+    // Extract the IdP subject claim — this is the OIDC user's identity anchor.
+    var subClaim = additionalClaims.GetValueOrDefault("sub");
+    if (string.IsNullOrWhiteSpace(subClaim))
+    {
+        logger.LogWarning(
+            "OIDC CompleteLogin: callback token missing sub claim (SessionId={SessionId})",
+            sessionId);
+        return BadRequest(new ErrorResponse("Callback token must contain a sub claim."));
+    }
+
+    // Pass email from IdP claims as a migration hint: if no user exists for
+    // this sub but one exists for this email, adopt that legacy record.
+    // TODO: Remove email parameter once all existing users have been migrated.
+    var emailHint = additionalClaims.GetValueOrDefault("email");
+    var (createdUser, _) = await userRepository.GetOrCreateUserByExternalIdAsync(
+        subClaim, emailHint, cancellationToken);
+    user = createdUser;
+
+    // Reconcile IAL from OIDC verification claims. The IdP is the source of truth —
+    // we derive IAL from claims and pass it through to the JWT, but do NOT persist
+    // it to the DB. The DB only stores the identity anchor (ExternalProviderId).
+    var verification = verificationClaimTranslator.Translate(additionalClaims);
+    if (verification != null)
+    {
+        // Set IAL in additionalClaims for JwtTokenService to pick up
+        additionalClaims[JwtClaimTypes.Ial] = verification.IalLevel switch
+        {
+            UserIalLevel.IAL1plus => "1plus",
+            UserIalLevel.IAL2 => "2",
+            UserIalLevel.IAL1 => "1",
+            _ => "0"
+        };
+        additionalClaims[JwtClaimTypes.IdProofingStatus] =
+            ((int)(verification.IsExpired ? IdProofingStatus.Expired : IdProofingStatus.Completed)).ToString();
+
+        if (verification.VerifiedAt != default)
+        {
+            var verifiedAtOffset = new DateTimeOffset(verification.VerifiedAt, TimeSpan.Zero);
+            additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
+                verifiedAtOffset.ToUnixTimeSeconds().ToString();
+        }
+
+        logger.LogInformation(
+            "OIDC verification claim reconciled: UserId {UserId}, IalLevel {IalLevel}, IsExpired {IsExpired}, VerifiedAt {VerifiedAt}, SessionId={SessionId}",
+            user.Id, verification.IalLevel, verification.IsExpired, verification.VerifiedAt, sessionId);
+    }
+    else
+    {
+        // No verification claims from IdP — user is IAL1 (authenticated but not verified)
+        additionalClaims[JwtClaimTypes.Ial] = "1";
+    }
+}
+```
+
+Note: `additionalClaims` needs to change from `var additionalClaims = new Dictionary<string, string>(...)` — it's already mutable. The IAL and IdProofing values are injected into the same dictionary that gets passed to `GenerateToken`.
+
+- [ ] **Step 6: Update the step-up flow too**
+
+The step-up flow also needs to use ExternalProviderId for lookup:
+
+```csharp
+if (session.IsStepUp)
+{
+    var subClaim = additionalClaims.GetValueOrDefault("sub");
+    if (string.IsNullOrWhiteSpace(subClaim))
+    {
+        logger.LogWarning("Step-up complete-login: missing sub claim (SessionId={SessionId})", sessionId);
+        return BadRequest(new ErrorResponse("Callback token must contain a sub claim."));
+    }
+
+    // Look up by ExternalProviderId for OIDC step-up
+    var existingEntity = await userRepository.GetUserByExternalIdAsync(subClaim, cancellationToken);
+    if (existingEntity == null)
+    {
+        logger.LogWarning(
+            "Step-up complete-login: no existing portal user for sub claim; sign-in required first (SessionId={SessionId}).",
+            sessionId);
+        return BadRequest(new { error = "Step-up requires an existing session. Please sign in again." });
+    }
+
+    user = existingEntity;
+
+    // Set step-up IAL in claims, not DB
+    additionalClaims[JwtClaimTypes.Ial] = "1plus";
+    additionalClaims[JwtClaimTypes.IdProofingStatus] = ((int)IdProofingStatus.Completed).ToString();
+    additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
+        new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+    logger.LogInformation(
+        "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel IAL1plus, SessionId={SessionId}",
+        user.Id, SanitizeForLog(stateKey), sessionId);
+}
+```
+
+Note: Step-up needs a new `GetUserByExternalIdAsync` (read-only) method added to the repository interface. Add it alongside `GetOrCreateUserByExternalIdAsync`.
+
+- [ ] **Step 7: Remove the GetEmailFromClaims usage for user lookup**
+
+The `GetEmailFromClaims` helper is still useful for extracting email for logging/claims, but it should no longer be used as the user identity for DB lookup. The `sub` claim is now used directly.
+
+- [ ] **Step 8: Run all tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~OidcControllerTests"`
+Expected: All PASS (update existing tests that assumed email-based lookup)
+
+- [ ] **Step 9: Commit**
+
+```
+fix: OidcController uses sub claim for user lookup, stops persisting IAL
+
+OIDC users are now looked up by ExternalProviderId (IdP sub claim).
+IAL is derived from IdP verification claims and passed through to
+the JWT via additionalClaims — never persisted to the DB.
+This fixes stale IAL on OIDC re-login and token refresh.
+```
+
+---
+
+## Task 6: RefreshTokenCommandHandler — OIDC-Aware Refresh
+
+**Files:**
+- Modify: `src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs`
+- Modify: `src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs`
+- Modify: `src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs`
+- Test: `test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs`
+
+- [ ] **Step 1: Write failing test — OIDC user refresh preserves JWT IAL, ignores DB**
+
+```csharp
+[Fact]
+public async Task Handle_WhenOidcUser_PreservesIalFromExistingJwtClaims()
+{
+    var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+    {
+        new Claim("email", "user@example.com"),
+        new Claim("sub", "pingone-sub-12345"),
+        new Claim(JwtClaimTypes.Ial, "1plus"),
+        new Claim(JwtClaimTypes.IdProofingStatus, "2"), // Completed
+    }));
+
+    var command = new RefreshTokenCommand
+    {
+        Email = "user@example.com",
+        ExternalProviderId = "pingone-sub-12345",
+        CurrentPrincipal = principal
+    };
+
+    // OIDC user has no IAL stored in DB
+    var user = new User
+    {
+        Id = 1,
+        ExternalProviderId = "pingone-sub-12345",
+        IalLevel = UserIalLevel.None
+    };
+
+    userRepository.GetUserByExternalIdAsync("pingone-sub-12345", Arg.Any<CancellationToken>())
+        .Returns(user);
+    jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+        .Returns("refreshed-jwt");
+
+    var result = await handler.Handle(command);
+
+    Assert.True(result.IsSuccess);
+    // Verify that IAL from JWT claims (1plus) was passed through, not DB (None)
+    jwtTokenService.Received(1).GenerateToken(
+        Arg.Any<User>(),
+        Arg.Is<IReadOnlyDictionary<string, string>>(c =>
+            c.ContainsKey(JwtClaimTypes.Ial) && c[JwtClaimTypes.Ial] == "1plus"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test --filter "FullyQualifiedName~Handle_WhenOidcUser_PreservesIalFromExistingJwtClaims"`
+Expected: FAIL — ExternalProviderId doesn't exist on RefreshTokenCommand yet.
+
+- [ ] **Step 3: Add ExternalProviderId to RefreshTokenCommand**
+
+```csharp
+// In RefreshTokenCommand.cs, add:
+
+/// <summary>
+/// The external provider ID (IdP sub claim) for OIDC users. Null for OTP users.
+/// When present, the handler looks up the user by ExternalProviderId instead of email
+/// and preserves IAL from JWT claims instead of reading from DB.
+/// </summary>
+public string? ExternalProviderId { get; set; }
+```
+
+- [ ] **Step 4: Update AuthController.RefreshToken to extract ExternalProviderId**
+
+```csharp
+// In AuthController.RefreshToken, update the command construction:
+var externalProviderId = User.FindFirst("sub")?.Value;
+// If the JWT sub differs from the email, it's an OIDC user whose sub is the IdP subject
+var email = GetUserEmail();
+var isOidcUser = externalProviderId != null && externalProviderId != email;
+
+var command = new RefreshTokenCommand
+{
+    Email = email,
+    ExternalProviderId = isOidcUser ? externalProviderId : null,
+    CurrentPrincipal = User
+};
+```
+
+- [ ] **Step 5: Update RefreshTokenCommandHandler for OIDC users**
+
+```csharp
+public async Task<Result<string>> Handle(RefreshTokenCommand command, CancellationToken cancellationToken = default)
+{
+    var validationResult = await validator.Validate(command, cancellationToken);
+    if (validationResult is ValidationFailedResult validationFailedResult)
+    {
+        logger.LogWarning("Token refresh validation failed: {Errors}",
+            string.Join(", ", validationFailedResult.Errors.Select(e => $"{e.Key}: {e.Message}")));
+        return Result<string>.ValidationFailed(validationFailedResult.Errors);
+    }
+
+    try
+    {
+        User? user;
+        if (!string.IsNullOrEmpty(command.ExternalProviderId))
+        {
+            // OIDC user — look up by IdP subject, not email
+            user = await userRepository.GetUserByExternalIdAsync(
+                command.ExternalProviderId, cancellationToken);
+        }
+        else
+        {
+            // OTP user — look up by email (existing behavior)
+            user = await userRepository.GetUserByEmailAsync(command.Email, cancellationToken);
+        }
+
+        if (user == null)
+        {
+            logger.LogWarning("Token refresh attempted for non-existent user");
+            return Result<string>.PreconditionFailed(
+                PreconditionFailedReason.NotFound, "User not found.");
+        }
+
+        // Pass all existing JWT claims through — for OIDC users, this preserves
+        // IAL and other IdP-derived claims. For OTP users, GenerateToken will
+        // prefer user object values (from DB) over these claims.
+        var additionalClaims = command.CurrentPrincipal.Claims
+            .DistinctBy(c => c.Type)
+            .ToDictionary(c => c.Type, c => c.Value);
+        var token = jwtTokenService.GenerateToken(user, additionalClaims);
+
+        var maskedPhone = PiiMasker.MaskPhone(
+            command.CurrentPrincipal.FindFirst("phone")?.Value
+            ?? command.CurrentPrincipal.FindFirst("phone_number")?.Value);
+        logger.LogInformation(
+            "Token refreshed successfully for UserId {UserId}, Phone={MaskedPhone}",
+            user.Id, maskedPhone);
+
+        return Result<string>.Success(token);
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Error refreshing token");
+        return Result<string>.DependencyFailed(
+            DependencyFailedReason.ConnectionFailed,
+            "An error occurred while refreshing the authentication token.");
+    }
+}
+```
+
+- [ ] **Step 6: Add GetUserByExternalIdAsync to IUserRepository**
+
+```csharp
+/// <summary>
+/// Retrieves a user by their external identity provider subject ID.
+/// </summary>
+Task<User?> GetUserByExternalIdAsync(string externalProviderId, CancellationToken cancellationToken = default);
+```
+
+- [ ] **Step 7: Implement GetUserByExternalIdAsync in DatabaseUserRepository**
+
+```csharp
+public async Task<User?> GetUserByExternalIdAsync(
+    string externalProviderId, CancellationToken cancellationToken = default)
+{
+    if (string.IsNullOrWhiteSpace(externalProviderId))
+    {
+        return null;
+    }
+
+    var entity = await dbContext.Users
+        .AsNoTracking()
+        .FirstOrDefaultAsync(u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+    return entity == null ? null : MapToDomainModel(entity);
+}
+```
+
+- [ ] **Step 8: Run all refresh tests**
+
+Run: `dotnet test --filter "FullyQualifiedName~RefreshTokenCommandHandlerTests"`
+Expected: All PASS (including new OIDC test and existing OTP tests)
+
+- [ ] **Step 9: Commit**
+
+```
+fix: token refresh for OIDC users preserves IAL from JWT claims
+
+OIDC users are looked up by ExternalProviderId during refresh.
+IAL and other IdP-derived claims are passed through from the
+existing JWT, preventing stale DB values from overriding them.
+```
+
+---
+
+## Task 7: Fix Compilation Errors from Nullable Email
+
+Making `User.Email` nullable will cause compilation errors across the codebase wherever it's assumed non-null. Fix each caller.
+
+**Files:**
+- Modify: Multiple files (compiler will tell us which)
+
+- [ ] **Step 1: Build and catalog all nullable warnings/errors**
+
+Run: `dotnet build src/SEBT.Portal.Api/SEBT.Portal.Api.csproj 2>&1 | grep -i "CS8"` (nullable warnings)
+
+Fix each one:
+- `DatabaseUserRepository.UpdateUserAsync` — guard against null email (only validate for OTP users)
+- `DatabaseUserRepository.GetOrCreateUserAsync` — still requires email (OTP path)
+- `DataSeeder.MapToEntity` — handle nullable email
+- `ValidateOtpCommandHandler` — OTP path always has email, assert non-null
+- Any other callers
+
+- [ ] **Step 2: Fix each file**
+
+Handle case-by-case. The pattern is:
+- OTP code paths: `Email` is always non-null (validated at entry)
+- OIDC code paths: `Email` may be null (comes from claims, not DB)
+- Use null-forgiving (`!`) only when the caller has already validated
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `dotnet test`
+Expected: All existing tests PASS, no nullable reference warnings in the error output.
+
+- [ ] **Step 4: Commit**
+
+```
+fix: handle nullable User.Email across codebase
+
+OTP code paths validate email at entry. OIDC paths derive email
+from IdP claims. Updated all callers to handle the nullable change.
+```
+
+---
+
+## Task 8: Update Existing Tests
+
+Existing tests for OidcController and RefreshTokenCommandHandler make assumptions that will break. Update them.
+
+**Files:**
+- Modify: `test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs`
+- Modify: `test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs`
+
+- [ ] **Step 1: Update OidcControllerTests**
+
+Key changes:
+- Tests that call `_userRepository.GetOrCreateUserAsync` need to mock `GetOrCreateUserByExternalIdAsync` instead
+- Tests need to include `sub` claim in callback tokens
+- Verification claim tests should verify IAL goes into additionalClaims, not into UpdateUserAsync
+- Step-up tests need to use `GetUserByExternalIdAsync` instead of `GetUserByEmailAsync`
+
+- [ ] **Step 2: Update RefreshTokenCommandHandlerTests**
+
+Key changes:
+- Existing tests become "OTP user" tests (no ExternalProviderId)
+- Add parallel "OIDC user" tests for each scenario
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pnpm api:test`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```
+test: update auth tests for ExternalProviderId-based OIDC lookup
+
+Existing tests now cover OTP path explicitly. New tests cover
+OIDC path with ExternalProviderId lookup and claims-based IAL.
+```
+
+---
+
+## Task 9: Final Verification
+
+- [ ] **Step 1: Run full backend test suite**
+
+Run: `pnpm api:test`
+Expected: All PASS
+
+- [ ] **Step 2: Run frontend tests**
+
+Run: `cd src/SEBT.Portal.Web && pnpm test`
+Expected: All PASS (frontend reads IAL from JWT claims via the status endpoint — no changes needed)
+
+- [ ] **Step 3: Run lint**
+
+Run: `cd src/SEBT.Portal.Web && pnpm lint`
+Expected: Clean
+
+- [ ] **Step 4: Manual smoke test (if local env available)**
+
+1. Start the stack: `docker compose up -d && pnpm dev`
+2. Log in via CO OIDC → verify JWT contains correct IAL from IdP
+3. Refresh the page (triggers token refresh) → verify IAL is preserved
+4. Log in via DC OTP → verify existing flow still works
+5. Check the Users table → CO user should have ExternalProviderId, no email; DC user should have email, no ExternalProviderId
+
+- [ ] **Step 5: Commit any remaining fixes**

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -40,7 +40,7 @@ public class AuthController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public IActionResult GetAuthorizationStatus()
     {
-        var userId = GetUserId();
+        var userId = User.GetUserId();
 
         logger.LogInformation("Authorization status check successful for UserId {UserId}, Phone={MaskedPhone}",
             userId?.ToString() ?? "unknown", GetMaskedPhone());
@@ -88,7 +88,7 @@ public class AuthController(
     public async Task<IActionResult> RefreshToken(
         [FromServices] ICommandHandler<RefreshTokenCommand, string> handler)
     {
-        var userId = GetUserId();
+        var userId = User.GetUserId();
 
         if (userId == null)
         {
@@ -133,16 +133,6 @@ public class AuthController(
 
             return BadRequest(new ErrorResponse(result.Message));
         }
-    }
-
-    /// <summary>
-    /// Extracts the portal's internal user ID from the authenticated JWT's sub claim.
-    /// Returns null if the sub claim is missing or not a positive integer.
-    /// </summary>
-    private int? GetUserId()
-    {
-        var subValue = User.FindFirst("sub")?.Value;
-        return int.TryParse(subValue, out var id) && id > 0 ? id : null;
     }
 
     /// <summary>

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -40,14 +40,14 @@ public class AuthController(
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public IActionResult GetAuthorizationStatus()
     {
-        var email = GetUserEmail();
+        var userId = GetUserId();
 
-        logger.LogInformation("Authorization status check successful for user {Email}, Phone={MaskedPhone}",
-            email ?? "unknown", GetMaskedPhone());
+        logger.LogInformation("Authorization status check successful for UserId {UserId}, Phone={MaskedPhone}",
+            userId?.ToString() ?? "unknown", GetMaskedPhone());
 
         return Ok(new AuthorizationStatusResponse(
             IsAuthorized: true,
-            Email: email,
+            Email: GetUserEmail(),
             Ial: User.FindFirst(JwtClaimTypes.Ial)?.Value,
             IdProofingStatus: int.TryParse(User.FindFirst(JwtClaimTypes.IdProofingStatus)?.Value, out var s) ? s : null,
             IdProofingCompletedAt: long.TryParse(User.FindFirst(JwtClaimTypes.IdProofingCompletedAt)?.Value, out var c) ? c : null,
@@ -88,40 +88,35 @@ public class AuthController(
     public async Task<IActionResult> RefreshToken(
         [FromServices] ICommandHandler<RefreshTokenCommand, string> handler)
     {
-        var email = GetUserEmail();
+        var userId = GetUserId();
 
-        if (string.IsNullOrWhiteSpace(email))
+        if (userId == null)
         {
-            logger.LogWarning("Token refresh attempted but email could not be extracted from claims");
+            logger.LogWarning("Token refresh attempted but user ID could not be extracted from claims");
             return Unauthorized(new ErrorResponse("Unable to identify user from token."));
         }
 
-        logger.LogInformation("Token refresh request received for email {Email}, Phone={MaskedPhone}",
-            email, GetMaskedPhone());
-
-        var externalProviderId = User.FindFirst("sub")?.Value;
-        // If the JWT sub differs from the email, it's an OIDC user whose sub is the IdP subject
-        var isOidcUser = externalProviderId != null && externalProviderId != email;
+        logger.LogInformation("Token refresh request received for UserId {UserId}, Phone={MaskedPhone}",
+            userId, GetMaskedPhone());
 
         var command = new RefreshTokenCommand
         {
-            Email = email,
-            ExternalProviderId = isOidcUser ? externalProviderId : null,
+            UserId = userId.Value,
             CurrentPrincipal = User
         };
         var result = await handler.Handle(command);
 
         if (result.IsSuccess)
         {
-            logger.LogInformation("Token refreshed successfully for email {Email}, Phone={MaskedPhone}",
-                email, GetMaskedPhone());
+            logger.LogInformation("Token refreshed successfully for UserId {UserId}, Phone={MaskedPhone}",
+                userId, GetMaskedPhone());
             var expiresAt = DateTimeOffset.UtcNow.AddMinutes(jwtSettingsOptions.Value.ExpirationMinutes);
             AuthCookies.SetAuthCookie(Response, result.Value, expiresAt);
             return NoContent();
         }
         else
         {
-            logger.LogWarning("Token refresh failed for email {Email}: {Message}", email, result.Message);
+            logger.LogWarning("Token refresh failed for UserId {UserId}: {Message}", userId, result.Message);
 
             if (result is ValidationFailedResult<string> validationFailed)
             {
@@ -141,18 +136,23 @@ public class AuthController(
     }
 
     /// <summary>
-    /// Extracts the user's email address from the authenticated user's claims.
-    /// Tries both long (.NET) and short (JWT) claim names so it works whether or not
-    /// the JWT handler has mapped inbound claims.
+    /// Extracts the portal's internal user ID from the authenticated JWT's sub claim.
+    /// Returns null if the sub claim is missing or not a positive integer.
     /// </summary>
-    /// <returns>The user's email address, or null if not found.</returns>
+    private int? GetUserId()
+    {
+        var subValue = User.FindFirst("sub")?.Value;
+        return int.TryParse(subValue, out var id) && id > 0 ? id : null;
+    }
+
+    /// <summary>
+    /// Extracts the user's email address from the authenticated user's JWT claims.
+    /// Returns null when absent (e.g. OIDC users whose IdP didn't include an email claim).
+    /// </summary>
     private string? GetUserEmail()
     {
         return User.FindFirst(ClaimTypes.Email)?.Value
-            ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? User.FindFirst("email")?.Value
-            ?? User.FindFirst("sub")?.Value
-            ?? User.Identity?.Name;
+            ?? User.FindFirst("email")?.Value;
     }
 
     /// <summary>
@@ -165,4 +165,3 @@ public class AuthController(
         return PiiMasker.MaskPhone(phone);
     }
 }
-

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -100,7 +100,6 @@ public class AuthController(
 
         var command = new RefreshTokenCommand
         {
-            UserId = userId.Value,
             CurrentPrincipal = User
         };
         var result = await handler.Handle(command);

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -47,7 +46,7 @@ public class AuthController(
 
         return Ok(new AuthorizationStatusResponse(
             IsAuthorized: true,
-            Email: GetUserEmail(),
+            Email: User.GetUserEmail(),
             Ial: User.FindFirst(JwtClaimTypes.Ial)?.Value,
             IdProofingStatus: int.TryParse(User.FindFirst(JwtClaimTypes.IdProofingStatus)?.Value, out var s) ? s : null,
             IdProofingCompletedAt: long.TryParse(User.FindFirst(JwtClaimTypes.IdProofingCompletedAt)?.Value, out var c) ? c : null,
@@ -133,16 +132,6 @@ public class AuthController(
 
             return BadRequest(new ErrorResponse(result.Message));
         }
-    }
-
-    /// <summary>
-    /// Extracts the user's email address from the authenticated user's JWT claims.
-    /// Returns null when absent (e.g. OIDC users whose IdP didn't include an email claim).
-    /// </summary>
-    private string? GetUserEmail()
-    {
-        return User.FindFirst(ClaimTypes.Email)?.Value
-            ?? User.FindFirst("email")?.Value;
     }
 
     /// <summary>

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -99,7 +99,16 @@ public class AuthController(
         logger.LogInformation("Token refresh request received for email {Email}, Phone={MaskedPhone}",
             email, GetMaskedPhone());
 
-        var command = new RefreshTokenCommand { Email = email, CurrentPrincipal = User };
+        var externalProviderId = User.FindFirst("sub")?.Value;
+        // If the JWT sub differs from the email, it's an OIDC user whose sub is the IdP subject
+        var isOidcUser = externalProviderId != null && externalProviderId != email;
+
+        var command = new RefreshTokenCommand
+        {
+            Email = email,
+            ExternalProviderId = isOidcUser ? externalProviderId : null,
+            CurrentPrincipal = User
+        };
         var result = await handler.Handle(command);
 
         if (result.IsSuccess)

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -460,16 +460,25 @@ public class OidcController(
 
             user = existingEntity;
 
-            // Set step-up IAL in claims, not DB
-            additionalClaims[JwtClaimTypes.Ial] = "1plus";
-            additionalClaims[JwtClaimTypes.IdProofingStatus] = ((int)IdProofingStatus.Completed).ToString();
-            additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
-                new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+            // Step-up IAL comes from the IdP's verification claims — could be 1plus
+            // (IDV) or 2 (doc verification), depending on the step-up client config.
+            // Reject if the IdP returned no verification claims: step-up exists to
+            // obtain verification, so its absence means something is misconfigured.
+            // Silently falling back to a default would risk downgrading the user's IAL.
+            var verification = verificationClaimTranslator.Translate(additionalClaims);
+            if (verification == null)
+            {
+                logger.LogWarning(
+                    "Step-up complete-login: IdP returned no verification claims (SessionId={SessionId})",
+                    sessionId);
+                return BadRequest(new { error = "Step-up verification failed. Please try again." });
+            }
+            ApplyVerificationToClaims(additionalClaims, verification);
 
             var safeStateKey = SanitizeForLog(stateKey);
             logger.LogInformation(
-                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel IAL1plus, SessionId={SessionId}",
-                user.Id, safeStateKey, sessionId);
+                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel {IalLevel}, IsExpired {IsExpired}, SessionId={SessionId}",
+                user.Id, safeStateKey, verification.IalLevel, verification.IsExpired, sessionId);
         }
         else
         {
@@ -496,32 +505,7 @@ public class OidcController(
             var verification = verificationClaimTranslator.Translate(additionalClaims);
             if (verification != null)
             {
-                // Set IAL in additionalClaims for JwtTokenService to pick up.
-                // If the verification has expired, reset to IAL1 — the user must re-verify.
-                if (verification.IsExpired)
-                {
-                    additionalClaims[JwtClaimTypes.Ial] = "1";
-                }
-                else
-                {
-                    additionalClaims[JwtClaimTypes.Ial] = verification.IalLevel switch
-                    {
-                        UserIalLevel.IAL1plus => "1plus",
-                        UserIalLevel.IAL2 => "2",
-                        UserIalLevel.IAL1 => "1",
-                        _ => "0"
-                    };
-                }
-                additionalClaims[JwtClaimTypes.IdProofingStatus] =
-                    ((int)(verification.IsExpired ? IdProofingStatus.Expired : IdProofingStatus.Completed)).ToString();
-
-                if (verification.VerifiedAt != default)
-                {
-                    var verifiedAtOffset = new DateTimeOffset(verification.VerifiedAt, TimeSpan.Zero);
-                    additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
-                        verifiedAtOffset.ToUnixTimeSeconds().ToString();
-                }
-
+                ApplyVerificationToClaims(additionalClaims, verification);
                 logger.LogInformation(
                     "OIDC verification claim reconciled: UserId {UserId}, IalLevel {IalLevel}, IsExpired {IsExpired}, VerifiedAt {VerifiedAt}, SessionId={SessionId}",
                     user.Id, verification.IalLevel, verification.IsExpired, verification.VerifiedAt, sessionId);
@@ -602,5 +586,35 @@ public class OidcController(
             return emailClaim.Value;
         var subClaim = principal.FindFirst("sub");
         return subClaim?.Value;
+    }
+
+    /// <summary>
+    /// Writes IAL, IdProofingStatus, and IdProofingCompletedAt claims into
+    /// <paramref name="additionalClaims"/> from the translated IdP verification result.
+    /// Expired verification resets IAL to 1 — the user must re-verify.
+    /// </summary>
+    private static void ApplyVerificationToClaims(
+        Dictionary<string, string> additionalClaims,
+        OidcVerificationResult verification)
+    {
+        additionalClaims[JwtClaimTypes.Ial] = verification.IsExpired
+            ? "1"
+            : verification.IalLevel switch
+            {
+                UserIalLevel.IAL1plus => "1plus",
+                UserIalLevel.IAL2 => "2",
+                UserIalLevel.IAL1 => "1",
+                _ => "0"
+            };
+
+        additionalClaims[JwtClaimTypes.IdProofingStatus] =
+            ((int)(verification.IsExpired ? IdProofingStatus.Expired : IdProofingStatus.Completed)).ToString();
+
+        if (verification.VerifiedAt != default)
+        {
+            var verifiedAtOffset = new DateTimeOffset(verification.VerifiedAt, TimeSpan.Zero);
+            additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
+                verifiedAtOffset.ToUnixTimeSeconds().ToString();
+        }
     }
 }

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -597,18 +597,27 @@ public class OidcController(
         Dictionary<string, string> additionalClaims,
         OidcVerificationResult verification)
     {
+        // A user completing OIDC login is always at least IAL1 (authenticated). Expired
+        // verification or an unrecognized level both fall back to "1", never "0".
         additionalClaims[JwtClaimTypes.Ial] = verification.IsExpired
             ? "1"
             : verification.IalLevel switch
             {
                 UserIalLevel.IAL1plus => "1plus",
                 UserIalLevel.IAL2 => "2",
-                UserIalLevel.IAL1 => "1",
-                _ => "0"
+                _ => "1"
             };
 
-        additionalClaims[JwtClaimTypes.IdProofingStatus] =
-            ((int)(verification.IsExpired ? IdProofingStatus.Expired : IdProofingStatus.Completed)).ToString();
+        // IdProofingStatus is "Completed" only when verification actually elevated the user
+        // above IAL1. At IAL1 the user is authenticated but has not completed identity
+        // proofing, so status stays at NotStarted. Expired verifications are Expired.
+        additionalClaims[JwtClaimTypes.IdProofingStatus] = (verification.IsExpired, verification.IalLevel) switch
+        {
+            (true, _) => ((int)IdProofingStatus.Expired).ToString(),
+            (_, UserIalLevel.IAL1plus) => ((int)IdProofingStatus.Completed).ToString(),
+            (_, UserIalLevel.IAL2) => ((int)IdProofingStatus.Completed).ToString(),
+            _ => ((int)IdProofingStatus.NotStarted).ToString()
+        };
 
         if (verification.VerifiedAt != default)
         {

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -431,67 +431,105 @@ public class OidcController(
         }
 
         var email = GetEmailFromClaims(principal);
-        if (string.IsNullOrWhiteSpace(email))
+        var subClaim = additionalClaims.GetValueOrDefault("sub");
+        if (string.IsNullOrWhiteSpace(email) && string.IsNullOrWhiteSpace(subClaim))
         {
             logger.LogWarning("Callback token had no email or sub claim (SessionId={SessionId})", sessionId);
             return BadRequest(new ErrorResponse("Callback token must contain an email or sub claim."));
         }
 
-        var normalizedEmail = EmailNormalizer.Normalize(email);
         User user;
 
         if (session.IsStepUp)
         {
-            var existingUser = await userRepository.GetUserByEmailAsync(normalizedEmail, cancellationToken);
-            if (existingUser == null)
+            if (string.IsNullOrWhiteSpace(subClaim))
             {
-                logger.LogWarning("Step-up complete-login: no existing portal user for callback token; sign-in required first (SessionId={SessionId}).", sessionId);
+                logger.LogWarning("Step-up complete-login: missing sub claim (SessionId={SessionId})", sessionId);
+                return BadRequest(new ErrorResponse("Callback token must contain a sub claim."));
+            }
+
+            // Look up by ExternalProviderId for OIDC step-up
+            var existingEntity = await userRepository.GetUserByExternalIdAsync(subClaim, cancellationToken);
+            if (existingEntity == null)
+            {
+                logger.LogWarning(
+                    "Step-up complete-login: no existing portal user for sub claim; sign-in required first (SessionId={SessionId}).",
+                    sessionId);
                 return BadRequest(new { error = "Step-up requires an existing session. Please sign in again." });
             }
 
-            user = existingUser;
-            user.IalLevel = UserIalLevel.IAL1plus;
-            user.IdProofingStatus = IdProofingStatus.Completed;
-            user.IdProofingCompletedAt = DateTime.UtcNow;
-            user.UpdatedAt = DateTime.UtcNow;
-            await userRepository.UpdateUserAsync(user, cancellationToken);
+            user = existingEntity;
+
+            // Set step-up IAL in claims, not DB
+            additionalClaims[JwtClaimTypes.Ial] = "1plus";
+            additionalClaims[JwtClaimTypes.IdProofingStatus] = ((int)IdProofingStatus.Completed).ToString();
+            additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
+                new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
 
             var safeStateKey = SanitizeForLog(stateKey);
             logger.LogInformation(
-                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel {IalLevel}, IdProofingStatus {IdProofingStatus}, Phone={MaskedPhone}, SessionId={SessionId}",
-                user.Id,
-                safeStateKey,
-                user.IalLevel,
-                user.IdProofingStatus,
-                maskedPhone,
-                sessionId);
+                "OIDC step-up complete-login succeeded: UserId {UserId}, StateCode {StateCode}, IalLevel IAL1plus, SessionId={SessionId}",
+                user.Id, safeStateKey, sessionId);
         }
         else
         {
-            var (createdUser, _) = await userRepository.GetOrCreateUserAsync(normalizedEmail, cancellationToken);
-            user = createdUser;
-
-            // A user who completed OIDC login is at least IAL1; don't downgrade if already higher
-            if (user.IalLevel < UserIalLevel.IAL1)
+            // Extract the IdP subject claim — this is the OIDC user's identity anchor.
+            if (string.IsNullOrWhiteSpace(subClaim))
             {
-                user.IalLevel = UserIalLevel.IAL1;
-                await userRepository.UpdateUserAsync(user, cancellationToken);
+                logger.LogWarning(
+                    "OIDC CompleteLogin: callback token missing sub claim (SessionId={SessionId})",
+                    sessionId);
+                return BadRequest(new ErrorResponse("Callback token must contain a sub claim."));
             }
 
-            // Reconcile IAL from OIDC verification claims (e.g. CO's PingOne/Socure).
-            // If the IdP says the user completed identity verification, update our DB
-            // to match — the IdP is the source of truth for OIDC-based verification.
-            // For states without OIDC verification (e.g. DC), Translate() returns null
-            // because the IdP claims don't contain the configured verification claim names.
+            // Pass email from IdP claims as a migration hint: if no user exists for
+            // this sub but one exists for this email, adopt that legacy record.
+            // TODO: Remove email parameter once all existing users have been migrated.
+            var emailHint = additionalClaims.GetValueOrDefault("email");
+            var (createdUser, _) = await userRepository.GetOrCreateUserByExternalIdAsync(
+                subClaim, emailHint, cancellationToken);
+            user = createdUser;
+
+            // Reconcile IAL from OIDC verification claims. The IdP is the source of truth —
+            // we derive IAL from claims and pass it through to the JWT, but do NOT persist
+            // it to the DB. The DB only stores the identity anchor (ExternalProviderId).
             var verification = verificationClaimTranslator.Translate(additionalClaims);
             if (verification != null)
             {
-                ReconcileIalFromOidcVerification(user, verification);
-                await userRepository.UpdateUserAsync(user, cancellationToken);
+                // Set IAL in additionalClaims for JwtTokenService to pick up.
+                // If the verification has expired, reset to IAL1 — the user must re-verify.
+                if (verification.IsExpired)
+                {
+                    additionalClaims[JwtClaimTypes.Ial] = "1";
+                }
+                else
+                {
+                    additionalClaims[JwtClaimTypes.Ial] = verification.IalLevel switch
+                    {
+                        UserIalLevel.IAL1plus => "1plus",
+                        UserIalLevel.IAL2 => "2",
+                        UserIalLevel.IAL1 => "1",
+                        _ => "0"
+                    };
+                }
+                additionalClaims[JwtClaimTypes.IdProofingStatus] =
+                    ((int)(verification.IsExpired ? IdProofingStatus.Expired : IdProofingStatus.Completed)).ToString();
+
+                if (verification.VerifiedAt != default)
+                {
+                    var verifiedAtOffset = new DateTimeOffset(verification.VerifiedAt, TimeSpan.Zero);
+                    additionalClaims[JwtClaimTypes.IdProofingCompletedAt] =
+                        verifiedAtOffset.ToUnixTimeSeconds().ToString();
+                }
 
                 logger.LogInformation(
                     "OIDC verification claim reconciled: UserId {UserId}, IalLevel {IalLevel}, IsExpired {IsExpired}, VerifiedAt {VerifiedAt}, SessionId={SessionId}",
-                    user.Id, user.IalLevel, verification.IsExpired, verification.VerifiedAt, sessionId);
+                    user.Id, verification.IalLevel, verification.IsExpired, verification.VerifiedAt, sessionId);
+            }
+            else
+            {
+                // No verification claims from IdP — user is IAL1 (authenticated but not verified)
+                additionalClaims[JwtClaimTypes.Ial] = "1";
             }
         }
 
@@ -552,28 +590,6 @@ public class OidcController(
         return value
             .Replace("\r", string.Empty, StringComparison.Ordinal)
             .Replace("\n", string.Empty, StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// Updates a user's IAL and proofing fields based on translated OIDC verification claims.
-    /// If the verification is expired, resets to IAL1 (the user must re-verify).
-    /// If valid, promotes to the verified IAL level.
-    /// </summary>
-    private static void ReconcileIalFromOidcVerification(User user, OidcVerificationResult verification)
-    {
-        if (verification.IsExpired)
-        {
-            // Verification has lapsed — reset to baseline IAL1 (they completed OIDC login,
-            // so they're at least IAL1, but no longer IAL1+).
-            user.IalLevel = UserIalLevel.IAL1;
-            user.IdProofingStatus = IdProofingStatus.Expired;
-            return;
-        }
-
-        // Valid, non-expired verification from the IdP — update to match.
-        user.IalLevel = verification.IalLevel;
-        user.IdProofingStatus = IdProofingStatus.Completed;
-        user.IdProofingCompletedAt = verification.VerifiedAt;
     }
 
     /// <summary>

--- a/src/SEBT.Portal.Api/Filters/ResolveUserFilter.cs
+++ b/src/SEBT.Portal.Api/Filters/ResolveUserFilter.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using SEBT.Portal.Api.Models;
@@ -7,9 +6,9 @@ using SEBT.Portal.Core.Repositories;
 namespace SEBT.Portal.Api.Filters;
 
 /// <summary>
-/// Action filter that resolves the authenticated user's numeric ID from their email claim
+/// Action filter that resolves the authenticated user's numeric ID from their JWT sub claim
 /// and stashes it on HttpContext.Items. Controllers read the pre-resolved ID, keeping PII
-/// (email) out of controller code entirely.
+/// (email) out of controller code entirely. Also verifies the user still exists in the DB.
 /// </summary>
 public class ResolveUserFilter(
     IUserRepository userRepository,
@@ -23,22 +22,23 @@ public class ResolveUserFilter(
     /// <inheritdoc />
     public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        var email = context.HttpContext.User.FindFirst(ClaimTypes.Email)?.Value
-            ?? context.HttpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? context.HttpContext.User.Identity?.Name;
-
-        if (string.IsNullOrWhiteSpace(email))
+        // The portal JWT sub claim is our internal user ID (set by JwtTokenService).
+        // This works uniformly for OIDC and OTP users — no email lookup required.
+        var subValue = context.HttpContext.User.FindFirst("sub")?.Value;
+        if (!int.TryParse(subValue, out var userId) || userId <= 0)
         {
-            logger.LogWarning("Request to resolved-user endpoint but email could not be extracted from claims");
+            logger.LogWarning("Request to resolved-user endpoint but sub claim missing or invalid");
             context.Result = new UnauthorizedObjectResult(
                 new ErrorResponse("Unable to identify user from token."));
             return;
         }
 
-        var user = await userRepository.GetUserByEmailAsync(email, context.HttpContext.RequestAborted);
+        // Verify the user still exists (defense-in-depth: JWTs remain valid after deletion).
+        var user = await userRepository.GetUserByIdAsync(userId, context.HttpContext.RequestAborted);
         if (user == null)
         {
-            logger.LogWarning("Request to resolved-user endpoint but authenticated user not found in database");
+            logger.LogWarning(
+                "Request to resolved-user endpoint but UserId {UserId} not found in database", userId);
             context.Result = new UnauthorizedObjectResult(
                 new ErrorResponse("Unable to identify user from token."));
             return;

--- a/src/SEBT.Portal.Api/Filters/ResolveUserFilter.cs
+++ b/src/SEBT.Portal.Api/Filters/ResolveUserFilter.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using SEBT.Portal.Api.Models;
 using SEBT.Portal.Core.Repositories;
+using SEBT.Portal.Core.Utilities;
 
 namespace SEBT.Portal.Api.Filters;
 
@@ -24,8 +25,8 @@ public class ResolveUserFilter(
     {
         // The portal JWT sub claim is our internal user ID (set by JwtTokenService).
         // This works uniformly for OIDC and OTP users — no email lookup required.
-        var subValue = context.HttpContext.User.FindFirst("sub")?.Value;
-        if (!int.TryParse(subValue, out var userId) || userId <= 0)
+        var userId = context.HttpContext.User.GetUserId();
+        if (userId == null)
         {
             logger.LogWarning("Request to resolved-user endpoint but sub claim missing or invalid");
             context.Result = new UnauthorizedObjectResult(
@@ -34,7 +35,7 @@ public class ResolveUserFilter(
         }
 
         // Verify the user still exists (defense-in-depth: JWTs remain valid after deletion).
-        var user = await userRepository.GetUserByIdAsync(userId, context.HttpContext.RequestAborted);
+        var user = await userRepository.GetUserByIdAsync(userId.Value, context.HttpContext.RequestAborted);
         if (user == null)
         {
             logger.LogWarning(

--- a/src/SEBT.Portal.Core/Models/Auth/User.cs
+++ b/src/SEBT.Portal.Core/Models/Auth/User.cs
@@ -13,7 +13,13 @@ public class User
     /// <summary>
     /// The user's email address, used as a unique identifier.
     /// </summary>
-    public string Email { get; set; } = string.Empty;
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// The subject identifier from the external identity provider (e.g., PingOne sub claim).
+    /// Set for OIDC users; null for OTP-authenticated users.
+    /// </summary>
+    public string? ExternalProviderId { get; set; }
 
     /// <summary>
     /// Workflow state of the ID proofing process (NotStarted, InProgress, Completed, Failed, Expired).

--- a/src/SEBT.Portal.Core/Repositories/IUserRepository.cs
+++ b/src/SEBT.Portal.Core/Repositories/IUserRepository.cs
@@ -54,4 +54,27 @@ public interface IUserRepository
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>The user if found; otherwise, <c>null</c>.</returns>
     Task<User?> GetUserByIdAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets or creates a user by their external identity provider subject ID.
+    /// Used for OIDC-authenticated users whose identity is anchored by the IdP's sub claim.
+    /// Creates a minimal record (no email, no IAL) — those attributes come from IdP claims.
+    ///
+    /// When <paramref name="email"/> is provided and no user exists for the given
+    /// <paramref name="externalProviderId"/>, falls back to an email-based lookup and
+    /// adopts that record by setting its ExternalProviderId. This migrates pre-existing
+    /// email-only user records to the new sub-based identity model.
+    /// TODO: Remove email fallback migration once all existing users have logged in
+    /// under the new flow.
+    /// </summary>
+    Task<(User user, bool isNewUser)> GetOrCreateUserByExternalIdAsync(
+        string externalProviderId,
+        string? email = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a user by their external identity provider subject ID.
+    /// </summary>
+    Task<User?> GetUserByExternalIdAsync(
+        string externalProviderId, CancellationToken cancellationToken = default);
 }

--- a/src/SEBT.Portal.Core/Utilities/ClaimsPrincipalExtensions.cs
+++ b/src/SEBT.Portal.Core/Utilities/ClaimsPrincipalExtensions.cs
@@ -17,4 +17,16 @@ public static class ClaimsPrincipalExtensions
         var subValue = principal.FindFirst("sub")?.Value;
         return int.TryParse(subValue, out var id) && id > 0 ? id : null;
     }
+
+    /// <summary>
+    /// Extracts the user's email address from the JWT claims. Checks the long-form
+    /// <see cref="ClaimTypes.Email"/> first (written by <c>JwtTokenService</c>) then the
+    /// short-form <c>email</c>. Returns null when absent — OIDC users whose IdP didn't
+    /// include an email claim legitimately have no email.
+    /// </summary>
+    public static string? GetUserEmail(this ClaimsPrincipal principal)
+    {
+        return principal.FindFirst(ClaimTypes.Email)?.Value
+            ?? principal.FindFirst("email")?.Value;
+    }
 }

--- a/src/SEBT.Portal.Core/Utilities/ClaimsPrincipalExtensions.cs
+++ b/src/SEBT.Portal.Core/Utilities/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,20 @@
+using System.Security.Claims;
+
+namespace SEBT.Portal.Core.Utilities;
+
+/// <summary>
+/// Extension methods for reading portal-specific values from <see cref="ClaimsPrincipal"/>.
+/// </summary>
+public static class ClaimsPrincipalExtensions
+{
+    /// <summary>
+    /// Extracts the portal's internal user ID from the authenticated JWT's <c>sub</c> claim.
+    /// Returns null when the claim is absent or does not parse to a positive integer
+    /// (e.g. an unauthenticated principal or a malformed token).
+    /// </summary>
+    public static int? GetUserId(this ClaimsPrincipal principal)
+    {
+        var subValue = principal.FindFirst("sub")?.Value;
+        return int.TryParse(subValue, out var id) && id > 0 ? id : null;
+    }
+}

--- a/src/SEBT.Portal.Infrastructure.Seeding/Services/DatabaseSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure.Seeding/Services/DatabaseSeeder.cs
@@ -212,11 +212,16 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
         else
         {
             var testUsers = CreateTestUsers(now);
-            var userEmails = testUsers.Select(u => u.Email).ToList();
+            var userEmails = testUsers
+                .Select(u => u.Email)
+                .Where(e => e != null)
+                .Cast<string>()
+                .ToList();
             var existingEmails = await _dataSeeder.GetExistingUserEmailsAsync(userEmails, cancellationToken);
 
             var usersToAdd = testUsers
-                .Where(user => !existingEmails.Contains(EmailNormalizer.Normalize(user.Email)))
+                .Where(user => user.Email != null
+                    && !existingEmails.Contains(EmailNormalizer.Normalize(user.Email)))
                 .ToList();
 
             if (usersToAdd.Count > 0)
@@ -347,11 +352,16 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
         else
         {
             var testUsers = CreateTestUsers(now);
-            var userEmails = testUsers.Select(u => u.Email).ToList();
+            var userEmails = testUsers
+                .Select(u => u.Email)
+                .Where(e => e != null)
+                .Cast<string>()
+                .ToList();
             var existingEmails = _dataSeeder.GetExistingUserEmails(userEmails);
 
             var usersToAdd = testUsers
-                .Where(user => !existingEmails.Contains(EmailNormalizer.Normalize(user.Email)))
+                .Where(user => user.Email != null
+                    && !existingEmails.Contains(EmailNormalizer.Normalize(user.Email)))
                 .ToList();
 
             if (usersToAdd.Count > 0)

--- a/src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs
+++ b/src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs
@@ -13,7 +13,13 @@ public class UserEntity
     /// <summary>
     /// The user's email address, used as a unique identifier.
     /// </summary>
-    public string Email { get; set; } = string.Empty;
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// The subject identifier from the external identity provider (e.g., PingOne sub claim).
+    /// Null for OTP-authenticated users.
+    /// </summary>
+    public string? ExternalProviderId { get; set; }
 
     /// <summary>
     /// Workflow state of ID proofing (NotStarted, InProgress, Completed, Failed, Expired)

--- a/src/SEBT.Portal.Infrastructure/Data/PortalDbContext.cs
+++ b/src/SEBT.Portal.Infrastructure/Data/PortalDbContext.cs
@@ -72,11 +72,11 @@ public class PortalDbContext : DbContext
                 .ValueGeneratedOnAdd()
                 .UseIdentityColumn();
             entity.Property(e => e.Email)
-                .IsRequired()
                 .HasMaxLength(255);
             entity.HasIndex(e => e.Email)
                 .IsUnique()
-                .HasDatabaseName("IX_Users_Email");
+                .HasDatabaseName("IX_Users_Email")
+                .HasFilter("[Email] IS NOT NULL");
             entity.Property(e => e.IdProofingStatus)
                 .IsRequired()
                 .HasDefaultValue(0); // 0 = NotStarted
@@ -106,6 +106,14 @@ public class PortalDbContext : DbContext
             entity.Property(e => e.SnapId).HasMaxLength(64);
             entity.Property(e => e.TanfId).HasMaxLength(64);
             entity.Property(e => e.Ssn).HasMaxLength(64);
+
+            // OIDC external provider identifier — nullable, filtered unique index
+            entity.Property(e => e.ExternalProviderId)
+                .HasMaxLength(255);
+            entity.HasIndex(e => e.ExternalProviderId)
+                .IsUnique()
+                .HasDatabaseName("IX_Users_ExternalProviderId")
+                .HasFilter("[ExternalProviderId] IS NOT NULL");
         });
 
         modelBuilder.Entity<DocVerificationChallengeEntity>(entity =>

--- a/src/SEBT.Portal.Infrastructure/Helpers/UserFactory.cs
+++ b/src/SEBT.Portal.Infrastructure/Helpers/UserFactory.cs
@@ -90,7 +90,7 @@ public static class UserFactory
         return new UserEntity
         {
             Id = user.Id,
-            Email = EmailNormalizer.Normalize(user.Email),
+            Email = user.Email != null ? EmailNormalizer.Normalize(user.Email) : null,
             IdProofingStatus = (int)user.IdProofingStatus,
             IalLevel = (int)user.IalLevel,
             IdProofingSessionId = user.IdProofingSessionId,

--- a/src/SEBT.Portal.Infrastructure/Migrations/20260418185820_AddExternalProviderIdToUsers.Designer.cs
+++ b/src/SEBT.Portal.Infrastructure/Migrations/20260418185820_AddExternalProviderIdToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SEBT.Portal.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using SEBT.Portal.Infrastructure.Data;
 namespace SEBT.Portal.Infrastructure.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    partial class PortalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418185820_AddExternalProviderIdToUsers")]
+    partial class AddExternalProviderIdToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SEBT.Portal.Infrastructure/Migrations/20260418185820_AddExternalProviderIdToUsers.cs
+++ b/src/SEBT.Portal.Infrastructure/Migrations/20260418185820_AddExternalProviderIdToUsers.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SEBT.Portal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalProviderIdToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_Email",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Users",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalProviderId",
+                table: "Users",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true,
+                filter: "[Email] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_ExternalProviderId",
+                table: "Users",
+                column: "ExternalProviderId",
+                unique: true,
+                filter: "[ExternalProviderId] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_Email",
+                table: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_ExternalProviderId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalProviderId",
+                table: "Users");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Users",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true);
+        }
+    }
+}

--- a/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
@@ -198,6 +198,97 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
         return entity == null ? null : MapToDomainModel(entity);
     }
 
+    public async Task<User?> GetUserByExternalIdAsync(
+        string externalProviderId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(externalProviderId))
+        {
+            return null;
+        }
+
+        var entity = await dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+        return entity == null ? null : MapToDomainModel(entity);
+    }
+
+    public async Task<(User user, bool isNewUser)> GetOrCreateUserByExternalIdAsync(
+        string externalProviderId,
+        string? email = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(externalProviderId))
+        {
+            throw new ArgumentException(
+                "External provider ID cannot be null or empty.", nameof(externalProviderId));
+        }
+
+        // Primary lookup: by ExternalProviderId (the steady-state path)
+        var entity = await dbContext.Users
+            .FirstOrDefaultAsync(u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+        if (entity != null)
+        {
+            return (MapToDomainModel(entity), false);
+        }
+
+        // Migration fallback: if an email hint is provided, check for a legacy
+        // email-only record and adopt it by setting ExternalProviderId.
+        // TODO: Remove this fallback once all existing users have logged in
+        // under the new sub-based identity flow.
+        if (!string.IsNullOrWhiteSpace(email))
+        {
+            var normalizedEmail = NormalizeEmail(email);
+            var legacyEntity = await dbContext.Users
+                .FirstOrDefaultAsync(
+                    u => u.Email == normalizedEmail && u.ExternalProviderId == null,
+                    cancellationToken);
+
+            if (legacyEntity != null)
+            {
+                legacyEntity.ExternalProviderId = externalProviderId;
+                legacyEntity.Email = null; // OIDC users derive email from IdP claims, not DB
+                legacyEntity.UpdatedAt = DateTime.UtcNow;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                return (MapToDomainModel(legacyEntity), false);
+            }
+        }
+
+        // No existing record found — create a new minimal one
+        var newEntity = new UserEntity
+        {
+            ExternalProviderId = externalProviderId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        dbContext.Users.Add(newEntity);
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex)
+        {
+            if (ex.InnerException?.Message.Contains("UNIQUE") == true ||
+                ex.InnerException?.Message.Contains("duplicate key") == true)
+            {
+                entity = await dbContext.Users
+                    .FirstOrDefaultAsync(
+                        u => u.ExternalProviderId == externalProviderId, cancellationToken);
+
+                if (entity != null)
+                {
+                    return (MapToDomainModel(entity), false);
+                }
+            }
+            throw;
+        }
+
+        return (MapToDomainModel(newEntity), true);
+    }
+
     /// <summary>
     /// Normalizes an email address to lowercase for consistent storage and comparison.
     /// </summary>
@@ -214,6 +305,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
         {
             Id = entity.Id,
             Email = entity.Email,
+            ExternalProviderId = entity.ExternalProviderId,
             IdProofingStatus = (IdProofingStatus)entity.IdProofingStatus,
             IalLevel = (UserIalLevel)entity.IalLevel,
             IdProofingSessionId = entity.IdProofingSessionId,
@@ -237,6 +329,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
         {
             Id = user.Id, // Will be 0 for new users, set by database
             Email = user.Email, // Will be normalized in calling method
+            ExternalProviderId = user.ExternalProviderId,
             IdProofingStatus = (int)user.IdProofingStatus,
             IalLevel = (int)user.IalLevel,
             IdProofingSessionId = user.IdProofingSessionId,

--- a/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
@@ -34,14 +34,20 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             throw new ArgumentNullException(nameof(user));
         }
 
-        if (string.IsNullOrWhiteSpace(user.Email))
+        // OTP users must have an email; OIDC users must have an ExternalProviderId.
+        // At least one identifier is required.
+        if (string.IsNullOrWhiteSpace(user.Email) && string.IsNullOrWhiteSpace(user.ExternalProviderId))
         {
-            throw new ArgumentException("Email cannot be null or empty.", nameof(user));
+            throw new ArgumentException(
+                "Either Email or ExternalProviderId must be provided.", nameof(user));
         }
 
         var entity = MapToEntity(user);
-        // Normalize email to lowercase for consistent storage
-        entity.Email = NormalizeEmail(entity.Email);
+        // Normalize email to lowercase for consistent storage (when present)
+        if (entity.Email != null)
+        {
+            entity.Email = NormalizeEmail(entity.Email);
+        }
         dbContext.Users.Add(entity);
         await dbContext.SaveChangesAsync(cancellationToken);
     }
@@ -58,11 +64,6 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             throw new ArgumentException("User Id must be greater than zero for updates.", nameof(user));
         }
 
-        if (string.IsNullOrWhiteSpace(user.Email))
-        {
-            throw new ArgumentException("Email cannot be null or empty.", nameof(user));
-        }
-
         var entity = await dbContext.Users
             .FirstOrDefaultAsync(u => u.Id == user.Id, cancellationToken);
 
@@ -71,11 +72,15 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             throw new InvalidOperationException($"User with Id {user.Id} not found.");
         }
 
-        var normalizedEmail = NormalizeEmail(user.Email);
-
-        if (entity.Email != normalizedEmail)
+        // Update email only when the caller provides one (OTP users).
+        // OIDC users have null email — leave the DB value unchanged in that case.
+        if (user.Email != null)
         {
-            entity.Email = normalizedEmail;
+            var normalizedEmail = NormalizeEmail(user.Email);
+            if (entity.Email != normalizedEmail)
+            {
+                entity.Email = normalizedEmail;
+            }
         }
 
         // Update properties

--- a/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
@@ -35,6 +35,7 @@ public class DataSeeder : IDataSeeder
         {
             Id = user.Id, // Will be 0 for new users, set by database
             Email = normalizedEmail,
+            ExternalProviderId = user.ExternalProviderId,
             IdProofingStatus = (int)user.IdProofingStatus,
             IalLevel = (int)user.IalLevel,
             IdProofingSessionId = user.IdProofingSessionId,

--- a/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
@@ -28,9 +28,8 @@ public class DataSeeder : IDataSeeder
     private UserEntity MapToEntity(User user)
     {
         ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(user.Email);
 
-        var normalizedEmail = EmailNormalizer.Normalize(user.Email);
+        var normalizedEmail = user.Email != null ? EmailNormalizer.Normalize(user.Email) : null;
         return new UserEntity
         {
             Id = user.Id, // Will be 0 for new users, set by database
@@ -79,8 +78,8 @@ public class DataSeeder : IDataSeeder
 
         var normalizedEmails = emails.Select(EmailNormalizer.Normalize).ToList();
         var existingEmails = await _dbContext.Users
-            .Where(u => normalizedEmails.Contains(u.Email))
-            .Select(u => u.Email)
+            .Where(u => u.Email != null && normalizedEmails.Contains(u.Email))
+            .Select(u => u.Email!)
             .ToListAsync(cancellationToken);
         return existingEmails.ToHashSet();
     }
@@ -116,8 +115,8 @@ public class DataSeeder : IDataSeeder
         ArgumentNullException.ThrowIfNull(emailDomain);
 
         return await _dbContext.Users
-            .Where(u => u.Email.EndsWith(emailDomain))
-            .Select(u => u.Email)
+            .Where(u => u.Email != null && u.Email.EndsWith(emailDomain))
+            .Select(u => u.Email!)
             .ToListAsync(cancellationToken);
     }
 
@@ -127,7 +126,7 @@ public class DataSeeder : IDataSeeder
 
         var normalizedEmails = emails.Select(EmailNormalizer.Normalize).ToList();
         var usersToRemove = await _dbContext.Users
-            .Where(u => normalizedEmails.Contains(u.Email))
+            .Where(u => u.Email != null && normalizedEmails.Contains(u.Email))
             .ToListAsync(cancellationToken);
 
         _dbContext.Users.RemoveRange(usersToRemove);
@@ -156,8 +155,8 @@ public class DataSeeder : IDataSeeder
 
         var normalizedEmails = emails.Select(EmailNormalizer.Normalize).ToList();
         var existingEmails = _dbContext.Users
-            .Where(u => normalizedEmails.Contains(u.Email))
-            .Select(u => u.Email)
+            .Where(u => u.Email != null && normalizedEmails.Contains(u.Email))
+            .Select(u => u.Email!)
             .ToList();
         return existingEmails.ToHashSet();
     }

--- a/src/SEBT.Portal.Infrastructure/Services/HouseholdIdentifierResolver.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/HouseholdIdentifierResolver.cs
@@ -40,19 +40,14 @@ public class HouseholdIdentifierResolver : IHouseholdIdentifierResolver
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var email = GetEmailFromClaims(principal);
-        if (string.IsNullOrWhiteSpace(email))
+        var userId = principal.GetUserId();
+
+        if (userId is null)
         {
             return null;
         }
 
-        var normalizedEmail = EmailNormalizer.NormalizeOrNull(email);
-        if (string.IsNullOrWhiteSpace(normalizedEmail))
-        {
-            return null;
-        }
-
-        var user = await _userRepository.GetUserByEmailAsync(normalizedEmail, cancellationToken);
+        var user = await _userRepository.GetUserByIdAsync(userId.Value, cancellationToken);
         if (user == null)
         {
             return null;
@@ -112,19 +107,6 @@ public class HouseholdIdentifierResolver : IHouseholdIdentifierResolver
         }
 
         return null;
-    }
-
-    /// <summary>
-    /// Gets the user's email from JWT claims (the only identity we need in the token).
-    /// </summary>
-    private static string? GetEmailFromClaims(ClaimsPrincipal principal)
-    {
-        var email = principal.FindFirst(ClaimTypes.Email)?.Value
-            ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
-            ?? principal.FindFirst("email")?.Value
-            ?? principal.FindFirst("sub")?.Value
-            ?? principal.Identity?.Name;
-        return string.IsNullOrWhiteSpace(email) ? null : email.Trim();
     }
 
     /// <summary>

--- a/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
@@ -50,14 +50,14 @@ public class JwtTokenService : IJwtTokenService
         var email = additionalClaims?.GetValueOrDefault("email") ?? user.Email ?? "";
 
         // For OIDC users, IAL comes from IdP claims carried in additionalClaims.
-        // For OTP users, it comes from user.IalLevel (the DB value).
+        // For OTP users, it comes from user.IalLevel (the DB value). Any user reaching
+        // GenerateToken is authenticated, so the floor is "1" (IAL1) — never "0".
         var ialValue = additionalClaims?.GetValueOrDefault(JwtClaimTypes.Ial)
             ?? user.IalLevel switch
             {
-                UserIalLevel.IAL1 => "1",
                 UserIalLevel.IAL1plus => "1plus",
                 UserIalLevel.IAL2 => "2",
-                _ => "0" // None
+                _ => "1"
             };
 
         var idProofingStatusValue = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingStatus)

--- a/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
@@ -41,10 +41,13 @@ public class JwtTokenService : IJwtTokenService
         var now = DateTimeOffset.UtcNow;
         var unixTimeSeconds = now.ToUnixTimeSeconds();
 
-        // For OIDC users, email and sub come from IdP claims (via additionalClaims).
-        // For OTP users, they come from user.Email (the DB value).
+        // The portal JWT sub is our internal user ID — always. The IdP's sub (for OIDC
+        // users) is stored as ExternalProviderId in the DB, not propagated into the JWT.
+        var sub = user.Id.ToString();
+
+        // For OIDC users, email comes from IdP claims (via additionalClaims).
+        // For OTP users, it comes from user.Email (the DB value).
         var email = additionalClaims?.GetValueOrDefault("email") ?? user.Email ?? "";
-        var sub = additionalClaims?.GetValueOrDefault("sub") ?? email;
 
         // For OIDC users, IAL comes from IdP claims carried in additionalClaims.
         // For OTP users, it comes from user.IalLevel (the DB value).

--- a/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
@@ -29,7 +29,9 @@ public class JwtTokenService : IJwtTokenService
     /// Generates a JWT token for the specified user.
     /// </summary>
     /// <param name="user">The authenticated user.</param>
-    /// <param name="additionalClaims">Optional claims to add</param>
+    /// <param name="additionalClaims">Optional claims to add. For OIDC users, these carry
+    /// fresh values from the IdP (email, sub, IAL, ID proofing state) that override stale
+    /// DB values. For OTP users, this is typically null and the user object is used.</param>
     /// <returns>A JWT token string.</returns>
     public string GenerateToken(User user, IReadOnlyDictionary<string, string>? additionalClaims = null)
     {
@@ -39,34 +41,54 @@ public class JwtTokenService : IJwtTokenService
         var now = DateTimeOffset.UtcNow;
         var unixTimeSeconds = now.ToUnixTimeSeconds();
 
+        // For OIDC users, email and sub come from IdP claims (via additionalClaims).
+        // For OTP users, they come from user.Email (the DB value).
+        var email = additionalClaims?.GetValueOrDefault("email") ?? user.Email ?? "";
+        var sub = additionalClaims?.GetValueOrDefault("sub") ?? email;
+
+        // For OIDC users, IAL comes from IdP claims carried in additionalClaims.
+        // For OTP users, it comes from user.IalLevel (the DB value).
+        var ialValue = additionalClaims?.GetValueOrDefault(JwtClaimTypes.Ial)
+            ?? user.IalLevel switch
+            {
+                UserIalLevel.IAL1 => "1",
+                UserIalLevel.IAL1plus => "1plus",
+                UserIalLevel.IAL2 => "2",
+                _ => "0" // None
+            };
+
+        var idProofingStatusValue = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingStatus)
+            ?? ((int)user.IdProofingStatus).ToString();
+
         var claims = new List<Claim>
         {
-            new Claim(ClaimTypes.Email, user.Email),
-            new Claim(JwtRegisteredClaimNames.Sub, user.Email),
+            new Claim(ClaimTypes.Email, email),
+            new Claim(JwtRegisteredClaimNames.Sub, sub),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new Claim(JwtRegisteredClaimNames.Iat, unixTimeSeconds.ToString(), ClaimValueTypes.Integer64),
             new Claim(JwtRegisteredClaimNames.Nbf, unixTimeSeconds.ToString(), ClaimValueTypes.Integer64),
             new Claim(JwtRegisteredClaimNames.Aud, "SEBT.Portal.Web"),
             new Claim(JwtRegisteredClaimNames.Iss, "SEBT.Portal.Api"),
             // Workflow state of ID proofing process
-            new Claim(JwtClaimTypes.IdProofingStatus, ((int)user.IdProofingStatus).ToString(), ClaimValueTypes.Integer32),
-            // The Users's current Identity Assurance Level (IAL)
-            new Claim(JwtClaimTypes.Ial, user.IalLevel switch
-            {
-                UserIalLevel.IAL1 => "1",
-                UserIalLevel.IAL1plus => "1plus",
-                UserIalLevel.IAL2 => "2",
-                _ => "0" // None
-            })
+            new Claim(JwtClaimTypes.IdProofingStatus, idProofingStatusValue, ClaimValueTypes.Integer32),
+            // The user's current Identity Assurance Level (IAL)
+            new Claim(JwtClaimTypes.Ial, ialValue)
         };
 
-        // Add optional ID proofing claims if available
-        if (!string.IsNullOrWhiteSpace(user.IdProofingSessionId))
+        // Add optional ID proofing claims — prefer additionalClaims, fall back to user properties
+        var sessionId = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingSessionId)
+            ?? user.IdProofingSessionId;
+        if (!string.IsNullOrWhiteSpace(sessionId))
         {
-            claims.Add(new Claim(JwtClaimTypes.IdProofingSessionId, user.IdProofingSessionId));
+            claims.Add(new Claim(JwtClaimTypes.IdProofingSessionId, sessionId));
         }
 
-        if (user.IdProofingCompletedAt.HasValue)
+        var completedAtStr = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingCompletedAt);
+        if (completedAtStr != null)
+        {
+            claims.Add(new Claim(JwtClaimTypes.IdProofingCompletedAt, completedAtStr, ClaimValueTypes.Integer64));
+        }
+        else if (user.IdProofingCompletedAt.HasValue)
         {
             var completedAtOffset = new DateTimeOffset(user.IdProofingCompletedAt.Value, TimeSpan.Zero);
             claims.Add(new Claim(JwtClaimTypes.IdProofingCompletedAt,
@@ -74,10 +96,13 @@ public class JwtTokenService : IJwtTokenService
                 ClaimValueTypes.Integer64));
         }
 
-        // Compute expiration dynamically from IdProofingCompletedAt + configured validity duration.
-        // This avoids storing baked-in expiration dates and allows config changes to take effect
-        // without bulk data updates.
-        if (user.IdProofingCompletedAt.HasValue)
+        // Compute expiration from completedAt + validity, regardless of source
+        var expiresAtStr = additionalClaims?.GetValueOrDefault(JwtClaimTypes.IdProofingExpiresAt);
+        if (expiresAtStr != null)
+        {
+            claims.Add(new Claim(JwtClaimTypes.IdProofingExpiresAt, expiresAtStr, ClaimValueTypes.Integer64));
+        }
+        else if (user.IdProofingCompletedAt.HasValue)
         {
             var expiresAt = user.IdProofingCompletedAt.Value.AddDays(_validitySettings.ValidityDays);
             var expiresAtOffset = new DateTimeOffset(expiresAt, TimeSpan.Zero);
@@ -86,7 +111,7 @@ public class JwtTokenService : IJwtTokenService
                 ClaimValueTypes.Integer64));
         }
 
-        // Portal-defined claim names we already set above; do not add again from additionalClaims
+        // Claim names already set above; do not add again from additionalClaims
         // or the JWT payload would have e.g. "sub": [a, b], which .NET's reader rejects (expects string).
         var reservedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -98,7 +123,12 @@ public class JwtTokenService : IJwtTokenService
             JwtRegisteredClaimNames.Iat,
             JwtRegisteredClaimNames.Nbf,
             JwtRegisteredClaimNames.Aud,
-            JwtRegisteredClaimNames.Iss
+            JwtRegisteredClaimNames.Iss,
+            JwtClaimTypes.Ial,
+            JwtClaimTypes.IdProofingStatus,
+            JwtClaimTypes.IdProofingSessionId,
+            JwtClaimTypes.IdProofingCompletedAt,
+            JwtClaimTypes.IdProofingExpiresAt,
         };
 
         if (additionalClaims != null)

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs
@@ -5,19 +5,15 @@ using SEBT.Portal.Kernel;
 namespace SEBT.Portal.UseCases.Auth;
 
 /// <summary>
-/// Command for refreshing a JWT token with updated user information.
+/// Command for refreshing a JWT token with updated user information. The user ID and
+/// the claims to preserve are both read from <see cref="CurrentPrincipal"/>.
 /// </summary>
 public class RefreshTokenCommand : ICommand<string>
 {
     /// <summary>
-    /// The portal's internal user ID, extracted from the authenticated JWT's sub claim.
-    /// </summary>
-    [Range(1, int.MaxValue, ErrorMessage = "User ID must be a positive integer.")]
-    public required int UserId { get; init; }
-
-    /// <summary>
-    /// The current ClaimsPrincipal for the request. IMPORTANT: Used to preserve existing claims
-    /// (e.g. IAL from IdP for OIDC users) when generating the refreshed token.
+    /// The current ClaimsPrincipal for the request. The handler reads the portal user ID
+    /// from the <c>sub</c> claim and preserves the remaining claims (e.g. IAL from IdP for
+    /// OIDC users) when generating the refreshed token.
     /// </summary>
     [Required(ErrorMessage = "CurrentPrincipal is required.")]
     public required ClaimsPrincipal CurrentPrincipal { get; init; }

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs
@@ -10,23 +10,15 @@ namespace SEBT.Portal.UseCases.Auth;
 public class RefreshTokenCommand : ICommand<string>
 {
     /// <summary>
-    /// The email address of the user requesting the token refresh.
+    /// The portal's internal user ID, extracted from the authenticated JWT's sub claim.
     /// </summary>
-    [Required(ErrorMessage = "Email address is required.")]
-    [EmailAddress(ErrorMessage = "Invalid email format.")]
-    public required string Email { get; init; } = string.Empty;
+    [Range(1, int.MaxValue, ErrorMessage = "User ID must be a positive integer.")]
+    public required int UserId { get; init; }
 
     /// <summary>
-    /// The current ClaimsPrincipal for the request. IMPORTANT: Used to preserve existing claims.
+    /// The current ClaimsPrincipal for the request. IMPORTANT: Used to preserve existing claims
+    /// (e.g. IAL from IdP for OIDC users) when generating the refreshed token.
     /// </summary>
     [Required(ErrorMessage = "CurrentPrincipal is required.")]
     public required ClaimsPrincipal CurrentPrincipal { get; init; }
-
-    /// <summary>
-    /// The external provider ID (IdP sub claim) for OIDC users. Null for OTP users.
-    /// When present, the handler looks up the user by ExternalProviderId instead of email
-    /// and preserves IAL from JWT claims instead of reading from DB.
-    /// </summary>
-    public string? ExternalProviderId { get; set; }
 }
-

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommand.cs
@@ -21,5 +21,12 @@ public class RefreshTokenCommand : ICommand<string>
     /// </summary>
     [Required(ErrorMessage = "CurrentPrincipal is required.")]
     public required ClaimsPrincipal CurrentPrincipal { get; init; }
+
+    /// <summary>
+    /// The external provider ID (IdP sub claim) for OIDC users. Null for OTP users.
+    /// When present, the handler looks up the user by ExternalProviderId instead of email
+    /// and preserves IAL from JWT claims instead of reading from DB.
+    /// </summary>
+    public string? ExternalProviderId { get; set; }
 }
 

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -39,22 +39,14 @@ public class RefreshTokenCommandHandler(
 
         try
         {
-            User? user;
-            if (!string.IsNullOrEmpty(command.ExternalProviderId))
-            {
-                // OIDC user — look up by IdP subject, not email
-                user = await userRepository.GetUserByExternalIdAsync(
-                    command.ExternalProviderId, cancellationToken);
-            }
-            else
-            {
-                // OTP user — look up by email (existing behavior)
-                user = await userRepository.GetUserByEmailAsync(command.Email, cancellationToken);
-            }
+            // Look up by our internal user ID (from the JWT sub claim), which is
+            // uniform across OIDC and OTP users.
+            var user = await userRepository.GetUserByIdAsync(command.UserId, cancellationToken);
 
             if (user == null)
             {
-                logger.LogWarning("Token refresh attempted for non-existent user");
+                logger.LogWarning(
+                    "Token refresh attempted for non-existent UserId {UserId}", command.UserId);
                 return Result<string>.PreconditionFailed(
                     PreconditionFailedReason.NotFound, "User not found.");
             }
@@ -78,7 +70,7 @@ public class RefreshTokenCommandHandler(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error refreshing token");
+            logger.LogError(ex, "Error refreshing token for UserId {UserId}", command.UserId);
             return Result<string>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "An error occurred while refreshing the authentication token.");

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -37,16 +37,25 @@ public class RefreshTokenCommandHandler(
             return Result<string>.ValidationFailed(validationFailedResult.Errors);
         }
 
+        // The user ID lives in the principal's sub claim. Missing or malformed means
+        // the caller isn't properly authenticated — reject rather than continuing.
+        var userId = command.CurrentPrincipal.GetUserId();
+        if (userId == null)
+        {
+            logger.LogWarning("Token refresh rejected: principal missing or invalid sub claim");
+            return Result<string>.PreconditionFailed(
+                PreconditionFailedReason.NotFound, "User not found.");
+        }
+
         try
         {
-            // Look up by our internal user ID (from the JWT sub claim), which is
-            // uniform across OIDC and OTP users.
-            var user = await userRepository.GetUserByIdAsync(command.UserId, cancellationToken);
+            // Look up by our internal user ID — uniform across OIDC and OTP users.
+            var user = await userRepository.GetUserByIdAsync(userId.Value, cancellationToken);
 
             if (user == null)
             {
                 logger.LogWarning(
-                    "Token refresh attempted for non-existent UserId {UserId}", command.UserId);
+                    "Token refresh attempted for non-existent UserId {UserId}", userId);
                 return Result<string>.PreconditionFailed(
                     PreconditionFailedReason.NotFound, "User not found.");
             }
@@ -70,7 +79,7 @@ public class RefreshTokenCommandHandler(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error refreshing token for UserId {UserId}", command.UserId);
+            logger.LogError(ex, "Error refreshing token for UserId {UserId}", userId);
             return Result<string>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "An error occurred while refreshing the authentication token.");

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Core.Utilities;
@@ -29,27 +30,38 @@ public class RefreshTokenCommandHandler(
     public async Task<Result<string>> Handle(RefreshTokenCommand command, CancellationToken cancellationToken = default)
     {
         var validationResult = await validator.Validate(command, cancellationToken);
-
         if (validationResult is ValidationFailedResult validationFailedResult)
         {
-            logger.LogWarning("Token refresh validation failed for email {Email}: {Errors}",
-                command.Email,
+            logger.LogWarning("Token refresh validation failed: {Errors}",
                 string.Join(", ", validationFailedResult.Errors.Select(e => $"{e.Key}: {e.Message}")));
             return Result<string>.ValidationFailed(validationFailedResult.Errors);
         }
 
         try
         {
-            var user = await userRepository.GetUserByEmailAsync(command.Email, cancellationToken);
+            User? user;
+            if (!string.IsNullOrEmpty(command.ExternalProviderId))
+            {
+                // OIDC user — look up by IdP subject, not email
+                user = await userRepository.GetUserByExternalIdAsync(
+                    command.ExternalProviderId, cancellationToken);
+            }
+            else
+            {
+                // OTP user — look up by email (existing behavior)
+                user = await userRepository.GetUserByEmailAsync(command.Email, cancellationToken);
+            }
 
             if (user == null)
             {
-                logger.LogWarning("Token refresh attempted for non-existent user {Email}", command.Email);
+                logger.LogWarning("Token refresh attempted for non-existent user");
                 return Result<string>.PreconditionFailed(
-                    PreconditionFailedReason.NotFound,
-                    "User not found.");
+                    PreconditionFailedReason.NotFound, "User not found.");
             }
 
+            // Pass all existing JWT claims through — for OIDC users, this preserves
+            // IAL and other IdP-derived claims. For OTP users, GenerateToken will
+            // prefer user object values (from DB) over these claims.
             var additionalClaims = command.CurrentPrincipal.Claims
                 .DistinctBy(c => c.Type)
                 .ToDictionary(c => c.Type, c => c.Value);
@@ -59,16 +71,14 @@ public class RefreshTokenCommandHandler(
                 command.CurrentPrincipal.FindFirst("phone")?.Value
                 ?? command.CurrentPrincipal.FindFirst("phone_number")?.Value);
             logger.LogInformation(
-                "Token refreshed successfully for email {Email} with IAL level {IalLevel}, Phone={MaskedPhone}",
-                command.Email,
-                user.IalLevel,
-                maskedPhone);
+                "Token refreshed successfully for UserId {UserId}, Phone={MaskedPhone}",
+                user.Id, maskedPhone);
 
             return Result<string>.Success(token);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error refreshing token for email {Email}", command.Email);
+            logger.LogError(ex, "Error refreshing token");
             return Result<string>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "An error occurred while refreshing the authentication token.");

--- a/src/SEBT.Portal.UseCases/Auth/ValidateOtp/ValidateOtpCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/ValidateOtp/ValidateOtpCommandHandler.cs
@@ -70,23 +70,23 @@ namespace SEBT.Portal.UseCases.Auth
                 if (isNewUser)
                 {
                     logger.LogInformation(
-                        "New user authenticated via OTP for email {Email} with IAL level {IalLevel} and co-loaded status {IsCoLoaded}",
-                        command.Email,
+                        "New user authenticated via OTP: UserId {UserId} with IAL level {IalLevel} and co-loaded status {IsCoLoaded}",
+                        user.Id,
                         user.IalLevel,
                         user.IsCoLoaded);
                 }
                 else
                 {
                     logger.LogInformation(
-                        "Returning user authenticated via OTP for email {Email} with IAL level {IalLevel} and co-loaded status {IsCoLoaded}",
-                        command.Email,
+                        "Returning user authenticated via OTP: UserId {UserId} with IAL level {IalLevel} and co-loaded status {IsCoLoaded}",
+                        user.Id,
                         user.IalLevel,
                         user.IsCoLoaded);
                 }
 
                 logger.LogInformation(
-                    "OTP validated successfully and JWT token generated for email {Email} with co-loaded status {IsCoLoaded}",
-                    command.Email,
+                    "OTP validated successfully and JWT token generated: UserId {UserId} with co-loaded status {IsCoLoaded}",
+                    user.Id,
                     user.IsCoLoaded);
                 return Result<string>.Success(token);
             }

--- a/src/SEBT.Portal.UseCases/IdProofing/StartChallenge/StartChallengeCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/StartChallenge/StartChallengeCommandHandler.cs
@@ -111,11 +111,17 @@ public class StartChallengeCommandHandler(
                 PreconditionFailedReason.NotFound, "User not found.");
         }
 
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            return Result<StartChallengeResponse>.PreconditionFailed(
+                PreconditionFailedReason.Conflict, "Email is required for document verification.");
+        }
+
         Result<SocureDocvSession> sessionResult;
         try
         {
             sessionResult = await socureClient.StartDocvSessionAsync(
-                command.UserId, user.Email, cancellationToken);
+                command.UserId, user.Email!, cancellationToken);
         }
         catch (NotSupportedException)
         {

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -50,6 +50,15 @@ public class SubmitIdProofingCommandHandler(
                 PreconditionFailedReason.NotFound, "User not found.");
         }
 
+        // Socure requires an email address. OIDC users who reach this point without
+        // an email cannot proceed with ID proofing.
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            logger.LogWarning("User {UserId} has no email, cannot submit ID proofing", command.UserId);
+            return Result<SubmitIdProofingResponse>.PreconditionFailed(
+                PreconditionFailedReason.Conflict, "Email is required for ID proofing.");
+        }
+
         // Max attempts reached → off-board (3-attempt cap)
         const int maxAttempts = 3;
         if (user.IdProofingAttemptCount >= maxAttempts)

--- a/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -43,6 +43,24 @@ public class AuthControllerTests
         };
     }
 
+    /// <summary>
+    /// Sets up the authenticated user with a numeric sub claim (the portal JWT format)
+    /// plus an optional email claim for GetAuthorizationStatus tests.
+    /// </summary>
+    private void SetupAuthenticatedUserWithSub(int userId, string? email = null)
+    {
+        var claims = new List<Claim> { new Claim("sub", userId.ToString()) };
+        if (email != null)
+        {
+            claims.Add(new Claim("email", email));
+        }
+        var identity = new ClaimsIdentity(claims, "Test");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+    }
+
     [Fact]
     public void GetAuthorizationStatus_WhenUserIsAuthenticated_ReturnsOkWithEmail()
     {
@@ -111,11 +129,10 @@ public class AuthControllerTests
     }
 
     [Fact]
-    public void GetAuthorizationStatus_WhenEmailClaimIsMissing_UsesSubClaim()
+    public void GetAuthorizationStatus_WhenEmailClaimIsMissing_ReturnsNullEmail()
     {
-        // Arrange
-        var email = "user@example.com";
-        SetupAuthenticatedUser(email, "sub");
+        // Arrange: portal JWT has sub (user ID) but no email claim — OIDC users without stored email
+        SetupAuthenticatedUserWithSub(userId: 1);
 
         // Act
         var result = _controller.GetAuthorizationStatus();
@@ -125,19 +142,19 @@ public class AuthControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsType<AuthorizationStatusResponse>(okResult.Value);
         Assert.True(response.IsAuthorized);
-        Assert.Equal(email, response.Email);
+        Assert.Null(response.Email);
     }
 
     [Fact]
     public async Task RefreshToken_WhenSuccess_ReturnsNoContentAndSetsAuthCookie()
     {
-        // Arrange
-        var email = "user@example.com";
-        var expectedToken = "refreshed.jwt.token";
-        SetupAuthenticatedUser(email);
+        // Arrange — controller reads UserId from the sub claim (portal JWT format: sub = user.Id)
+        const int userId = 1;
+        const string expectedToken = "refreshed.jwt.token";
+        SetupAuthenticatedUserWithSub(userId, email: "user@example.com");
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email))
+        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId))
             .Returns(Result<string>.Success(expectedToken));
 
         // Act
@@ -148,14 +165,14 @@ public class AuthControllerTests
         var setCookie = _controller.Response.Headers["Set-Cookie"].ToString();
         Assert.Contains($"{AuthCookies.AuthCookieName}={expectedToken}", setCookie);
         Assert.Contains("httponly", setCookie, StringComparison.OrdinalIgnoreCase);
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email));
+        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId));
     }
 
     [Fact]
-    public async Task RefreshToken_WhenEmailCannotBeExtracted_ReturnsUnauthorized()
+    public async Task RefreshToken_WhenSubClaimMissing_ReturnsUnauthorized()
     {
-        // Arrange
-        var claims = new List<Claim>(); // No email claim
+        // Arrange — no sub claim means the controller cannot identify the user
+        var claims = new List<Claim>(); // No sub claim
         var identity = new ClaimsIdentity(claims, "Test");
         var principal = new ClaimsPrincipal(identity);
         _controller.ControllerContext = new ControllerContext
@@ -179,11 +196,11 @@ public class AuthControllerTests
     public async Task RefreshToken_WhenUserNotFound_ReturnsNotFound()
     {
         // Arrange
-        var email = "nonexistent@example.com";
-        SetupAuthenticatedUser(email);
+        const int userId = 999;
+        SetupAuthenticatedUserWithSub(userId);
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email))
+        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId))
             .Returns(Result<string>.PreconditionFailed(
                 PreconditionFailedReason.NotFound,
                 "User not found."));
@@ -201,16 +218,16 @@ public class AuthControllerTests
     [Fact]
     public async Task RefreshToken_WhenValidationFails_ReturnsBadRequestWithErrors()
     {
-        // Arrange
-        var email = "invalid-email";
-        SetupAuthenticatedUser(email);
+        // Arrange — handler returns a validation failure (e.g. some business rule violation)
+        const int userId = 1;
+        SetupAuthenticatedUserWithSub(userId);
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
         var validationErrors = new[]
         {
-            new ValidationError("Email", "Invalid email format.")
+            new ValidationError("UserId", "User ID must be a positive integer.")
         };
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email))
+        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
             .Returns(Result<string>.ValidationFailed(validationErrors));
 
         // Act
@@ -230,11 +247,11 @@ public class AuthControllerTests
     public async Task RefreshToken_WhenDependencyFails_ReturnsBadRequest()
     {
         // Arrange
-        var email = "user@example.com";
-        SetupAuthenticatedUser(email);
+        const int userId = 1;
+        SetupAuthenticatedUserWithSub(userId);
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email))
+        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId))
             .Returns(Result<string>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "An error occurred while refreshing the authentication token."));
@@ -250,11 +267,11 @@ public class AuthControllerTests
     }
 
     [Fact]
-    public async Task RefreshToken_ExtractsEmailFromEmailClaim()
+    public async Task RefreshToken_ExtractsUserIdFromSubClaim()
     {
-        // Arrange
-        var email = "user@example.com";
-        SetupAuthenticatedUser(email);
+        // Arrange — portal JWT always has sub = user.Id (integer string)
+        const int userId = 42;
+        SetupAuthenticatedUserWithSub(userId);
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
         handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
@@ -264,97 +281,27 @@ public class AuthControllerTests
         var result = await _controller.RefreshToken(handlerMock);
 
         // Assert
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email));
+        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId));
     }
 
     [Fact]
-    public async Task RefreshToken_ExtractsEmailFromSubClaim_WhenEmailClaimMissing()
+    public async Task RefreshToken_WhenSubClaimIsNotAnInteger_ReturnsUnauthorized()
     {
-        // Arrange
-        var email = "user@example.com";
-        SetupAuthenticatedUser(email, "sub");
-
-        var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
-            .Returns(Result<string>.Success("token"));
-
-        // Act
-        var result = await _controller.RefreshToken(handlerMock);
-
-        // Assert
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email));
-    }
-
-    [Fact]
-    public async Task RefreshToken_ExtractsEmailFromIdentityName_WhenOtherClaimsMissing()
-    {
-        // Arrange
-        var email = "user@example.com";
-        var identity = new ClaimsIdentity("Test");
-        identity.AddClaim(new Claim(ClaimTypes.Name, email));
-        var principal = new ClaimsPrincipal(identity);
+        // Arrange — OIDC-style sub (non-integer) is rejected; portal JWT sub is always user.Id
+        var claims = new List<Claim> { new Claim("sub", "not-an-integer") };
+        var identity = new ClaimsIdentity(claims, "Test");
         _controller.ControllerContext = new ControllerContext
         {
-            HttpContext = new DefaultHttpContext { User = principal }
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
         };
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
-            .Returns(Result<string>.Success("token"));
 
         // Act
         var result = await _controller.RefreshToken(handlerMock);
 
         // Assert
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email));
-    }
-
-    [Fact]
-    public async Task RefreshToken_ExtractsEmailFromShortEmailClaim_WhenJwtHandlerMappedClaims()
-    {
-        // Arrange: JWT Bearer maps inbound claims to short names; principal may have "email" not ClaimTypes.Email
-        var email = "user@example.com";
-        var identity = new ClaimsIdentity("Test");
-        identity.AddClaim(new Claim("email", email));
-        var principal = new ClaimsPrincipal(identity);
-        _controller.ControllerContext = new ControllerContext
-        {
-            HttpContext = new DefaultHttpContext { User = principal }
-        };
-
-        var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
-            .Returns(Result<string>.Success("token"));
-
-        // Act
-        var result = await _controller.RefreshToken(handlerMock);
-
-        // Assert
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email));
-    }
-
-    [Fact]
-    public async Task RefreshToken_ExtractsEmailFromSubClaim_WhenJwtHandlerMappedClaims()
-    {
-        // Arrange: OIDC tokens often use "sub" as the user identifier; ensure we accept it for refresh
-        var email = "user@example.com";
-        var identity = new ClaimsIdentity("Test");
-        identity.AddClaim(new Claim("sub", email));
-        var principal = new ClaimsPrincipal(identity);
-        _controller.ControllerContext = new ControllerContext
-        {
-            HttpContext = new DefaultHttpContext { User = principal }
-        };
-
-        var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
-            .Returns(Result<string>.Success("token"));
-
-        // Act
-        var result = await _controller.RefreshToken(handlerMock);
-
-        // Assert
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.Email == email));
+        Assert.IsType<UnauthorizedObjectResult>(result);
+        await handlerMock.DidNotReceive().Handle(Arg.Any<RefreshTokenCommand>());
     }
 }
-

--- a/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -9,6 +9,7 @@ using SEBT.Portal.Api.Models;
 using SEBT.Portal.Api.Services;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.Kernel.Results;
 using SEBT.Portal.UseCases.Auth;
@@ -154,7 +155,7 @@ public class AuthControllerTests
         SetupAuthenticatedUserWithSub(userId, email: "user@example.com");
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId))
+        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.CurrentPrincipal.GetUserId() == userId))
             .Returns(Result<string>.Success(expectedToken));
 
         // Act
@@ -165,7 +166,7 @@ public class AuthControllerTests
         var setCookie = _controller.Response.Headers["Set-Cookie"].ToString();
         Assert.Contains($"{AuthCookies.AuthCookieName}={expectedToken}", setCookie);
         Assert.Contains("httponly", setCookie, StringComparison.OrdinalIgnoreCase);
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId));
+        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.CurrentPrincipal.GetUserId() == userId));
     }
 
     [Fact]
@@ -200,7 +201,7 @@ public class AuthControllerTests
         SetupAuthenticatedUserWithSub(userId);
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId))
+        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.CurrentPrincipal.GetUserId() == userId))
             .Returns(Result<string>.PreconditionFailed(
                 PreconditionFailedReason.NotFound,
                 "User not found."));
@@ -251,7 +252,7 @@ public class AuthControllerTests
         SetupAuthenticatedUserWithSub(userId);
 
         var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId))
+        handlerMock.Handle(Arg.Is<RefreshTokenCommand>(c => c.CurrentPrincipal.GetUserId() == userId))
             .Returns(Result<string>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "An error occurred while refreshing the authentication token."));
@@ -281,7 +282,7 @@ public class AuthControllerTests
         var result = await _controller.RefreshToken(handlerMock);
 
         // Assert
-        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.UserId == userId));
+        await handlerMock.Received(1).Handle(Arg.Is<RefreshTokenCommand>(c => c.CurrentPrincipal.GetUserId() == userId));
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
@@ -260,7 +260,8 @@ public class OidcControllerTests
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com" };
-        _userRepository.GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((user, false));
 
         const string portalJwt = "portal-jwt-returned-by-service";
@@ -293,7 +294,7 @@ public class OidcControllerTests
         var callbackToken = CreateValidCallbackToken(signingKey, email: "new-user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken, IsStepUp: true);
 
-        _userRepository.GetUserByEmailAsync("new-user@example.com", Arg.Any<CancellationToken>())
+        _userRepository.GetUserByExternalIdAsync("test-sub-12345", Arg.Any<CancellationToken>())
             .Returns((User?)null);
 
         var result = await _controller.CompleteLogin(body, CancellationToken.None);
@@ -306,7 +307,8 @@ public class OidcControllerTests
             "Step-up requires an existing session. Please sign in again.",
             errorProp.GetValue(badRequest.Value) as string);
 
-        await _userRepository.DidNotReceive().GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _userRepository.DidNotReceive().GetOrCreateUserByExternalIdAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         await _userRepository.DidNotReceive().UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
@@ -321,10 +323,8 @@ public class OidcControllerTests
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com" };
-        _userRepository.GetUserByEmailAsync("user@example.com", Arg.Any<CancellationToken>())
+        _userRepository.GetUserByExternalIdAsync("test-sub-12345", Arg.Any<CancellationToken>())
             .Returns(user);
-        _userRepository.UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
 
         const string portalJwt = "portal-jwt-returned-by-service";
         _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
@@ -355,10 +355,8 @@ public class OidcControllerTests
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com" };
-        _userRepository.GetUserByEmailAsync("user@example.com", Arg.Any<CancellationToken>())
+        _userRepository.GetUserByExternalIdAsync("test-sub-12345", Arg.Any<CancellationToken>())
             .Returns(user);
-        _userRepository.UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
 
         _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
             .Returns("portal-jwt");
@@ -407,7 +405,8 @@ public class OidcControllerTests
         var body = new CompleteLoginRequest(CoStateKey, callbackToken, IsStepUp: true);
 
         var user = new User { Id = 1, Email = "user@example.com" };
-        _userRepository.GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((user, false));
         _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
             .Returns("portal-jwt");
@@ -417,9 +416,11 @@ public class OidcControllerTests
         // Should succeed (non-step-up path), NOT the step-up path
         Assert.IsType<OkObjectResult>(result);
 
-        // The non-step-up path calls GetOrCreateUserAsync, NOT GetUserByEmailAsync
-        await _userRepository.Received(1).GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await _userRepository.DidNotReceive().GetUserByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        // The non-step-up path calls GetOrCreateUserByExternalIdAsync, NOT GetUserByExternalIdAsync
+        await _userRepository.Received(1).GetOrCreateUserByExternalIdAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _userRepository.DidNotReceive().GetUserByExternalIdAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     #region OIDC verification claim reconciliation
@@ -483,7 +484,7 @@ public class OidcControllerTests
     }
 
     [Fact]
-    public async Task CompleteLogin_WhenOidcClaimsContainFreshVerification_UpdatesUserToIAL1plus()
+    public async Task CompleteLogin_WhenOidcClaimsContainFreshVerification_SetsIalInClaimsNotDb()
     {
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
         _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
@@ -494,27 +495,36 @@ public class OidcControllerTests
         var verificationDate = DateTime.UtcNow.AddDays(-30).ToString("o");
         var callbackToken = CreateCallbackTokenWithClaims(signingKey,
             new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
             new Claim("socureIdVerificationLevel", "1.5"),
             new Claim("socureIdVerificationDate", verificationDate));
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
-        _userRepository.GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((user, false));
-        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+
+        IReadOnlyDictionary<string, string>? capturedClaims = null;
+        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Do<IReadOnlyDictionary<string, string>?>(c => capturedClaims = c))
             .Returns("portal-jwt");
 
         await controller.CompleteLogin(body, CancellationToken.None);
 
-        // User should have been updated to IAL1plus
-        await _userRepository.Received().UpdateUserAsync(
-            Arg.Is<User>(u => u.IalLevel == UserIalLevel.IAL1plus
-                           && u.IdProofingStatus == IdProofingStatus.Completed),
-            Arg.Any<CancellationToken>());
+        // IAL should be passed in additionalClaims, not persisted to DB
+        Assert.NotNull(capturedClaims);
+        Assert.Equal("1plus", capturedClaims![JwtClaimTypes.Ial]);
+        Assert.Equal(
+            ((int)IdProofingStatus.Completed).ToString(),
+            capturedClaims[JwtClaimTypes.IdProofingStatus]);
+
+        // DB should NOT have been updated
+        await _userRepository.DidNotReceive().UpdateUserAsync(
+            Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task CompleteLogin_WhenOidcVerificationExpired_ResetsUserToIAL1()
+    public async Task CompleteLogin_WhenOidcVerificationExpired_SetsExpiredIalInClaims()
     {
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
         _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
@@ -527,27 +537,36 @@ public class OidcControllerTests
         var verificationDate = DateTime.UtcNow.AddYears(-2).ToString("o");
         var callbackToken = CreateCallbackTokenWithClaims(signingKey,
             new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
             new Claim("socureIdVerificationLevel", "1.5"),
             new Claim("socureIdVerificationDate", verificationDate));
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com", IalLevel = UserIalLevel.IAL1plus };
-        _userRepository.GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((user, false));
-        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+
+        IReadOnlyDictionary<string, string>? capturedClaims = null;
+        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Do<IReadOnlyDictionary<string, string>?>(c => capturedClaims = c))
             .Returns("portal-jwt");
 
         await controller.CompleteLogin(body, CancellationToken.None);
 
-        // User should have been reset to IAL1 with Expired status
-        await _userRepository.Received().UpdateUserAsync(
-            Arg.Is<User>(u => u.IalLevel == UserIalLevel.IAL1
-                           && u.IdProofingStatus == IdProofingStatus.Expired),
-            Arg.Any<CancellationToken>());
+        // Expired verification: IAL should be "1" with Expired status in claims
+        Assert.NotNull(capturedClaims);
+        Assert.Equal("1", capturedClaims![JwtClaimTypes.Ial]);
+        Assert.Equal(
+            ((int)IdProofingStatus.Expired).ToString(),
+            capturedClaims[JwtClaimTypes.IdProofingStatus]);
+
+        // DB should NOT have been updated
+        await _userRepository.DidNotReceive().UpdateUserAsync(
+            Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task CompleteLogin_WhenNoVerificationClaims_DoesNotChangeIal()
+    public async Task CompleteLogin_WhenNoVerificationClaims_SetsIal1InClaims()
     {
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
         _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
@@ -560,17 +579,144 @@ public class OidcControllerTests
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
-        _userRepository.GetOrCreateUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((user, false));
+
+        IReadOnlyDictionary<string, string>? capturedClaims = null;
+        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Do<IReadOnlyDictionary<string, string>?>(c => capturedClaims = c))
+            .Returns("portal-jwt");
+
+        await controller.CompleteLogin(body, CancellationToken.None);
+
+        // No verification claims → IAL1 default in additionalClaims
+        Assert.NotNull(capturedClaims);
+        Assert.Equal("1", capturedClaims![JwtClaimTypes.Ial]);
+
+        // DB should NOT have been updated
+        await _userRepository.DidNotReceive().UpdateUserAsync(
+            Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// CompleteLogin uses the sub claim (ExternalProviderId) for user lookup and passes
+    /// email as a migration hint to GetOrCreateUserByExternalIdAsync.
+    /// </summary>
+    [Fact]
+    public async Task CompleteLogin_WhenValidOidcLogin_LooksUpUserByExternalProviderId()
+    {
+        const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+        var controller = CreateControllerWithTranslator();
+        SetupPreAuthSessionForController(controller);
+
+        var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "oidc-sub-abc123"));
+        var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+        var user = new User { Id = 1, Email = "user@example.com" };
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                "oidc-sub-abc123", "user@example.com", Arg.Any<CancellationToken>())
+            .Returns((user, false));
+        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+            .Returns("portal-jwt");
+
+        var result = await controller.CompleteLogin(body, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+
+        // Should have been called with the exact sub and email values
+        await _userRepository.Received(1).GetOrCreateUserByExternalIdAsync(
+            "oidc-sub-abc123", "user@example.com", Arg.Any<CancellationToken>());
+
+        // Should NOT use the old email-based lookup
+        await _userRepository.DidNotReceive().GetOrCreateUserAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _userRepository.DidNotReceive().GetUserByEmailAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// CompleteLogin does NOT persist IAL to the database — verification claims
+    /// are injected into additionalClaims for JwtTokenService to pick up.
+    /// </summary>
+    [Fact]
+    public async Task CompleteLogin_WhenVerificationPresent_DoesNotPersistIalToDb()
+    {
+        const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+        var controller = CreateControllerWithTranslator();
+        SetupPreAuthSessionForController(controller);
+
+        var verificationDate = DateTime.UtcNow.AddDays(-30).ToString("o");
+        var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
+            new Claim("socureIdVerificationLevel", "1.5"),
+            new Claim("socureIdVerificationDate", verificationDate));
+        var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+        var user = new User { Id = 1, Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns((user, false));
         _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
             .Returns("portal-jwt");
 
         await controller.CompleteLogin(body, CancellationToken.None);
 
-        // No verification claims → no IAL reconciliation update
-        // Only the initial IAL1 bump may have been called (user is already IAL1)
+        // UpdateUserAsync should NEVER be called — IAL is in claims, not DB
         await _userRepository.DidNotReceive().UpdateUserAsync(
             Arg.Any<User>(), Arg.Any<CancellationToken>());
+
+        // The user object's IAL should remain untouched (IAL1, not IAL1plus)
+        Assert.Equal(UserIalLevel.IAL1, user.IalLevel);
+    }
+
+    /// <summary>
+    /// CompleteLogin passes IAL from verification claims into additionalClaims
+    /// so that GenerateToken includes them in the JWT.
+    /// </summary>
+    [Fact]
+    public async Task CompleteLogin_WhenVerificationPresent_PassesIalInAdditionalClaimsToGenerateToken()
+    {
+        const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+        var controller = CreateControllerWithTranslator();
+        SetupPreAuthSessionForController(controller);
+
+        var verificationDate = DateTime.UtcNow.AddDays(-30).ToString("o");
+        var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
+            new Claim("socureIdVerificationLevel", "1.5"),
+            new Claim("socureIdVerificationDate", verificationDate));
+        var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+        var user = new User { Id = 1, Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
+        _userRepository.GetOrCreateUserByExternalIdAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((user, false));
+
+        IReadOnlyDictionary<string, string>? capturedClaims = null;
+        _jwtService.GenerateToken(
+                Arg.Any<User>(),
+                Arg.Do<IReadOnlyDictionary<string, string>?>(c => capturedClaims = c))
+            .Returns("portal-jwt");
+
+        await controller.CompleteLogin(body, CancellationToken.None);
+
+        // Verify IAL claims were passed to GenerateToken
+        Assert.NotNull(capturedClaims);
+        Assert.Equal("1plus", capturedClaims![JwtClaimTypes.Ial]);
+        Assert.Equal(
+            ((int)IdProofingStatus.Completed).ToString(),
+            capturedClaims[JwtClaimTypes.IdProofingStatus]);
+        Assert.True(capturedClaims.ContainsKey(JwtClaimTypes.IdProofingCompletedAt));
     }
 
     #endregion
@@ -578,11 +724,11 @@ public class OidcControllerTests
     /// <summary>Callback token issuer/audience must match <c>Oidc:CallbackRedirectUri</c> (trimmed).</summary>
     private const string TestCallbackTokenAudience = "http://localhost:3000/callback";
 
-    private static string CreateValidCallbackToken(string signingKey, string email)
+    private static string CreateValidCallbackToken(string signingKey, string email, string sub = "test-sub-12345")
     {
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var claims = new List<Claim> { new("email", email) };
+        var claims = new List<Claim> { new("email", email), new("sub", sub) };
         var token = new JwtSecurityToken(
             issuer: TestCallbackTokenAudience,
             audience: TestCallbackTokenAudience,

--- a/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
@@ -319,7 +319,13 @@ public class OidcControllerTests
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
         _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
 
-        var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
+        // Step-up requires verification claims from the IdP — step-up exists to obtain them
+        var verificationDate = DateTime.UtcNow.AddDays(-1).ToString("o");
+        var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
+            new Claim("socureIdVerificationLevel", "1.5"),
+            new Claim("socureIdVerificationDate", verificationDate));
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com" };
@@ -351,7 +357,12 @@ public class OidcControllerTests
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
         _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
 
-        var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
+        var verificationDate = DateTime.UtcNow.AddDays(-1).ToString("o");
+        var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
+            new Claim("socureIdVerificationLevel", "1.5"),
+            new Claim("socureIdVerificationDate", verificationDate));
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
 
         var user = new User { Id = 1, Email = "user@example.com" };
@@ -366,6 +377,66 @@ public class OidcControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsType<CompleteLoginResponse>(okResult.Value);
         Assert.Null(response.ReturnUrl);
+    }
+
+    /// <summary>
+    /// Step-up IAL comes from the IdP's verification claim — when the IdP asserts IAL2,
+    /// the portal JWT must carry "2", not a hardcoded "1plus".
+    /// </summary>
+    [Fact]
+    public async Task CompleteLogin_WhenStepUpAndIdpAssertsIal2_PassesIal2InAdditionalClaims()
+    {
+        SetupPreAuthSession(isStepUp: true);
+        const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+        var verificationDate = DateTime.UtcNow.AddDays(-1).ToString("o");
+        var callbackToken = CreateCallbackTokenWithClaims(signingKey,
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "test-sub-12345"),
+            new Claim("socureIdVerificationLevel", "2"),
+            new Claim("socureIdVerificationDate", verificationDate));
+        var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+        var user = new User { Id = 1 };
+        _userRepository.GetUserByExternalIdAsync("test-sub-12345", Arg.Any<CancellationToken>())
+            .Returns(user);
+        _jwtService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>())
+            .Returns("portal-jwt");
+
+        var result = await _controller.CompleteLogin(body, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        _jwtService.Received(1).GenerateToken(
+            Arg.Any<User>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(c =>
+                c.ContainsKey(JwtClaimTypes.Ial) && c[JwtClaimTypes.Ial] == "2"));
+    }
+
+    /// <summary>
+    /// Step-up rejects when the IdP returned no verification claims. Silently defaulting
+    /// to a fixed IAL would risk downgrading the user's existing IAL.
+    /// </summary>
+    [Fact]
+    public async Task CompleteLogin_WhenStepUpAndNoVerificationClaims_Returns400()
+    {
+        SetupPreAuthSession(isStepUp: true);
+        const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
+        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+
+        // Callback token has email + sub but NO verification claims
+        var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
+        var body = new CompleteLoginRequest(CoStateKey, callbackToken);
+
+        var user = new User { Id = 1 };
+        _userRepository.GetUserByExternalIdAsync("test-sub-12345", Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        var result = await _controller.CompleteLogin(body, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        _jwtService.DidNotReceive().GenerateToken(
+            Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>?>());
     }
 
     /// <summary>

--- a/test/SEBT.Portal.Tests/Unit/Data/Entities/UserEntityTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Data/Entities/UserEntityTests.cs
@@ -12,7 +12,8 @@ public class UserEntityTests
         var entity = new UserEntity();
 
         // Assert
-        Assert.Equal(string.Empty, entity.Email);
+        Assert.Null(entity.Email);
+        Assert.Null(entity.ExternalProviderId);
         Assert.Equal(0, entity.IalLevel); // UserIalLevel.None
         Assert.Null(entity.IdProofingSessionId);
         Assert.Null(entity.IdProofingCompletedAt);

--- a/test/SEBT.Portal.Tests/Unit/Data/PortalDbContextTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Data/PortalDbContextTests.cs
@@ -374,8 +374,9 @@ public class PortalDbContextTests
     }
 
     [Fact]
-    public void Users_Email_ShouldBeRequired()
+    public void Users_Email_ShouldBeNullable()
     {
+        // Email is optional — OIDC users may not have an email address.
         // Arrange
         var options = new DbContextOptionsBuilder<PortalDbContext>()
             .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
@@ -389,7 +390,75 @@ public class PortalDbContextTests
 
         // Assert
         Assert.NotNull(emailProperty);
-        Assert.False(emailProperty!.IsNullable);
+        Assert.True(emailProperty!.IsNullable);
+    }
+
+    [Fact]
+    public void Users_Email_ShouldHaveFilteredUniqueIndex()
+    {
+        // The filtered index ensures uniqueness only among non-null emails,
+        // allowing multiple OIDC users with no email address.
+        // Arrange
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new PortalDbContext(options);
+
+        // Act
+        var entityType = context.Model.FindEntityType(typeof(UserEntity));
+        var emailIndex = entityType!.GetIndexes()
+            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0].Name == "Email");
+
+        // Assert
+        Assert.NotNull(emailIndex);
+        Assert.True(emailIndex!.IsUnique);
+        Assert.Equal("IX_Users_Email", emailIndex.GetDatabaseName());
+        Assert.Equal("[Email] IS NOT NULL", emailIndex.GetFilter());
+    }
+
+    [Fact]
+    public void Users_ExternalProviderId_ShouldBeNullableWithMaxLength255()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new PortalDbContext(options);
+
+        // Act
+        var entityType = context.Model.FindEntityType(typeof(UserEntity));
+        var property = entityType!.FindProperty("ExternalProviderId");
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.True(property!.IsNullable);
+        Assert.Equal(255, property.GetMaxLength());
+    }
+
+    [Fact]
+    public void Users_ExternalProviderId_ShouldHaveFilteredUniqueIndex()
+    {
+        // Filtered index allows multiple null ExternalProviderIds (email-auth users)
+        // while enforcing uniqueness across OIDC users.
+        // Arrange
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new PortalDbContext(options);
+
+        // Act
+        var entityType = context.Model.FindEntityType(typeof(UserEntity));
+        var index = entityType!.GetIndexes()
+            .FirstOrDefault(i => i.Properties.Count == 1 && i.Properties[0].Name == "ExternalProviderId");
+
+        // Assert
+        Assert.NotNull(index);
+        Assert.True(index!.IsUnique);
+        Assert.Equal("IX_Users_ExternalProviderId", index.GetDatabaseName());
+        Assert.Equal("[ExternalProviderId] IS NOT NULL", index.GetFilter());
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Filters/ResolveUserFilterTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Filters/ResolveUserFilterTests.cs
@@ -41,22 +41,22 @@ public class ResolveUserFilterTests
             controller: null!);
     }
 
-    private static ClaimsPrincipal CreateAuthenticatedUser(string email, string claimType = ClaimTypes.Email)
+    private static ClaimsPrincipal CreateAuthenticatedUserWithSub(string sub)
     {
-        var claims = new List<Claim> { new(claimType, email) };
+        var claims = new List<Claim> { new("sub", sub) };
         var identity = new ClaimsIdentity(claims, "Test");
         return new ClaimsPrincipal(identity);
     }
 
     [Fact]
-    public async Task OnActionExecutionAsync_ShouldSetUserId_WhenEmailClaimResolvesToUser()
+    public async Task OnActionExecutionAsync_ShouldSetUserId_WhenSubClaimResolvesToUser()
     {
         var filter = CreateFilter();
-        var user = new User { Id = 42, Email = "test@example.com" };
-        userRepository.GetUserByEmailAsync("test@example.com", Arg.Any<CancellationToken>())
+        var user = new User { Id = 123, Email = "test@example.com" };
+        userRepository.GetUserByIdAsync(123, Arg.Any<CancellationToken>())
             .Returns(user);
 
-        var context = CreateContext(CreateAuthenticatedUser("test@example.com"));
+        var context = CreateContext(CreateAuthenticatedUserWithSub("123"));
         var nextCalled = false;
 
         await filter.OnActionExecutionAsync(context, () =>
@@ -67,11 +67,11 @@ public class ResolveUserFilterTests
         });
 
         Assert.True(nextCalled);
-        Assert.Equal(42, context.HttpContext.Items[ResolveUserFilter.UserIdKey]);
+        Assert.Equal(123, context.HttpContext.Items[ResolveUserFilter.UserIdKey]);
     }
 
     [Fact]
-    public async Task OnActionExecutionAsync_ShouldReturn401_WhenNoEmailClaim()
+    public async Task OnActionExecutionAsync_ShouldReturn401_WhenNoSubClaim()
     {
         var filter = CreateFilter();
         var context = CreateContext(new ClaimsPrincipal(new ClaimsIdentity()));
@@ -84,13 +84,10 @@ public class ResolveUserFilterTests
     }
 
     [Fact]
-    public async Task OnActionExecutionAsync_ShouldReturn401_WhenUserNotFoundInDatabase()
+    public async Task OnActionExecutionAsync_ShouldReturn401_WhenSubClaimIsNotAnInteger()
     {
         var filter = CreateFilter();
-        userRepository.GetUserByEmailAsync("unknown@example.com", Arg.Any<CancellationToken>())
-            .Returns((User?)null);
-
-        var context = CreateContext(CreateAuthenticatedUser("unknown@example.com"));
+        var context = CreateContext(CreateAuthenticatedUserWithSub("notanumber"));
 
         await filter.OnActionExecutionAsync(context, () =>
             throw new InvalidOperationException("Next should not be called"));
@@ -100,24 +97,18 @@ public class ResolveUserFilterTests
     }
 
     [Fact]
-    public async Task OnActionExecutionAsync_ShouldFallBackToNameIdentifier_WhenEmailClaimMissing()
+    public async Task OnActionExecutionAsync_ShouldReturn401_WhenUserNotFoundInDatabase()
     {
         var filter = CreateFilter();
-        var user = new User { Id = 7, Email = "fallback@example.com" };
-        userRepository.GetUserByEmailAsync("fallback@example.com", Arg.Any<CancellationToken>())
-            .Returns(user);
+        userRepository.GetUserByIdAsync(999, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
 
-        var context = CreateContext(CreateAuthenticatedUser("fallback@example.com", ClaimTypes.NameIdentifier));
+        var context = CreateContext(CreateAuthenticatedUserWithSub("999"));
 
-        var nextCalled = false;
         await filter.OnActionExecutionAsync(context, () =>
-        {
-            nextCalled = true;
-            return Task.FromResult(new ActionExecutedContext(
-                context, new List<IFilterMetadata>(), controller: null!));
-        });
+            throw new InvalidOperationException("Next should not be called"));
 
-        Assert.True(nextCalled);
-        Assert.Equal(7, context.HttpContext.Items[ResolveUserFilter.UserIdKey]);
+        var result = Assert.IsType<UnauthorizedObjectResult>(context.Result);
+        Assert.NotNull(result);
     }
 }

--- a/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
@@ -47,7 +47,7 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         await context.SaveChangesAsync();
 
         // Act
-        var result = await repository.GetUserByEmailAsync(entity.Email);
+        var result = await repository.GetUserByEmailAsync(entity.Email!);
 
         // Assert
         Assert.NotNull(result);

--- a/test/SEBT.Portal.Tests/Unit/Services/DatabaseSeederTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/DatabaseSeederTests.cs
@@ -136,7 +136,10 @@ public class DatabaseSeederTests : IClassFixture<SqlServerTestFixture>
         // Assert
         var users = await context.Users.ToListAsync();
         Assert.All(users, user =>
-            Assert.Equal(user.Email, user.Email.ToLowerInvariant()));
+        {
+            Assert.NotNull(user.Email);
+            Assert.Equal(user.Email, user.Email!.ToLowerInvariant());
+        });
     }
 
     [Fact]
@@ -581,8 +584,9 @@ public class DatabaseSeederTests : IClassFixture<SqlServerTestFixture>
 
         foreach (var user in users)
         {
-            Assert.NotEmpty(user.Email);
-            Assert.Contains("@", user.Email);
+            Assert.NotNull(user.Email);
+            Assert.NotEmpty(user.Email!);
+            Assert.Contains("@", user.Email!);
             Assert.InRange(user.IalLevel, 0, 3); // Valid UserIalLevel range
             Assert.NotEqual(default(DateTime), user.CreatedAt);
             Assert.NotEqual(default(DateTime), user.UpdatedAt);
@@ -603,7 +607,10 @@ public class DatabaseSeederTests : IClassFixture<SqlServerTestFixture>
         // Assert - All emails should be lowercase
         var users = await context.Users.ToListAsync();
         Assert.All(users, user =>
-            Assert.Equal(user.Email, user.Email.ToLowerInvariant()));
+        {
+            Assert.NotNull(user.Email);
+            Assert.Equal(user.Email, user.Email!.ToLowerInvariant());
+        });
     }
 
     [Fact]
@@ -620,7 +627,10 @@ public class DatabaseSeederTests : IClassFixture<SqlServerTestFixture>
         // Assert - All emails should be lowercase
         var users = await context.Users.ToListAsync();
         Assert.All(users, user =>
-            Assert.Equal(user.Email, user.Email.ToLowerInvariant()));
+        {
+            Assert.NotNull(user.Email);
+            Assert.Equal(user.Email, user.Email!.ToLowerInvariant());
+        });
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Services/HouseholdIdentifierResolverTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/HouseholdIdentifierResolverTests.cs
@@ -46,31 +46,29 @@ public class HouseholdIdentifierResolverTests
         return new HouseholdIdentifierResolver(SnapshotFor(settings), userRepository, phoneOverride);
     }
 
-    private static ClaimsPrincipal CreatePrincipal(string email, string claimType = ClaimTypes.Email)
+    /// <summary>
+    /// Creates a principal with a sub claim matching the user's Id, plus any additional claims.
+    /// </summary>
+    private static ClaimsPrincipal CreatePrincipalForUser(User user, params Claim[] extraClaims)
     {
-        var claims = new List<Claim> { new Claim(claimType, email) };
-        var identity = new ClaimsIdentity(claims, "Test");
-        return new ClaimsPrincipal(identity);
-    }
-
-    private static ClaimsPrincipal CreatePrincipalWithNoEmail()
-    {
-        var identity = new ClaimsIdentity();
-        return new ClaimsPrincipal(identity);
+        var claims = new List<Claim> { new("sub", user.Id.ToString()) };
+        claims.AddRange(extraClaims);
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
     }
 
     /// <summary>
-    /// Creates a principal where email is only available via Identity.Name (no Email or NameIdentifier claims).
+    /// Creates a user with a positive Id using an object initializer, seeding any additional
+    /// properties via the customize action. GetUserId() requires Id > 0 to be non-null.
     /// </summary>
-    private static ClaimsPrincipal CreatePrincipalWithIdentityNameOnly(string email)
+    private static User CreateUser(int id, string email, Action<User>? customize = null)
     {
-        var claims = new List<Claim> { new Claim(ClaimTypes.Name, email) };
-        var identity = new ClaimsIdentity(claims, "Test");
-        return new ClaimsPrincipal(identity);
+        var user = new User { Id = id, Email = EmailNormalizer.Normalize(email) };
+        customize?.Invoke(user);
+        return user;
     }
 
     [Fact]
-    public async Task ResolveAsync_WhenNoEmailInClaims_ReturnsNull()
+    public async Task ResolveAsync_WhenNoSubClaim_ReturnsNull()
     {
         var settings = new StateHouseholdIdSettings
         {
@@ -78,63 +76,48 @@ public class HouseholdIdentifierResolverTests
         };
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipalWithNoEmail();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
 
         var result = await resolver.ResolveAsync(principal);
 
         Assert.Null(result);
-        await _userRepository.DidNotReceive().GetUserByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ResolveAsync_WhenEmailClaimIsWhitespace_ReturnsNull()
-    {
-        var settings = new StateHouseholdIdSettings
-        {
-            PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
-        };
-        var resolver = CreateResolver(_userRepository, settings);
-
-        var principal = CreatePrincipal("   ");
-
-        var result = await resolver.ResolveAsync(principal);
-
-        Assert.Null(result);
+        await _userRepository.DidNotReceive().GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ResolveAsync_WhenUserNotFound_ReturnsNull()
     {
+        var user = CreateUser(1, "user@example.com");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns((User?)null);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal("user@example.com");
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
         Assert.Null(result);
-        await _userRepository.Received(1).GetUserByEmailAsync(EmailNormalizer.Normalize("user@example.com"), Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ResolveAsync_WhenPrefersEmailAndUserHasEmail_ReturnsEmailIdentifier()
     {
         var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email);
+        var user = CreateUser(2, email);
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -146,17 +129,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPrefersPhoneAndUserHasPhone_ReturnsPhoneIdentifier()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Phone = "5551234567");
+        var user = CreateUser(3, "user@example.com", u => u.Phone = "5551234567");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -172,17 +154,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenSettingsHavePhoneOnly_ReturnsPhoneNotEmail()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Phone = "8185558437");
+        var user = CreateUser(4, "user@example.com", u => u.Phone = "8185558437");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -198,17 +179,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenSettingsHavePhoneOnlyAndUserHasNoPhone_ReturnsNull()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Phone = null);
+        var user = CreateUser(5, "user@example.com", u => u.Phone = null);
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -218,19 +198,18 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPhoneOverrideProviderReturnsValue_UsesOverrideOverJwtAndUser()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Phone = "5551234567");
+        var user = CreateUser(6, "user@example.com", u => u.Phone = "5551234567");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var overrideProvider = Substitute.For<IPhoneOverrideProvider>();
         overrideProvider.GetOverridePhone().Returns("8185558437");
         var resolver = CreateResolver(_userRepository, settings, overrideProvider);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -245,19 +224,18 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPhoneOverrideProviderReturnsNull_UsesUserOrClaimsInstead()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Phone = "5551234567");
+        var user = CreateUser(7, "user@example.com", u => u.Phone = "5551234567");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var overrideProvider = Substitute.For<IPhoneOverrideProvider>();
         overrideProvider.GetOverridePhone().Returns((string?)null);
         var resolver = CreateResolver(_userRepository, settings, overrideProvider);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -269,22 +247,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPrefersPhoneAndUserHasNoPhoneButClaimsHavePhone_ReturnsPhoneFromClaims()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Phone = null);
+        var user = CreateUser(8, "user@example.com", u => u.Phone = null);
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var claims = new List<Claim>
-        {
-            new Claim(ClaimTypes.Email, email),
-            new Claim("phone", "5559876543")
-        };
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+        var principal = CreatePrincipalForUser(user, new Claim("phone", "5559876543"));
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -296,17 +268,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPrefersSnapIdAndUserHasSnapId_ReturnsSnapIdIdentifier()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.SnapId = "SNAP-001");
+        var user = CreateUser(9, "user@example.com", u => u.SnapId = "SNAP-001");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.SnapId, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -318,17 +289,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPrefersTanfIdAndUserHasTanfId_ReturnsTanfIdIdentifier()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.TanfId = "TANF-001");
+        var user = CreateUser(10, "user@example.com", u => u.TanfId = "TANF-001");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.TanfId, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -341,17 +311,16 @@ public class HouseholdIdentifierResolverTests
     public async Task ResolveAsync_WhenPrefersSsnAndUserHasSsn_ReturnsSsnHashAsIs()
     {
         var hashedSsn = "A1B2C3D4E5F6789012345678901234567890ABCDEF1234567890ABCDEF123456";
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u => u.Ssn = hashedSsn);
+        var user = CreateUser(11, "user@example.com", u => u.Ssn = hashedSsn);
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Ssn, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -363,8 +332,7 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenFirstPreferredTypeIsEmpty_FallsThroughToNext()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u =>
+        var user = CreateUser(12, "user@example.com", u =>
         {
             u.Phone = null;
             u.SnapId = "SNAP-002";
@@ -373,11 +341,11 @@ public class HouseholdIdentifierResolverTests
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone, PreferredHouseholdIdType.SnapId, PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -389,17 +357,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPreferredHouseholdIdTypesIsNull_ThrowsInvalidOperationException()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email);
+        var user = CreateUser(13, "user@example.com");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = null!
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => resolver.ResolveAsync(principal));
@@ -411,17 +378,16 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenPreferredHouseholdIdTypesIsEmpty_ThrowsInvalidOperationException()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email);
+        var user = CreateUser(14, "user@example.com");
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = []
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
             () => resolver.ResolveAsync(principal));
@@ -433,8 +399,7 @@ public class HouseholdIdentifierResolverTests
     [Fact]
     public async Task ResolveAsync_WhenNoPreferredTypeHasValue_ReturnsNull()
     {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email, u =>
+        var user = CreateUser(15, "user@example.com", u =>
         {
             u.Phone = null;
             u.SnapId = null;
@@ -445,11 +410,11 @@ public class HouseholdIdentifierResolverTests
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Phone, PreferredHouseholdIdType.SnapId]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -457,63 +422,19 @@ public class HouseholdIdentifierResolverTests
     }
 
     [Fact]
-    public async Task ResolveAsync_WhenEmailFromNameIdentifierClaim_ResolvesCorrectly()
-    {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email);
-        var settings = new StateHouseholdIdSettings
-        {
-            PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
-        };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
-            .Returns(user);
-        var resolver = CreateResolver(_userRepository, settings);
-
-        var principal = CreatePrincipal(email, ClaimTypes.NameIdentifier);
-
-        var result = await resolver.ResolveAsync(principal);
-
-        Assert.NotNull(result);
-        Assert.Equal(PreferredHouseholdIdType.Email, result!.Type);
-        Assert.Equal(EmailNormalizer.Normalize(email), result.Value);
-    }
-
-    [Fact]
-    public async Task ResolveAsync_WhenEmailFromIdentityName_ResolvesCorrectly()
-    {
-        var email = "user@example.com";
-        var user = UserFactory.CreateUserWithEmail(email);
-        var settings = new StateHouseholdIdSettings
-        {
-            PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
-        };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
-            .Returns(user);
-        var resolver = CreateResolver(_userRepository, settings);
-
-        var principal = CreatePrincipalWithIdentityNameOnly(email);
-
-        var result = await resolver.ResolveAsync(principal);
-
-        Assert.NotNull(result);
-        Assert.Equal(PreferredHouseholdIdType.Email, result!.Type);
-        Assert.Equal(EmailNormalizer.Normalize(email), result.Value);
-    }
-
-    [Fact]
     public async Task ResolveAsync_NormalizesEmailToLowercase()
     {
         var email = "User@Example.COM";
-        var user = UserFactory.CreateUserWithEmail(EmailNormalizer.Normalize(email));
+        var user = CreateUser(16, email);
         var settings = new StateHouseholdIdSettings
         {
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
         };
-        _userRepository.GetUserByEmailAsync(EmailNormalizer.Normalize(email), Arg.Any<CancellationToken>())
+        _userRepository.GetUserByIdAsync(user.Id, Arg.Any<CancellationToken>())
             .Returns(user);
         var resolver = CreateResolver(_userRepository, settings);
 
-        var principal = CreatePrincipal(email);
+        var principal = CreatePrincipalForUser(user);
 
         var result = await resolver.ResolveAsync(principal);
 
@@ -529,7 +450,7 @@ public class HouseholdIdentifierResolverTests
             PreferredHouseholdIdTypes = [PreferredHouseholdIdType.Email]
         };
         var resolver = CreateResolver(settings);
-        var principal = CreatePrincipal("user@example.com");
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("sub", "99") }, "Test"));
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 

--- a/test/SEBT.Portal.Tests/Unit/Services/JwtTokenServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/JwtTokenServiceTests.cs
@@ -506,8 +506,8 @@ public class JwtTokenServiceTests
     [Fact]
     public void GenerateToken_WithAdditionalClaims_DoesNotDuplicateReservedClaims()
     {
-        // Arrange: Callback token may include "sub" and "email"; we must not add them again or JWT payload
-        // would have "sub": [a, b] which .NET's reader rejects
+        // Arrange: additionalClaims may include "sub" and "email"; they should override user values
+        // but each claim type must appear exactly once (no duplicates)
         var user = new User
         {
             Email = "user@example.com",
@@ -523,15 +523,15 @@ public class JwtTokenServiceTests
         // Act
         var token = _jwtTokenService.GenerateToken(user, additionalClaims);
 
-        // Assert: sub and email remain the portal values (from user); phone is added
+        // Assert: sub and email come from additionalClaims (override), each appears once; phone is added
         var handler = new JwtSecurityTokenHandler();
         var jsonToken = handler.ReadJwtToken(token);
         var subClaims = jsonToken.Claims.Where(c => c.Type == JwtRegisteredClaimNames.Sub).ToList();
         var emailClaims = jsonToken.Claims.Where(c => c.Type == ClaimTypes.Email || c.Type == "email").ToList();
         Assert.Single(subClaims);
-        Assert.Equal(user.Email, subClaims[0].Value);
+        Assert.Equal("idp-sub-123", subClaims[0].Value);
         Assert.Single(emailClaims);
-        Assert.Equal(user.Email, emailClaims[0].Value);
+        Assert.Equal("other@example.com", emailClaims[0].Value);
         Assert.Equal("+13035551234", jsonToken.Claims.FirstOrDefault(c => c.Type == "phone")?.Value);
     }
 
@@ -546,6 +546,171 @@ public class JwtTokenServiceTests
         var handler = new JwtSecurityTokenHandler();
         var jsonToken = handler.ReadJwtToken(token);
         Assert.Equal(user.Email, jsonToken.Claims.First(c => c.Type == JwtRegisteredClaimNames.Sub).Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenAdditionalClaimsContainEmail_UsesClaimsEmail()
+    {
+        // Arrange: OIDC user has no stored email; email comes from IdP claims
+        var user = new User { Id = 1, Email = null };
+        var claims = new Dictionary<string, string>
+        {
+            ["email"] = "oidc-user@example.com",
+            ["sub"] = "pingone-sub-123"
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user, claims);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var emailClaim = jwt.Claims.First(c => c.Type == ClaimTypes.Email);
+        Assert.Equal("oidc-user@example.com", emailClaim.Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenAdditionalClaimsContainIal_UsesClaimsIal()
+    {
+        // Arrange: OIDC user has stale IAL in DB; fresh IAL comes from IdP claims
+        var user = new User { Id = 1, IalLevel = UserIalLevel.None };
+        var claims = new Dictionary<string, string>
+        {
+            ["email"] = "user@example.com",
+            [JwtClaimTypes.Ial] = "1plus"
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user, claims);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var ialClaim = jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial);
+        Assert.Equal("1plus", ialClaim.Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenNoAdditionalClaims_UsesUserProperties()
+    {
+        // Arrange: OTP user — email and IAL come from the user object (DB values)
+        var user = new User
+        {
+            Id = 1,
+            Email = "otp-user@example.com",
+            IalLevel = UserIalLevel.IAL1plus
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        Assert.Equal("otp-user@example.com", jwt.Claims.First(c => c.Type == ClaimTypes.Email).Value);
+        Assert.Equal("1plus", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenAdditionalClaimsContainSub_UsesClaimsSub()
+    {
+        // Arrange: OIDC user — sub comes from IdP, not from user.Email
+        var user = new User { Id = 1, Email = null };
+        var claims = new Dictionary<string, string>
+        {
+            ["email"] = "oidc-user@example.com",
+            ["sub"] = "pingone-sub-456"
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user, claims);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var subClaim = jwt.Claims.First(c => c.Type == JwtRegisteredClaimNames.Sub);
+        Assert.Equal("pingone-sub-456", subClaim.Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenAdditionalClaimsContainIdProofingStatus_UsesClaimsValue()
+    {
+        // Arrange: OIDC user — ID proofing status comes from claims
+        var user = new User
+        {
+            Id = 1,
+            Email = null,
+            IdProofingStatus = IdProofingStatus.NotStarted
+        };
+        var claims = new Dictionary<string, string>
+        {
+            ["email"] = "user@example.com",
+            [JwtClaimTypes.IdProofingStatus] = "2" // Completed
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user, claims);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var statusClaim = jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingStatus);
+        Assert.Equal("2", statusClaim.Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenAdditionalClaimsContainIdProofingSessionId_UsesClaimsValue()
+    {
+        // Arrange: OIDC user — session ID comes from claims, not user object
+        var user = new User
+        {
+            Id = 1,
+            Email = null,
+            IdProofingSessionId = null
+        };
+        var claims = new Dictionary<string, string>
+        {
+            ["email"] = "user@example.com",
+            [JwtClaimTypes.IdProofingSessionId] = "oidc-session-xyz"
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user, claims);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var sessionIdClaim = jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingSessionId);
+        Assert.Equal("oidc-session-xyz", sessionIdClaim.Value);
+    }
+
+    [Fact]
+    public void GenerateToken_WhenAdditionalClaimsContainIdProofingTimestamps_UsesClaimsValues()
+    {
+        // Arrange: OIDC user — completed_at and expires_at come from claims
+        var user = new User
+        {
+            Id = 1,
+            Email = null,
+            IdProofingCompletedAt = null
+        };
+        var completedAtUnix = "1700000000";
+        var expiresAtUnix = "1857676800";
+        var claims = new Dictionary<string, string>
+        {
+            ["email"] = "user@example.com",
+            [JwtClaimTypes.IdProofingCompletedAt] = completedAtUnix,
+            [JwtClaimTypes.IdProofingExpiresAt] = expiresAtUnix
+        };
+
+        // Act
+        var token = _jwtTokenService.GenerateToken(user, claims);
+
+        // Assert
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        Assert.Equal(completedAtUnix, jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingCompletedAt).Value);
+        Assert.Equal(expiresAtUnix, jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingExpiresAt).Value);
     }
 }
 

--- a/test/SEBT.Portal.Tests/Unit/Services/JwtTokenServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/JwtTokenServiceTests.cs
@@ -75,9 +75,10 @@ public class JwtTokenServiceTests
     [Fact]
     public void GenerateToken_ShouldContainSubjectClaim()
     {
-        // Arrange
+        // Arrange — sub is always the internal user ID, not the email
         var user = new User
         {
+            Id = 1,
             Email = "user@example.com",
             IalLevel = UserIalLevel.None
         };
@@ -91,7 +92,7 @@ public class JwtTokenServiceTests
         var subClaim = jsonToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub);
 
         Assert.NotNull(subClaim);
-        Assert.Equal(user.Email, subClaim.Value);
+        Assert.Equal(user.Id.ToString(), subClaim.Value);
     }
 
     [Fact]
@@ -506,10 +507,12 @@ public class JwtTokenServiceTests
     [Fact]
     public void GenerateToken_WithAdditionalClaims_DoesNotDuplicateReservedClaims()
     {
-        // Arrange: additionalClaims may include "sub" and "email"; they should override user values
-        // but each claim type must appear exactly once (no duplicates)
+        // Arrange: additionalClaims may include "sub" and "email"; sub is always user.Id.ToString()
+        // (not overridable), email is overridable via additionalClaims, and each claim type appears
+        // exactly once (no duplicates).
         var user = new User
         {
+            Id = 1,
             Email = "user@example.com",
             IalLevel = UserIalLevel.None
         };
@@ -523,13 +526,14 @@ public class JwtTokenServiceTests
         // Act
         var token = _jwtTokenService.GenerateToken(user, additionalClaims);
 
-        // Assert: sub and email come from additionalClaims (override), each appears once; phone is added
+        // Assert: sub is always user.Id, not additionalClaims sub; email comes from additionalClaims;
+        // each claim type appears exactly once; phone is added
         var handler = new JwtSecurityTokenHandler();
         var jsonToken = handler.ReadJwtToken(token);
         var subClaims = jsonToken.Claims.Where(c => c.Type == JwtRegisteredClaimNames.Sub).ToList();
         var emailClaims = jsonToken.Claims.Where(c => c.Type == ClaimTypes.Email || c.Type == "email").ToList();
         Assert.Single(subClaims);
-        Assert.Equal("idp-sub-123", subClaims[0].Value);
+        Assert.Equal(user.Id.ToString(), subClaims[0].Value);
         Assert.Single(emailClaims);
         Assert.Equal("other@example.com", emailClaims[0].Value);
         Assert.Equal("+13035551234", jsonToken.Claims.FirstOrDefault(c => c.Type == "phone")?.Value);
@@ -538,14 +542,14 @@ public class JwtTokenServiceTests
     [Fact]
     public void GenerateToken_WithNullAdditionalClaims_BehavesAsSingleArgumentOverload()
     {
-        var user = new User { Email = "user@example.com", IalLevel = UserIalLevel.None };
+        var user = new User { Id = 1, Email = "user@example.com", IalLevel = UserIalLevel.None };
 
         var token = _jwtTokenService.GenerateToken(user, null);
 
         Assert.NotNull(token);
         var handler = new JwtSecurityTokenHandler();
         var jsonToken = handler.ReadJwtToken(token);
-        Assert.Equal(user.Email, jsonToken.Claims.First(c => c.Type == JwtRegisteredClaimNames.Sub).Value);
+        Assert.Equal(user.Id.ToString(), jsonToken.Claims.First(c => c.Type == JwtRegisteredClaimNames.Sub).Value);
     }
 
     [Fact]
@@ -612,9 +616,11 @@ public class JwtTokenServiceTests
     }
 
     [Fact]
-    public void GenerateToken_WhenAdditionalClaimsContainSub_UsesClaimsSub()
+    public void GenerateToken_WhenAdditionalClaimsContainSub_SubIsAlwaysUserId()
     {
-        // Arrange: OIDC user — sub comes from IdP, not from user.Email
+        // Arrange: OIDC user — sub in the portal JWT is always user.Id.ToString(),
+        // even when additionalClaims carries the IdP's sub. The IdP sub is stored as
+        // ExternalProviderId in the DB and is not propagated into the portal JWT.
         var user = new User { Id = 1, Email = null };
         var claims = new Dictionary<string, string>
         {
@@ -629,7 +635,7 @@ public class JwtTokenServiceTests
         var handler = new JwtSecurityTokenHandler();
         var jwt = handler.ReadJwtToken(token);
         var subClaim = jwt.Claims.First(c => c.Type == JwtRegisteredClaimNames.Sub);
-        Assert.Equal("pingone-sub-456", subClaim.Value);
+        Assert.Equal(user.Id.ToString(), subClaim.Value);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using NSubstitute.ReceivedExtensions;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
@@ -29,15 +28,22 @@ public class RefreshTokenCommandHandlerTests
             logger);
     }
 
+    /// <summary>Builds a ClaimsPrincipal carrying a sub claim (the portal's user ID) plus
+    /// any additional claims the test needs to pass through to the refreshed token.</summary>
+    private static ClaimsPrincipal PrincipalWithSub(string userIdSub, params Claim[] extraClaims)
+    {
+        var claims = new List<Claim> { new("sub", userIdSub) };
+        claims.AddRange(extraClaims);
+        return new ClaimsPrincipal(new ClaimsIdentity(claims));
+    }
+
     [Fact]
     public async Task Handle_ShouldReturnSuccessResult_WhenUserExists()
     {
         // Arrange
-
         var command = new RefreshTokenCommand
         {
-            UserId = 1,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("1")
         };
 
         var user = new User
@@ -47,9 +53,9 @@ public class RefreshTokenCommandHandlerTests
             IalLevel = UserIalLevel.IAL1plus
         };
 
-        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(1, Arg.Any<CancellationToken>())
             .Returns(user);
-        jwtTokenService.GenerateToken(Arg.Is<User>(u => u.Id == command.UserId), Arg.Any<IReadOnlyDictionary<string, string>>())
+        jwtTokenService.GenerateToken(Arg.Is<User>(u => u.Id == 1), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("refreshed.jwt.token");
 
         // Act
@@ -59,18 +65,19 @@ public class RefreshTokenCommandHandlerTests
         Assert.True(result.IsSuccess);
         var successResult = Assert.IsType<SuccessResult<string>>(result);
         Assert.Equal("refreshed.jwt.token", successResult.Value);
-        await userRepository.Received(1).GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>());
-        jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u => u.Id == command.UserId && u.IalLevel == UserIalLevel.IAL1plus), Arg.Any<IReadOnlyDictionary<string, string>>());
+        await userRepository.Received(1).GetUserByIdAsync(1, Arg.Any<CancellationToken>());
+        jwtTokenService.Received(1).GenerateToken(
+            Arg.Is<User>(u => u.Id == 1 && u.IalLevel == UserIalLevel.IAL1plus),
+            Arg.Any<IReadOnlyDictionary<string, string>>());
     }
 
     [Fact]
-    public async Task Handle_ShouldReturnValidationFailure_WhenUserIdIsZero()
+    public async Task Handle_WhenPrincipalHasNoSubClaim_ReturnsPreconditionFailed()
     {
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 0,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = new ClaimsPrincipal(new ClaimsIdentity())
         };
 
         // Act
@@ -78,10 +85,29 @@ public class RefreshTokenCommandHandlerTests
 
         // Assert
         Assert.False(result.IsSuccess);
-        var failedResult = Assert.IsType<ValidationFailedResult<string>>(result);
-        Assert.Contains("UserId", failedResult.Errors.Select(e => e.Key));
+        var failedResult = Assert.IsType<PreconditionFailedResult<string>>(result);
+        Assert.Equal(PreconditionFailedReason.NotFound, failedResult.Reason);
         await userRepository.DidNotReceive().GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
         jwtTokenService.DidNotReceive().GenerateToken(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenPrincipalSubIsNotAnInteger_ReturnsPreconditionFailed()
+    {
+        // Arrange — sub is present but malformed (e.g. legacy email-based sub)
+        var command = new RefreshTokenCommand
+        {
+            CurrentPrincipal = PrincipalWithSub("not-a-number")
+        };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var failedResult = Assert.IsType<PreconditionFailedResult<string>>(result);
+        Assert.Equal(PreconditionFailedReason.NotFound, failedResult.Reason);
+        await userRepository.DidNotReceive().GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -90,11 +116,10 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 999,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("999")
         };
 
-        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(999, Arg.Any<CancellationToken>())
             .Returns((User?)null);
 
         // Act
@@ -114,8 +139,7 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 1,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("1")
         };
 
         var user = new User
@@ -127,7 +151,7 @@ public class RefreshTokenCommandHandlerTests
             IdProofingCompletedAt = null
         };
 
-        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(1, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("new.token");
@@ -138,7 +162,7 @@ public class RefreshTokenCommandHandlerTests
         // Assert
         Assert.True(result.IsSuccess);
         jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u =>
-            u.Id == command.UserId &&
+            u.Id == 1 &&
             u.IalLevel == UserIalLevel.IAL1 &&
             u.IdProofingSessionId == "session-abc-123"), Arg.Any<IReadOnlyDictionary<string, string>>());
     }
@@ -149,8 +173,7 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 1,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("1")
         };
 
         userRepository.GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
@@ -173,8 +196,7 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 1,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("1")
         };
 
         var user = new User
@@ -184,7 +206,7 @@ public class RefreshTokenCommandHandlerTests
             IalLevel = UserIalLevel.None
         };
 
-        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(1, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService
             .When(x => x.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>()))
@@ -206,8 +228,7 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 1,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("1")
         };
 
         var user = new User
@@ -217,7 +238,7 @@ public class RefreshTokenCommandHandlerTests
             IalLevel = UserIalLevel.IAL1plus
         };
 
-        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(1, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("token");
@@ -227,7 +248,7 @@ public class RefreshTokenCommandHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        await userRepository.Received(1).GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>());
+        await userRepository.Received(1).GetUserByIdAsync(1, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -236,8 +257,7 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            UserId = 1,
-            CurrentPrincipal = new ClaimsPrincipal()
+            CurrentPrincipal = PrincipalWithSub("1")
         };
 
         var completedAt = DateTime.UtcNow.AddDays(-5);
@@ -250,7 +270,7 @@ public class RefreshTokenCommandHandlerTests
             IdProofingCompletedAt = completedAt
         };
 
-        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(1, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("token");
@@ -261,7 +281,7 @@ public class RefreshTokenCommandHandlerTests
         // Assert
         Assert.True(result.IsSuccess);
         jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u =>
-            u.Id == command.UserId &&
+            u.Id == 1 &&
             u.IalLevel == UserIalLevel.IAL1plus &&
             u.IdProofingSessionId == "session-xyz" &&
             u.IdProofingCompletedAt == completedAt), Arg.Any<IReadOnlyDictionary<string, string>>());
@@ -270,22 +290,16 @@ public class RefreshTokenCommandHandlerTests
     [Fact]
     public async Task Handle_WhenOidcUser_PreservesIalFromExistingJwtClaims()
     {
-        // Arrange
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
-        {
+        // Arrange — OIDC user whose IdP-sourced IAL lives in the existing JWT,
+        // not in the DB (where IalLevel is None).
+        var principal = PrincipalWithSub(
+            "1",
             new Claim("email", "user@example.com"),
-            new Claim("sub", "1"),
             new Claim(JwtClaimTypes.Ial, "1plus"),
-            new Claim(JwtClaimTypes.IdProofingStatus, "2"), // Completed
-        }));
+            new Claim(JwtClaimTypes.IdProofingStatus, "2")); // Completed
 
-        var command = new RefreshTokenCommand
-        {
-            UserId = 1,
-            CurrentPrincipal = principal
-        };
+        var command = new RefreshTokenCommand { CurrentPrincipal = principal };
 
-        // OIDC user has no IAL stored in DB
         var user = new User
         {
             Id = 1,
@@ -303,32 +317,10 @@ public class RefreshTokenCommandHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        // Verify that IAL from JWT claims (1plus) was passed through, not DB (None)
+        // IAL from JWT claims (1plus) was passed through, not DB (None).
         jwtTokenService.Received(1).GenerateToken(
             Arg.Any<User>(),
             Arg.Is<IReadOnlyDictionary<string, string>>(c =>
                 c.ContainsKey(JwtClaimTypes.Ial) && c[JwtClaimTypes.Ial] == "1plus"));
-    }
-
-    [Fact]
-    public async Task Handle_WhenUserNotFoundById_ReturnsPreconditionFailed()
-    {
-        // Arrange
-        var command = new RefreshTokenCommand
-        {
-            UserId = 42,
-            CurrentPrincipal = new ClaimsPrincipal()
-        };
-
-        userRepository.GetUserByIdAsync(42, Arg.Any<CancellationToken>())
-            .Returns((User?)null);
-
-        // Act
-        var result = await handler.Handle(command);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        var failedResult = Assert.IsType<PreconditionFailedResult<string>>(result);
-        Assert.Equal(PreconditionFailedReason.NotFound, failedResult.Reason);
     }
 }

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
@@ -36,19 +36,20 @@ public class RefreshTokenCommandHandlerTests
 
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
+            UserId = 1,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
         var user = new User
         {
-            Email = command.Email,
+            Id = 1,
+            Email = "user@example.com",
             IalLevel = UserIalLevel.IAL1plus
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Is<string>(email => email == command.Email), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns(user);
-        jwtTokenService.GenerateToken(Arg.Is<User>(u => u.Email == command.Email), Arg.Any<IReadOnlyDictionary<string, string>>())
+        jwtTokenService.GenerateToken(Arg.Is<User>(u => u.Id == command.UserId), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("refreshed.jwt.token");
 
         // Act
@@ -58,17 +59,17 @@ public class RefreshTokenCommandHandlerTests
         Assert.True(result.IsSuccess);
         var successResult = Assert.IsType<SuccessResult<string>>(result);
         Assert.Equal("refreshed.jwt.token", successResult.Value);
-        await userRepository.Received(1).GetUserByEmailAsync(command.Email, Arg.Any<CancellationToken>());
-        jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u => u.Email == command.Email && u.IalLevel == UserIalLevel.IAL1plus), Arg.Any<IReadOnlyDictionary<string, string>>());
+        await userRepository.Received(1).GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>());
+        jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u => u.Id == command.UserId && u.IalLevel == UserIalLevel.IAL1plus), Arg.Any<IReadOnlyDictionary<string, string>>());
     }
 
     [Fact]
-    public async Task Handle_ShouldReturnValidationFailure_WhenEmailIsEmpty()
+    public async Task Handle_ShouldReturnValidationFailure_WhenUserIdIsZero()
     {
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = string.Empty,
+            UserId = 0,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
@@ -78,29 +79,8 @@ public class RefreshTokenCommandHandlerTests
         // Assert
         Assert.False(result.IsSuccess);
         var failedResult = Assert.IsType<ValidationFailedResult<string>>(result);
-        Assert.Contains("Email", failedResult.Errors.Select(e => e.Key));
-        await userRepository.DidNotReceive().GetUserByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        jwtTokenService.DidNotReceive().GenerateToken(Arg.Any<User>());
-    }
-
-    [Fact]
-    public async Task Handle_ShouldReturnValidationFailure_WhenEmailIsInvalid()
-    {
-        // Arrange
-        var command = new RefreshTokenCommand
-        {
-            Email = "invalid-email",
-            CurrentPrincipal = new ClaimsPrincipal()
-        };
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        var failedResult = Assert.IsType<ValidationFailedResult<string>>(result);
-        Assert.Contains("Email", failedResult.Errors.Select(e => e.Key));
-        await userRepository.DidNotReceive().GetUserByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        Assert.Contains("UserId", failedResult.Errors.Select(e => e.Key));
+        await userRepository.DidNotReceive().GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
         jwtTokenService.DidNotReceive().GenerateToken(Arg.Any<User>());
     }
 
@@ -110,11 +90,11 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "nonexistent@example.com",
+            UserId = 999,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Is<string>(email => email == command.Email), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns((User?)null);
 
         // Act
@@ -134,19 +114,20 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
+            UserId = 1,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
         var user = new User
         {
-            Email = command.Email,
+            Id = 1,
+            Email = "user@example.com",
             IalLevel = UserIalLevel.IAL1,
             IdProofingSessionId = "session-abc-123",
             IdProofingCompletedAt = null
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Is<string>(email => email == command.Email), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("new.token");
@@ -157,7 +138,7 @@ public class RefreshTokenCommandHandlerTests
         // Assert
         Assert.True(result.IsSuccess);
         jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u =>
-            u.Email == command.Email &&
+            u.Id == command.UserId &&
             u.IalLevel == UserIalLevel.IAL1 &&
             u.IdProofingSessionId == "session-abc-123"), Arg.Any<IReadOnlyDictionary<string, string>>());
     }
@@ -168,11 +149,11 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
+            UserId = 1,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<User?>(new Exception("Database connection failed")));
 
         // Act
@@ -192,17 +173,18 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
+            UserId = 1,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
         var user = new User
         {
-            Email = command.Email,
+            Id = 1,
+            Email = "user@example.com",
             IalLevel = UserIalLevel.None
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Is<string>(email => email == command.Email), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService
             .When(x => x.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>()))
@@ -224,17 +206,18 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
+            UserId = 1,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
         var user = new User
         {
-            Email = command.Email,
+            Id = 1,
+            Email = "user@example.com",
             IalLevel = UserIalLevel.IAL1plus
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Is<string>(email => email == command.Email), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("token");
@@ -244,7 +227,7 @@ public class RefreshTokenCommandHandlerTests
 
         // Assert
         Assert.True(result.IsSuccess);
-        await userRepository.Received(1).GetUserByEmailAsync(command.Email, Arg.Any<CancellationToken>());
+        await userRepository.Received(1).GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -253,20 +236,21 @@ public class RefreshTokenCommandHandlerTests
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
+            UserId = 1,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
         var completedAt = DateTime.UtcNow.AddDays(-5);
         var user = new User
         {
-            Email = command.Email,
+            Id = 1,
+            Email = "user@example.com",
             IalLevel = UserIalLevel.IAL1plus,
             IdProofingSessionId = "session-xyz",
             IdProofingCompletedAt = completedAt
         };
 
-        userRepository.GetUserByEmailAsync(Arg.Is<string>(email => email == command.Email), Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("token");
@@ -277,7 +261,7 @@ public class RefreshTokenCommandHandlerTests
         // Assert
         Assert.True(result.IsSuccess);
         jwtTokenService.Received(1).GenerateToken(Arg.Is<User>(u =>
-            u.Email == command.Email &&
+            u.Id == command.UserId &&
             u.IalLevel == UserIalLevel.IAL1plus &&
             u.IdProofingSessionId == "session-xyz" &&
             u.IdProofingCompletedAt == completedAt), Arg.Any<IReadOnlyDictionary<string, string>>());
@@ -290,15 +274,14 @@ public class RefreshTokenCommandHandlerTests
         var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
         {
             new Claim("email", "user@example.com"),
-            new Claim("sub", "pingone-sub-12345"),
+            new Claim("sub", "1"),
             new Claim(JwtClaimTypes.Ial, "1plus"),
             new Claim(JwtClaimTypes.IdProofingStatus, "2"), // Completed
         }));
 
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
-            ExternalProviderId = "pingone-sub-12345",
+            UserId = 1,
             CurrentPrincipal = principal
         };
 
@@ -310,7 +293,7 @@ public class RefreshTokenCommandHandlerTests
             IalLevel = UserIalLevel.None
         };
 
-        userRepository.GetUserByExternalIdAsync("pingone-sub-12345", Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(1, Arg.Any<CancellationToken>())
             .Returns(user);
         jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
             .Returns("refreshed-jwt");
@@ -328,17 +311,16 @@ public class RefreshTokenCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WhenOidcUserNotFound_ReturnsPreconditionFailed()
+    public async Task Handle_WhenUserNotFoundById_ReturnsPreconditionFailed()
     {
         // Arrange
         var command = new RefreshTokenCommand
         {
-            Email = "user@example.com",
-            ExternalProviderId = "pingone-sub-nonexistent",
+            UserId = 42,
             CurrentPrincipal = new ClaimsPrincipal()
         };
 
-        userRepository.GetUserByExternalIdAsync("pingone-sub-nonexistent", Arg.Any<CancellationToken>())
+        userRepository.GetUserByIdAsync(42, Arg.Any<CancellationToken>())
             .Returns((User?)null);
 
         // Act
@@ -350,4 +332,3 @@ public class RefreshTokenCommandHandlerTests
         Assert.Equal(PreconditionFailedReason.NotFound, failedResult.Reason);
     }
 }
-

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
@@ -282,5 +282,72 @@ public class RefreshTokenCommandHandlerTests
             u.IdProofingSessionId == "session-xyz" &&
             u.IdProofingCompletedAt == completedAt), Arg.Any<IReadOnlyDictionary<string, string>>());
     }
+
+    [Fact]
+    public async Task Handle_WhenOidcUser_PreservesIalFromExistingJwtClaims()
+    {
+        // Arrange
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim("email", "user@example.com"),
+            new Claim("sub", "pingone-sub-12345"),
+            new Claim(JwtClaimTypes.Ial, "1plus"),
+            new Claim(JwtClaimTypes.IdProofingStatus, "2"), // Completed
+        }));
+
+        var command = new RefreshTokenCommand
+        {
+            Email = "user@example.com",
+            ExternalProviderId = "pingone-sub-12345",
+            CurrentPrincipal = principal
+        };
+
+        // OIDC user has no IAL stored in DB
+        var user = new User
+        {
+            Id = 1,
+            ExternalProviderId = "pingone-sub-12345",
+            IalLevel = UserIalLevel.None
+        };
+
+        userRepository.GetUserByExternalIdAsync("pingone-sub-12345", Arg.Any<CancellationToken>())
+            .Returns(user);
+        jwtTokenService.GenerateToken(Arg.Any<User>(), Arg.Any<IReadOnlyDictionary<string, string>>())
+            .Returns("refreshed-jwt");
+
+        // Act
+        var result = await handler.Handle(command);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        // Verify that IAL from JWT claims (1plus) was passed through, not DB (None)
+        jwtTokenService.Received(1).GenerateToken(
+            Arg.Any<User>(),
+            Arg.Is<IReadOnlyDictionary<string, string>>(c =>
+                c.ContainsKey(JwtClaimTypes.Ial) && c[JwtClaimTypes.Ial] == "1plus"));
+    }
+
+    [Fact]
+    public async Task Handle_WhenOidcUserNotFound_ReturnsPreconditionFailed()
+    {
+        // Arrange
+        var command = new RefreshTokenCommand
+        {
+            Email = "user@example.com",
+            ExternalProviderId = "pingone-sub-nonexistent",
+            CurrentPrincipal = new ClaimsPrincipal()
+        };
+
+        userRepository.GetUserByExternalIdAsync("pingone-sub-nonexistent", Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        // Act
+        var result = await handler.Handle(command);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        var failedResult = Assert.IsType<PreconditionFailedResult<string>>(result);
+        Assert.Equal(PreconditionFailedReason.NotFound, failedResult.Reason);
+    }
 }
 

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/ValidateOtpCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/ValidateOtpCommandHandlerTests.cs
@@ -492,6 +492,7 @@ public class ValidateOtpCommandHandlerTests
 
         var newUser = new User
         {
+            Id = 1,
             Email = command.Email,
             IalLevel = UserIalLevel.None
         };
@@ -511,7 +512,7 @@ public class ValidateOtpCommandHandlerTests
         mockLogger.Received().Log(
             LogLevel.Information,
             Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("New user authenticated via OTP") && o.ToString()!.Contains(command.Email)),
+            Arg.Is<object>(o => o.ToString()!.Contains("New user authenticated via OTP") && o.ToString()!.Contains("UserId")),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
     }
@@ -535,6 +536,7 @@ public class ValidateOtpCommandHandlerTests
 
         var existingUser = new User
         {
+            Id = 2,
             Email = command.Email,
             IalLevel = UserIalLevel.IAL1plus
         };
@@ -554,7 +556,7 @@ public class ValidateOtpCommandHandlerTests
         mockLogger.Received().Log(
             LogLevel.Information,
             Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("Returning user authenticated via OTP") && o.ToString()!.Contains(command.Email)),
+            Arg.Is<object>(o => o.ToString()!.Contains("Returning user authenticated via OTP") && o.ToString()!.Contains("UserId")),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
     }
@@ -578,6 +580,7 @@ public class ValidateOtpCommandHandlerTests
 
         var newUser = new User
         {
+            Id = 3,
             Email = command.Email,
             IalLevel = UserIalLevel.None
         };
@@ -598,7 +601,7 @@ public class ValidateOtpCommandHandlerTests
             LogLevel.Information,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("New user authenticated via OTP") &&
-                               o.ToString()!.Contains(command.Email) &&
+                               o.ToString()!.Contains("UserId") &&
                                o.ToString()!.Contains("IAL1")),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
@@ -623,6 +626,7 @@ public class ValidateOtpCommandHandlerTests
 
         var existingUser = new User
         {
+            Id = 4,
             Email = command.Email,
             IalLevel = UserIalLevel.IAL1
         };
@@ -643,7 +647,7 @@ public class ValidateOtpCommandHandlerTests
             LogLevel.Information,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("Returning user authenticated via OTP") &&
-                               o.ToString()!.Contains(command.Email) &&
+                               o.ToString()!.Contains("UserId") &&
                                o.ToString()!.Contains("IAL1")),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
@@ -668,6 +672,7 @@ public class ValidateOtpCommandHandlerTests
 
         var user = new User
         {
+            Id = 5,
             Email = command.Email,
             IalLevel = UserIalLevel.None
         };
@@ -688,7 +693,7 @@ public class ValidateOtpCommandHandlerTests
             LogLevel.Information,
             Arg.Any<EventId>(),
             Arg.Is<object>(o => o.ToString()!.Contains("OTP validated successfully and JWT token generated") &&
-                               o.ToString()!.Contains(command.Email)),
+                               o.ToString()!.Contains("UserId")),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
     }


### PR DESCRIPTION
## Jira ticket
https://codeforamerica.atlassian.net/browse/DC-292


## Summary

- **Fix stale IAL bug** for OIDC users (Colorado): the portal was reading IAL from its database instead of from the identity provider's claims, causing IAL to go stale between logins
- **Add `ExternalProviderId`** to User model — OIDC users are now identified by IdP `sub` claim instead of email
- **Stop persisting IAL to DB** for OIDC users — IAL, email, and verification state flow from IdP claims at login time and are carried in the JWT
- **In-flight migration** for existing users: legacy email-only records are adopted on next OIDC login by setting `ExternalProviderId` and clearing email
- **Token refresh** is now OIDC-aware: preserves IAL from existing JWT claims instead of overriding with stale DB values

## Known issues to fix before merge

1. `ResolveUserFilter` uses email-only DB lookup — breaks for OIDC users with null email
2. Missing `IdProofingExpiresAt` claim for OIDC users — frontend treats verification as stale
3. Token refresh OIDC detection heuristic (`sub != email`) is fragile — should use explicit claim

## Test plan

- [ ] Run full backend test suite
- [ ] Run frontend test suite
- [ ] Local smoke test: CO OIDC login → verify JWT contains correct IAL
- [ ] Local smoke test: token refresh preserves IAL
- [ ] Local smoke test: DC OTP login still works
- [ ] Verify Users table: CO user has ExternalProviderId, no email; DC user has email, no ExternalProviderId

🤖 Generated with [Claude Code](https://claude.com/claude-code)