### PR TITLE
DC-90(Feat) SNAP-TANF ID/DOB matching

### DIFF
--- a/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
+++ b/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
@@ -31,4 +31,13 @@ internal sealed class DefaultSummerEbtCaseService : ISummerEbtCaseService
     {
         return Task.FromResult<HouseholdData?>(null);
     }
+
+    /// <inheritdoc />
+    public Task<bool> TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+        string benefitIdentifierIc,
+        DateOnly guardianDateOfBirth,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(false);
+    }
 }

--- a/src/SEBT.Portal.Api/Composition/ServiceCollectionPluginExtensions.cs
+++ b/src/SEBT.Portal.Api/Composition/ServiceCollectionPluginExtensions.cs
@@ -148,3 +148,4 @@ internal static class ServiceCollectionPluginExtensions
         return services;
     }
 }
+

--- a/src/SEBT.Portal.Core/Models/Auth/CoLoadedBenefitIdentifierMatch.cs
+++ b/src/SEBT.Portal.Core/Models/Auth/CoLoadedBenefitIdentifierMatch.cs
@@ -1,0 +1,87 @@
+using SEBT.Portal.Core.Models.Household;
+
+namespace SEBT.Portal.Core.Models.Auth;
+
+/// <summary>
+/// Verifies a co-loaded user's submitted SNAP/TANF identifier against values already on file
+/// (user record and/or co-loaded Summer EBT cases from the state connector).
+/// </summary>
+public static class CoLoadedBenefitIdentifierMatch
+{
+    /// <summary>
+    /// Returns true when <paramref name="idValue"/> matches on-file benefit identifiers for the given <paramref name="idType"/>.
+    /// </summary>
+    public static bool Matches(User user, HouseholdData? household, string idType, string idValue)
+    {
+        var normalized = Normalize(idValue);
+        if (string.IsNullOrEmpty(normalized))
+        {
+            return false;
+        }
+
+        return idType switch
+        {
+            "snapAccountId" => MatchSnapAccount(user, household, normalized),
+            "snapPersonId" => MatchSnapPerson(household, normalized),
+            "tanfAccountId" => MatchTanfAccount(user, household, normalized),
+            "tanfPersonId" => MatchTanfPerson(household, normalized),
+            _ => false
+        };
+    }
+
+    private static string Normalize(string value) => value.Trim();
+
+    private static bool EqualsNormalized(string? onFile, string submitted) =>
+        !string.IsNullOrWhiteSpace(onFile)
+        && string.Equals(onFile.Trim(), submitted, StringComparison.OrdinalIgnoreCase);
+
+    private static bool MatchSnapAccount(User user, HouseholdData? household, string v) =>
+        EqualsNormalized(user.SnapId, v)
+        || AnyMatchingCoLoadedCase(household, IsSnapCase, c =>
+            EqualsNormalized(c.EbtCaseNumber, v) || EqualsNormalized(c.SummerEBTCaseID, v));
+
+    private static bool MatchSnapPerson(HouseholdData? household, string v) =>
+        AnyMatchingCoLoadedCase(household, IsSnapCase, c => EqualsNormalized(c.ApplicationStudentId, v));
+
+    private static bool MatchTanfAccount(User user, HouseholdData? household, string v) =>
+        EqualsNormalized(user.TanfId, v)
+        || AnyMatchingCoLoadedCase(household, IsTanfCase, c =>
+            EqualsNormalized(c.EbtCaseNumber, v) || EqualsNormalized(c.SummerEBTCaseID, v));
+
+    private static bool MatchTanfPerson(HouseholdData? household, string v) =>
+        AnyMatchingCoLoadedCase(household, IsTanfCase, c => EqualsNormalized(c.ApplicationStudentId, v));
+
+    private static bool IsSnapCase(SummerEbtCase c) =>
+        c.IssuanceType == IssuanceType.SnapEbtCard
+        || string.Equals(c.EligibilityType, "SNAP", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsTanfCase(SummerEbtCase c) =>
+        c.IssuanceType == IssuanceType.TanfEbtCard
+        || string.Equals(c.EligibilityType, "TANF", StringComparison.OrdinalIgnoreCase);
+
+    private static bool AnyMatchingCoLoadedCase(
+        HouseholdData? household,
+        Func<SummerEbtCase, bool> typeFilter,
+        Func<SummerEbtCase, bool> valueMatches)
+    {
+        if (household?.SummerEbtCases is not { Count: > 0 })
+        {
+            return false;
+        }
+
+        foreach (var c in household.SummerEbtCases)
+        {
+            if (!c.IsCoLoaded || !typeFilter(c))
+            {
+                continue;
+            }
+
+            if (valueMatches(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/SEBT.Portal.Core/Models/Auth/IdProofingBenefitIdentifierTypes.cs
+++ b/src/SEBT.Portal.Core/Models/Auth/IdProofingBenefitIdentifierTypes.cs
@@ -1,0 +1,24 @@
+namespace SEBT.Portal.Core.Models.Auth;
+
+/// <summary>
+/// SNAP/TANF identifier options from the id-proofing onboarding form. These values are matched in-portal
+/// against co-loaded records; they are not sent to Socure as <c>national_id</c>.
+/// Co-loaded users who submit one of these types may be streamlined to completed proofing without a Socure match.
+/// </summary>
+public static class IdProofingBenefitIdentifierTypes
+{
+    private static readonly HashSet<string> SnapOrTanfPortalTypes = new(StringComparer.Ordinal)
+    {
+        "snapAccountId",
+        "snapPersonId",
+        "tanfAccountId",
+        "tanfPersonId",
+    };
+
+    /// <summary>
+    /// True when <paramref name="idType"/> is a SNAP or TANF selection from the portal onboarding UI
+    /// (aligned with the web <c>IdType</c> enum and any future TANF variants).
+    /// </summary>
+    public static bool IsSnapOrTanfPortalSelection(string? idType) =>
+        idType != null && SnapOrTanfPortalTypes.Contains(idType);
+}

--- a/src/SEBT.Portal.Core/Models/Auth/User.cs
+++ b/src/SEBT.Portal.Core/Models/Auth/User.cs
@@ -16,6 +16,11 @@ public class User
     public string Email { get; set; } = string.Empty;
 
     /// <summary>
+    /// The user's date of birth (calendar date), when collected for household matching or verification.
+    /// </summary>
+    public DateOnly? DateOfBirth { get; set; }
+
+    /// <summary>
     /// Workflow state of the ID proofing process (NotStarted, InProgress, Completed, Failed, Expired).
     /// </summary>
     public IdProofingStatus IdProofingStatus { get; set; } = IdProofingStatus.NotStarted;

--- a/src/SEBT.Portal.Core/Repositories/IHouseholdRepository.cs
+++ b/src/SEBT.Portal.Core/Repositories/IHouseholdRepository.cs
@@ -43,6 +43,19 @@ public interface IHouseholdRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// For co-loaded SNAP/TANF ID proofing: asks the state plugin whether the submitted benefit identifier
+    /// (IC) and guardian date of birth match state warehouse data. Implemented for DC only; other states return <c>false</c>.
+    /// </summary>
+    /// <param name="benefitIdentifierIc">SNAP/TANF identifier from onboarding, mapped to warehouse IC.</param>
+    /// <param name="guardianDateOfBirth">Guardian DOB from ID proofing.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns><c>true</c> if the state reports a match.</returns>
+    Task<bool> TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+        string benefitIdentifierIc,
+        DateOnly guardianDateOfBirth,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Creates or updates household data.
     /// </summary>
     /// <param name="householdData">The household data to create or update.</param>

--- a/src/SEBT.Portal.Core/Seeding/SeedScenarios.cs
+++ b/src/SEBT.Portal.Core/Seeding/SeedScenarios.cs
@@ -10,6 +10,8 @@ public static class SeedScenarios
 {
     // IAL1+ scenarios
     public static readonly SeedScenario CoLoaded = new("co-loaded", UserIalLevel.IAL1plus);
+    /// <summary>Co-loaded with SNAP/TANF on file; ID proofing not started (DC mock household + benefit-match dev).</summary>
+    public static readonly SeedScenario CoLoadedPendingIdProofing = new("co-loaded-pending-id-proofing", UserIalLevel.None);
     public static readonly SeedScenario Verified = new("verified", UserIalLevel.IAL1plus);
     public static readonly SeedScenario Expired = new("expired", UserIalLevel.IAL1plus);
     public static readonly SeedScenario Review = new("review", UserIalLevel.IAL1plus);
@@ -44,7 +46,7 @@ public static class SeedScenarios
     /// </summary>
     public static readonly IReadOnlyList<SeedScenario> UserScenarios =
     [
-        CoLoaded, Verified, SingleChild, LargeFamily, Expired,
+        CoLoaded, CoLoadedPendingIdProofing, Verified, SingleChild, LargeFamily, Expired,
         NonCoLoaded, NotStarted, Pending, Minimal, Denied,
         Review, Cancelled, Unknown,
         Simple1, Simple2, Simple3, Simple4, Simple5, Simple6, Simple7
@@ -54,7 +56,11 @@ public static class SeedScenarios
     /// Scenarios that should only be seeded when STATE=dc.
     /// </summary>
     public static readonly IReadOnlySet<SeedScenario> DcOnlyScenarios =
-        new HashSet<SeedScenario> { Simple1, Simple2, Simple3, Simple4, Simple5, Simple6, Simple7 };
+        new HashSet<SeedScenario>
+        {
+            Simple1, Simple2, Simple3, Simple4, Simple5, Simple6, Simple7,
+            CoLoadedPendingIdProofing,
+        };
 
     /// <summary>
     /// All scenarios including household-only entries (e.g., MultipleApps).

--- a/src/SEBT.Portal.Infrastructure.Seeding/Services/DatabaseSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure.Seeding/Services/DatabaseSeeder.cs
@@ -123,6 +123,8 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
         if (useMockHouseholdData)
         {
             var coLoadedEmail = EmailNormalizer.Normalize(_settings.BuildEmail(SeedScenarios.CoLoaded.Name));
+            var coLoadedPendingIdProofingEmail = EmailNormalizer.Normalize(
+                _settings.BuildEmail(SeedScenarios.CoLoadedPendingIdProofing.Name));
             var verifiedEmail = EmailNormalizer.Normalize(_settings.BuildEmail(SeedScenarios.Verified.Name));
 
             foreach (var scenario in SeedScenarios.UserScenarios)
@@ -156,6 +158,22 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             u.IdProofingExpiresAt = now.AddDays(DaysUntilIdProofingExpires);
                             u.CoLoadedLastUpdated = now.AddDays(DaysSinceCoLoadedUpdate);
                             u.Phone = "5551234567";
+                            u.SnapId = "SNAP-CO-001";
+                            u.TanfId = "TANF-CO-001";
+                            u.Ssn = "123456789";
+                        });
+                    }
+                    else if (normalizedEmail == coLoadedPendingIdProofingEmail)
+                    {
+                        user = UserFactory.CreateCoLoadedUser(u =>
+                        {
+                            u.Email = normalizedEmail;
+                            u.IdProofingStatus = IdProofingStatus.NotStarted;
+                            u.IalLevel = UserIalLevel.None;
+                            u.IdProofingCompletedAt = null;
+                            u.IdProofingExpiresAt = null;
+                            u.CoLoadedLastUpdated = now.AddDays(DaysSinceCoLoadedUpdate);
+                            u.Phone = "8185558438";
                             u.SnapId = "SNAP-CO-001";
                             u.TanfId = "TANF-CO-001";
                             u.Ssn = "123456789";
@@ -260,6 +278,8 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
         if (useMockHouseholdData)
         {
             var coLoadedEmail = EmailNormalizer.Normalize(_settings.BuildEmail(SeedScenarios.CoLoaded.Name));
+            var coLoadedPendingIdProofingEmail = EmailNormalizer.Normalize(
+                _settings.BuildEmail(SeedScenarios.CoLoadedPendingIdProofing.Name));
             var verifiedEmail = EmailNormalizer.Normalize(_settings.BuildEmail(SeedScenarios.Verified.Name));
             foreach (var scenario in SeedScenarios.UserScenarios)
             {
@@ -292,6 +312,22 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             u.IdProofingExpiresAt = now.AddDays(DaysUntilIdProofingExpires);
                             u.CoLoadedLastUpdated = now.AddDays(DaysSinceCoLoadedUpdate);
                             u.Phone = "5551234567";
+                            u.SnapId = "SNAP-CO-001";
+                            u.TanfId = "TANF-CO-001";
+                            u.Ssn = "123456789";
+                        });
+                    }
+                    else if (normalizedEmail == coLoadedPendingIdProofingEmail)
+                    {
+                        user = UserFactory.CreateCoLoadedUser(u =>
+                        {
+                            u.Email = normalizedEmail;
+                            u.IdProofingStatus = IdProofingStatus.NotStarted;
+                            u.IalLevel = UserIalLevel.None;
+                            u.IdProofingCompletedAt = null;
+                            u.IdProofingExpiresAt = null;
+                            u.CoLoadedLastUpdated = now.AddDays(DaysSinceCoLoadedUpdate);
+                            u.Phone = "8185558438";
                             u.SnapId = "SNAP-CO-001";
                             u.TanfId = "TANF-CO-001";
                             u.Ssn = "123456789";

--- a/src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs
+++ b/src/SEBT.Portal.Infrastructure/Data/Entities/UserEntity.cs
@@ -16,6 +16,11 @@ public class UserEntity
     public string Email { get; set; } = string.Empty;
 
     /// <summary>
+    /// The user's date of birth, when collected.
+    /// </summary>
+    public DateOnly? DateOfBirth { get; set; }
+
+    /// <summary>
     /// Workflow state of ID proofing (NotStarted, InProgress, Completed, Failed, Expired)
     /// </summary>
     public int IdProofingStatus { get; set; } = 0; // 0 = NotStarted

--- a/src/SEBT.Portal.Infrastructure/Helpers/UserFactory.cs
+++ b/src/SEBT.Portal.Infrastructure/Helpers/UserFactory.cs
@@ -96,6 +96,7 @@ public static class UserFactory
             IdProofingSessionId = user.IdProofingSessionId,
             IdProofingCompletedAt = user.IdProofingCompletedAt,
             IdProofingExpiresAt = user.IdProofingExpiresAt,
+            DateOfBirth = user.DateOfBirth,
             IsCoLoaded = user.IsCoLoaded,
             CoLoadedLastUpdated = user.CoLoadedLastUpdated,
             IdProofingAttemptCount = user.IdProofingAttemptCount,

--- a/src/SEBT.Portal.Infrastructure/Migrations/20260415165707_AddDateOfBirthToUsers.Designer.cs
+++ b/src/SEBT.Portal.Infrastructure/Migrations/20260415165707_AddDateOfBirthToUsers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SEBT.Portal.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using SEBT.Portal.Infrastructure.Data;
 namespace SEBT.Portal.Infrastructure.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    partial class PortalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260415165707_AddDateOfBirthToUsers")]
+    partial class AddDateOfBirthToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SEBT.Portal.Infrastructure/Migrations/20260415165707_AddDateOfBirthToUsers.cs
+++ b/src/SEBT.Portal.Infrastructure/Migrations/20260415165707_AddDateOfBirthToUsers.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SEBT.Portal.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDateOfBirthToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "DateOfBirth",
+                table: "Users",
+                type: "date",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DateOfBirth",
+                table: "Users");
+        }
+    }
+}

--- a/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
@@ -84,6 +84,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
         entity.IdProofingSessionId = user.IdProofingSessionId;
         entity.IdProofingCompletedAt = user.IdProofingCompletedAt;
         entity.IdProofingExpiresAt = user.IdProofingExpiresAt;
+        entity.DateOfBirth = user.DateOfBirth;
         entity.IsCoLoaded = user.IsCoLoaded;
         entity.CoLoadedLastUpdated = user.CoLoadedLastUpdated;
         entity.Phone = user.Phone;
@@ -219,6 +220,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             IdProofingSessionId = entity.IdProofingSessionId,
             IdProofingCompletedAt = entity.IdProofingCompletedAt,
             IdProofingExpiresAt = entity.IdProofingExpiresAt,
+            DateOfBirth = entity.DateOfBirth,
             IsCoLoaded = entity.IsCoLoaded,
             CoLoadedLastUpdated = entity.CoLoadedLastUpdated,
             Phone = entity.Phone,
@@ -242,6 +244,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             IdProofingSessionId = user.IdProofingSessionId,
             IdProofingCompletedAt = user.IdProofingCompletedAt,
             IdProofingExpiresAt = user.IdProofingExpiresAt,
+            DateOfBirth = user.DateOfBirth,
             IsCoLoaded = user.IsCoLoaded,
             CoLoadedLastUpdated = user.CoLoadedLastUpdated,
             Phone = user.Phone,

--- a/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
@@ -132,6 +132,18 @@ public class HouseholdRepository : IHouseholdRepository
             cancellationToken);
     }
 
+    /// <inheritdoc />
+    public Task<bool> TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+        string benefitIdentifierIc,
+        DateOnly guardianDateOfBirth,
+        CancellationToken cancellationToken = default)
+    {
+        return _summerEbtCaseService.TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+            benefitIdentifierIc,
+            guardianDateOfBirth,
+            cancellationToken);
+    }
+
     private static HouseholdData ApplyPiiVisibility(HouseholdData source, PiiVisibility piiVisibility)
     {
         return source with

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -172,10 +172,16 @@ public class MockHouseholdRepository : IHouseholdRepository
                 HouseholdFactory.CreateSummerEbtCase("Sophia", "Martinez", "SNAP", c =>
                 {
                     c.IssuanceType = IssuanceType.SnapEbtCard;
+                    c.IsCoLoaded = true;
+                    c.EbtCaseNumber = "SNAP-CO-001";
+                    c.ApplicationStudentId = "SNAP-PERSON-CO-001";
                 }),
                 HouseholdFactory.CreateSummerEbtCase("James", "Martinez", "TANF", c =>
                 {
                     c.IssuanceType = IssuanceType.TanfEbtCard;
+                    c.IsCoLoaded = true;
+                    c.EbtCaseNumber = "TANF-CO-001";
+                    c.ApplicationStudentId = "TANF-PERSON-CO-001";
                 })
             };
         });
@@ -184,6 +190,19 @@ public class MockHouseholdRepository : IHouseholdRepository
         coLoaded.UserProfile = new UserProfile { FirstName = "Maria", MiddleName = "Elena", LastName = "MartinezMOCK" };
         _households[coLoadedEmail] = coLoaded;
         IndexByPhone(coLoaded);
+
+        if (string.Equals(_settings.State, "dc", StringComparison.OrdinalIgnoreCase))
+        {
+            var coLoadedPendingIdProofingEmail = _settings.BuildEmail(SeedScenarios.CoLoadedPendingIdProofing.Name);
+            var fullPii = new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true);
+            var coLoadedPending = CreateCopy(coLoaded, fullPii) with
+            {
+                Email = coLoadedPendingIdProofingEmail,
+                Phone = "8185558438",
+            };
+            _households[coLoadedPendingIdProofingEmail] = coLoadedPending;
+            IndexByPhone(coLoadedPending);
+        }
 
         // Scenario 2: Approved application with address (ID verified user)
         var verifiedEmail = _settings.BuildEmail(SeedScenarios.Verified.Name);
@@ -732,6 +751,8 @@ public class MockHouseholdRepository : IHouseholdRepository
                     : null,
                 EligibilitySource = sec.EligibilitySource,
                 IssuanceType = sec.IssuanceType,
+                IsCoLoaded = sec.IsCoLoaded,
+                IsStreamlineCertified = sec.IsStreamlineCertified,
                 EbtCaseNumber = sec.EbtCaseNumber,
                 EbtCardLastFour = sec.EbtCardLastFour,
                 EbtCardStatus = sec.EbtCardStatus,

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -104,6 +104,15 @@ public class MockHouseholdRepository : IHouseholdRepository
         return GetHouseholdByIdentifierAsync(HouseholdIdentifier.Email(email), piiVisibility, userIalLevel, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public Task<bool> TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+        string benefitIdentifierIc,
+        DateOnly guardianDateOfBirth,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(false);
+    }
+
     public Task UpsertHouseholdAsync(
         HouseholdData householdData,
         CancellationToken cancellationToken = default)

--- a/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
+++ b/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
@@ -24,7 +24,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MailKit" Version="4.15.1" />
+      <PackageReference Include="MailKit" Version="4.16.0" />
+      <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
         <PrivateAssets>all</PrivateAssets>

--- a/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
@@ -40,6 +40,7 @@ public class DataSeeder : IDataSeeder
             IdProofingSessionId = user.IdProofingSessionId,
             IdProofingCompletedAt = user.IdProofingCompletedAt,
             IdProofingExpiresAt = user.IdProofingExpiresAt,
+            DateOfBirth = user.DateOfBirth,
             IsCoLoaded = user.IsCoLoaded,
             CoLoadedLastUpdated = user.CoLoadedLastUpdated,
             Phone = user.Phone,

--- a/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
@@ -131,11 +131,14 @@ public class HttpSocureClient(
                 ? settings.DiSessionToken
                 : null;
 
+        var sendIdentifierToSocure = !string.IsNullOrWhiteSpace(idType)
+            && !SocureExcludedIdentifierTypes.IsExcludedFromSocurePayload(idType);
+
         var individual = new SocureIndividual
         {
             Email = email,
             DateOfBirth = dateOfBirth,
-            NationalId = !string.IsNullOrWhiteSpace(idType) && !string.IsNullOrWhiteSpace(idValue)
+            NationalId = sendIdentifierToSocure && !string.IsNullOrWhiteSpace(idValue)
                 ? idValue
                 : null,
             DiSessionToken = effectiveDiToken,

--- a/src/SEBT.Portal.Infrastructure/Services/Socure/SocureExcludedIdentifierTypes.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/Socure/SocureExcludedIdentifierTypes.cs
@@ -1,0 +1,15 @@
+using SEBT.Portal.Core.Models.Auth;
+
+namespace SEBT.Portal.Infrastructure.Services.Socure;
+
+/// <summary>
+/// Benefit-program identifiers are not sent on Socure evaluation requests; see <see cref="IdProofingBenefitIdentifierTypes"/>.
+/// </summary>
+internal static class SocureExcludedIdentifierTypes
+{
+    /// <summary>
+    /// When true, <c>national_id</c> must not be set for this portal id type (SNAP/TANF stay in-portal).
+    /// </summary>
+    public static bool IsExcludedFromSocurePayload(string? idType) =>
+        IdProofingBenefitIdentifierTypes.IsSnapOrTanfPortalSelection(idType);
+}

--- a/src/SEBT.Portal.TestUtilities/Helpers/UserFactory.cs
+++ b/src/SEBT.Portal.TestUtilities/Helpers/UserFactory.cs
@@ -23,6 +23,8 @@ public static class UserFactory
                 : null)
         .RuleFor(u => u.IdProofingExpiresAt, (f, u) =>
             u.IdProofingCompletedAt?.AddYears(1))
+        .RuleFor(u => u.DateOfBirth, f =>
+            DateOnly.FromDateTime(f.Date.Between(DateTime.UtcNow.AddYears(-65), DateTime.UtcNow.AddYears(-21))))
         .RuleFor(u => u.IsCoLoaded, f => f.Random.Bool(0.3f))
         .RuleFor(u => u.CoLoadedLastUpdated, (f, u) =>
             u.IsCoLoaded ? f.Date.Recent(60) : null)

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -87,18 +87,50 @@ public class SubmitIdProofingCommandHandler(
                     AllowIdRetry: activeChallenge.AllowIdRetry));
         }
 
-        // Co-loaded households: SNAP/TANF IDs are verified against records we already have — no Socure national_id path.
+        // Co-loaded households: SNAP/TANF IDs must match on-file records — no Socure national_id path.
         if (user.IsCoLoaded
             && IdProofingBenefitIdentifierTypes.IsSnapOrTanfPortalSelection(command.IdType)
             && !string.IsNullOrWhiteSpace(command.IdValue))
         {
+            HouseholdData? benefitHousehold = null;
+            try
+            {
+                benefitHousehold = await householdRepository.GetHouseholdByEmailAsync(
+                    user.Email,
+                    new PiiVisibility(IncludeAddress: false, IncludeEmail: false, IncludePhone: false),
+                    user.IalLevel,
+                    cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Household lookup failed for co-loaded benefit ID verification for user {UserId}",
+                    command.UserId);
+            }
+
+            if (CoLoadedBenefitIdentifierMatch.Matches(user, benefitHousehold, command.IdType, command.IdValue))
+            {
+                logger.LogInformation(
+                    "User {UserId} co-loaded benefit ID verified for type {IdType}",
+                    command.UserId, command.IdType);
+                return await CompleteProofingAndRespond(
+                    user,
+                    cancellationToken,
+                    "co-loaded SNAP/TANF matched to on-file records (no Socure)");
+            }
+
             logger.LogInformation(
-                "User {UserId} is co-loaded and submitted benefit-program ID type {IdType}; completing proofing without Socure",
+                "User {UserId} co-loaded benefit ID did not match on-file records for type {IdType}",
                 command.UserId, command.IdType);
-            return await CompleteProofingAndRespond(
-                user,
-                cancellationToken,
-                "co-loaded SNAP/TANF in-portal match (no Socure)");
+
+            user.IdProofingAttemptCount++;
+            var allowBenefitRetry = user.IdProofingAttemptCount < maxAttempts;
+            await userRepository.UpdateUserAsync(user, cancellationToken);
+            return Result<SubmitIdProofingResponse>.Success(
+                new SubmitIdProofingResponse(
+                    "failed",
+                    AllowIdRetry: allowBenefitRetry,
+                    OffboardingReason: "idProofingFailed"));
         }
 
         // Fetch household data for user's name and address (best-effort, optional for Socure)

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -17,7 +17,7 @@ namespace SEBT.Portal.UseCases.IdProofing;
 /// 1. Validate input
 /// 2. Early exit if no ID provided (noIdProvided off-boarding)
 /// 3. Reuse existing active challenge if one exists
-/// 4. Co-loaded users with SNAP/TANF ID: complete at IAL2 without Socure
+/// 4. Co-loaded users with SNAP/TANF ID: complete at IAL1+ without Socure
 /// 5. Call Socure for risk assessment
 /// 6. Create a new challenge if document verification is required
 /// </summary>
@@ -115,6 +115,7 @@ public class SubmitIdProofingCommandHandler(
                     command.UserId, command.IdType);
                 return await CompleteProofingAndRespond(
                     user,
+                    UserIalLevel.IAL1plus,
                     cancellationToken,
                     "co-loaded SNAP/TANF matched to on-file records (no Socure)");
             }
@@ -210,6 +211,7 @@ public class SubmitIdProofingCommandHandler(
                 // Single save: attempt count + proofing completion together
                 return await CompleteProofingAndRespond(
                     user,
+                    UserIalLevel.IAL2,
                     cancellationToken,
                     "Socure ACCEPT (no DocV required)");
 
@@ -234,11 +236,12 @@ public class SubmitIdProofingCommandHandler(
 
     private async Task<Result<SubmitIdProofingResponse>> CompleteProofingAndRespond(
         User user,
+        UserIalLevel ialLevelOnCompletion,
         CancellationToken cancellationToken,
         string completionReasonForLog)
     {
         user.IdProofingStatus = IdProofingStatus.Completed;
-        user.IalLevel = UserIalLevel.IAL2;
+        user.IalLevel = ialLevelOnCompletion;
         user.IdProofingCompletedAt = DateTime.UtcNow;
         await userRepository.UpdateUserAsync(user, cancellationToken);
 

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Exceptions;
@@ -17,7 +18,7 @@ namespace SEBT.Portal.UseCases.IdProofing;
 /// 1. Validate input
 /// 2. Early exit if no ID provided (noIdProvided off-boarding)
 /// 3. Reuse existing active challenge if one exists
-/// 4. Co-loaded users with SNAP/TANF ID: complete at IAL1+ without Socure
+/// 4. Co-loaded users with SNAP/TANF ID: complete at IAL1+ without Socure (DC warehouse IC+DOB when applicable, then on-file match)
 /// 5. Call Socure for risk assessment
 /// 6. Create a new challenge if document verification is required
 /// </summary>
@@ -92,6 +93,39 @@ public class SubmitIdProofingCommandHandler(
             && IdProofingBenefitIdentifierTypes.IsSnapOrTanfPortalSelection(command.IdType)
             && !string.IsNullOrWhiteSpace(command.IdValue))
         {
+            if (DateOnly.TryParse(
+                    command.DateOfBirth,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var guardianDob))
+            {
+                try
+                {
+                    if (await householdRepository.TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+                            command.IdValue.Trim(),
+                            guardianDob,
+                            cancellationToken))
+                    {
+                        logger.LogInformation(
+                            "User {UserId} co-loaded benefit ID verified via DC warehouse (IC+DOB) for type {IdType}",
+                            command.UserId,
+                            command.IdType);
+                        return await CompleteProofingAndRespond(
+                            user,
+                            UserIalLevel.IAL1plus,
+                            cancellationToken,
+                            "co-loaded SNAP/TANF matched via DC GetHouseholdByGuardian IC+DOB (no Socure)");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "DC warehouse IC+DOB match failed for co-loaded benefit ID verification for user {UserId}",
+                        command.UserId);
+                }
+            }
+
             HouseholdData? benefitHousehold = null;
             try
             {

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -17,8 +17,9 @@ namespace SEBT.Portal.UseCases.IdProofing;
 /// 1. Validate input
 /// 2. Early exit if no ID provided (noIdProvided off-boarding)
 /// 3. Reuse existing active challenge if one exists
-/// 4. Call Socure for risk assessment
-/// 5. Create a new challenge if document verification is required
+/// 4. Co-loaded users with SNAP/TANF ID: complete at IAL2 without Socure
+/// 5. Call Socure for risk assessment
+/// 6. Create a new challenge if document verification is required
 /// </summary>
 public class SubmitIdProofingCommandHandler(
     IUserRepository userRepository,
@@ -84,6 +85,20 @@ public class SubmitIdProofingCommandHandler(
                     "documentVerificationRequired",
                     ChallengeId: activeChallenge.PublicId,
                     AllowIdRetry: activeChallenge.AllowIdRetry));
+        }
+
+        // Co-loaded households: SNAP/TANF IDs are verified against records we already have — no Socure national_id path.
+        if (user.IsCoLoaded
+            && IdProofingBenefitIdentifierTypes.IsSnapOrTanfPortalSelection(command.IdType)
+            && !string.IsNullOrWhiteSpace(command.IdValue))
+        {
+            logger.LogInformation(
+                "User {UserId} is co-loaded and submitted benefit-program ID type {IdType}; completing proofing without Socure",
+                command.UserId, command.IdType);
+            return await CompleteProofingAndRespond(
+                user,
+                cancellationToken,
+                "co-loaded SNAP/TANF in-portal match (no Socure)");
         }
 
         // Fetch household data for user's name and address (best-effort, optional for Socure)
@@ -161,7 +176,10 @@ public class SubmitIdProofingCommandHandler(
         {
             case IdProofingOutcome.Matched:
                 // Single save: attempt count + proofing completion together
-                return await CompleteProofingAndRespond(user, cancellationToken);
+                return await CompleteProofingAndRespond(
+                    user,
+                    cancellationToken,
+                    "Socure ACCEPT (no DocV required)");
 
             case IdProofingOutcome.Failed:
                 await userRepository.UpdateUserAsync(user, cancellationToken);
@@ -184,7 +202,8 @@ public class SubmitIdProofingCommandHandler(
 
     private async Task<Result<SubmitIdProofingResponse>> CompleteProofingAndRespond(
         User user,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string completionReasonForLog)
     {
         user.IdProofingStatus = IdProofingStatus.Completed;
         user.IalLevel = UserIalLevel.IAL2;
@@ -192,8 +211,9 @@ public class SubmitIdProofingCommandHandler(
         await userRepository.UpdateUserAsync(user, cancellationToken);
 
         logger.LogInformation(
-            "User {UserId} proofing completed via Socure ACCEPT (no DocV required)",
-            user.Id);
+            "User {UserId} ID proofing completed: {Reason}",
+            user.Id,
+            completionReasonForLog);
 
         return Result<SubmitIdProofingResponse>.Success(
             new SubmitIdProofingResponse("matched"));

--- a/test/SEBT.Portal.Tests/Unit/AppSettings/SeedingSettingsTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/AppSettings/SeedingSettingsTests.cs
@@ -11,10 +11,10 @@ public class SeedingSettingsTests
         var settings = new SeedingSettings
         {
             EmailPattern = "{0}@example.com",
-            CoLoadedSeedEmailOverride = "michael.corey.walsh@gmail.com",
+            CoLoadedSeedEmailOverride = "co-loaded-override@example.com",
         };
 
-        Assert.Equal("michael.corey.walsh@gmail.com", settings.BuildEmail(SeedScenarios.CoLoaded.Name));
+        Assert.Equal("co-loaded-override@example.com", settings.BuildEmail(SeedScenarios.CoLoaded.Name));
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/HttpSocureClientTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/HttpSocureClientTests.cs
@@ -260,6 +260,62 @@ public class HttpSocureClientTests
         Assert.False(individual.TryGetProperty("national_id", out _));
     }
 
+    [Fact]
+    public async Task RunIdProofingAssessment_ShouldOmitNationalId_ForSnapBenefitIdTypes()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        var client = CreateClient(handler);
+        await client.RunIdProofingAssessmentAsync(
+            42, "user@example.com", "1990-06-15", "snapAccountId", "123456789");
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        Assert.False(individual.TryGetProperty("national_id", out _));
+    }
+
+    [Fact]
+    public async Task RunIdProofingAssessment_ShouldOmitNationalId_WhenIdTypeProvidedWithoutIdValue()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "REJECT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        var client = CreateClient(handler);
+        await client.RunIdProofingAssessmentAsync(
+            42, "user@example.com", "1990-06-15", "itin", null);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        Assert.False(individual.TryGetProperty("national_id", out _));
+    }
+
     // --- DI session token ---
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Models/Auth/CoLoadedBenefitIdentifierMatchTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Models/Auth/CoLoadedBenefitIdentifierMatchTests.cs
@@ -1,0 +1,81 @@
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Models.Household;
+
+namespace SEBT.Portal.Tests.Unit.Models.Auth;
+
+public class CoLoadedBenefitIdentifierMatchTests
+{
+    [Fact]
+    public void Matches_ReturnsTrue_WhenSnapAccountEqualsUserSnapId()
+    {
+        var user = new User { SnapId = "SNAP-CO-001" };
+        Assert.True(CoLoadedBenefitIdentifierMatch.Matches(user, null, "snapAccountId", "snap-co-001"));
+    }
+
+    [Fact]
+    public void Matches_ReturnsTrue_WhenSnapAccountEqualsCoLoadedCaseEbtNumber()
+    {
+        var user = new User();
+        var household = new HouseholdData
+        {
+            SummerEbtCases =
+            [
+                new SummerEbtCase
+                {
+                    IsCoLoaded = true,
+                    IssuanceType = IssuanceType.SnapEbtCard,
+                    EbtCaseNumber = "ACC-99"
+                }
+            ]
+        };
+
+        Assert.True(CoLoadedBenefitIdentifierMatch.Matches(user, household, "snapAccountId", "acc-99"));
+    }
+
+    [Fact]
+    public void Matches_ReturnsTrue_WhenSnapPersonEqualsApplicationStudentId()
+    {
+        var user = new User();
+        var household = new HouseholdData
+        {
+            SummerEbtCases =
+            [
+                new SummerEbtCase
+                {
+                    IsCoLoaded = true,
+                    EligibilityType = "SNAP",
+                    ApplicationStudentId = "P-1"
+                }
+            ]
+        };
+
+        Assert.True(CoLoadedBenefitIdentifierMatch.Matches(user, household, "snapPersonId", "P-1"));
+    }
+
+    [Fact]
+    public void Matches_ReturnsFalse_WhenCaseNotCoLoaded()
+    {
+        var user = new User();
+        var household = new HouseholdData
+        {
+            SummerEbtCases =
+            [
+                new SummerEbtCase
+                {
+                    IsCoLoaded = false,
+                    IssuanceType = IssuanceType.SnapEbtCard,
+                    EbtCaseNumber = "X"
+                }
+            ]
+        };
+
+        Assert.False(CoLoadedBenefitIdentifierMatch.Matches(user, household, "snapAccountId", "X"));
+    }
+
+    [Fact]
+    public void Matches_ReturnsTrue_WhenTanfAccountEqualsUserTanfId()
+    {
+        var user = new User { TanfId = "TANF-1" };
+        Assert.True(CoLoadedBenefitIdentifierMatch.Matches(user, null, "tanfAccountId", "tanf-1"));
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
@@ -83,6 +83,23 @@ public class HouseholdRepositoryTests
     }
 
     [Fact]
+    public async Task TryMatchCoLoadedGuardianByBenefitIdAndDobAsync_DelegatesToPlugin()
+    {
+        var dob = new DateOnly(2000, 1, 1);
+        _summerEbtCaseService
+            .TryMatchCoLoadedGuardianByBenefitIdAndDobAsync("IC1", dob, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _repository.TryMatchCoLoadedGuardianByBenefitIdAndDobAsync("IC1", dob);
+
+        Assert.True(result);
+        await _summerEbtCaseService.Received(1).TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+            "IC1",
+            dob,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task GetHouseholdByEmailAsync_WhenPluginReturnsSummerEbtCases_MapsToCore()
     {
         var email = "guardian@example.com";

--- a/test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs
@@ -135,6 +135,34 @@ public class MockHouseholdRepositoryTests
     }
 
     [Fact]
+    public async Task GetHouseholdByEmailAsync_WhenDcCoLoadedPendingIdProofing_UsesDistinctPhoneAndCoLoadedCases()
+    {
+        var repo = CreateRepository("{0}@example.com", state: "dc");
+        const string email = "co-loaded-pending-id-proofing@example.com";
+
+        var result = await repo.GetHouseholdByEmailAsync(email, FullPiiVisibility, UserIalLevel.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(email, result!.Email);
+        Assert.Equal("8185558438", result.Phone);
+        Assert.NotNull(result.SummerEbtCases);
+        var snapCase = Assert.Single(result.SummerEbtCases.Where(c => c.EbtCaseNumber == "SNAP-CO-001"));
+        Assert.True(snapCase.IsCoLoaded);
+    }
+
+    [Fact]
+    public async Task GetHouseholdByIdentifierAsync_WhenPhone8185558438_AndDc_ReturnsCoLoadedPendingHousehold()
+    {
+        var repo = CreateRepository("{0}@example.com", state: "dc");
+        var identifier = HouseholdIdentifier.Phone("8185558438");
+
+        var result = await repo.GetHouseholdByIdentifierAsync(identifier, FullPiiVisibility, UserIalLevel.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("co-loaded-pending-id-proofing@example.com", result!.Email);
+    }
+
+    [Fact]
     public async Task GetHouseholdByEmailAsync_WhenHouseholdDoesNotExist_ReturnsNull()
     {
         // Arrange

--- a/test/SEBT.Portal.Tests/Unit/Services/DatabaseSeederTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/DatabaseSeederTests.cs
@@ -678,6 +678,31 @@ public class DatabaseSeederTests : IClassFixture<SqlServerTestFixture>
     }
 
     [Fact]
+    public async Task SeedTestUsersAsync_WithMockHouseholdData_AndStateDc_ShouldSeedCoLoadedPendingIdProofingUser()
+    {
+        using var context = CreateContext();
+        await CleanupDatabaseAsync(context);
+        var settings = new SeedingSettings { EmailPattern = "{0}@example.com", State = "dc" };
+        var seeder = CreateSeeder(context, settings);
+
+        await seeder.SeedTestUsersAsync(useMockHouseholdData: true);
+
+        var users = await context.Users.ToListAsync();
+        Assert.Equal(21, users.Count);
+        var pending = await context.Users
+            .SingleOrDefaultAsync(u => u.Email == "co-loaded-pending-id-proofing@example.com");
+        Assert.NotNull(pending);
+        Assert.True(pending!.IsCoLoaded);
+        Assert.Equal((int)IdProofingStatus.NotStarted, pending.IdProofingStatus);
+        Assert.Equal((int)UserIalLevel.None, pending.IalLevel);
+        Assert.Null(pending.IdProofingCompletedAt);
+        Assert.Null(pending.IdProofingExpiresAt);
+        Assert.Equal("8185558438", pending.Phone);
+        Assert.Equal("SNAP-CO-001", pending.SnapId);
+        Assert.Equal("TANF-CO-001", pending.TanfId);
+    }
+
+    [Fact]
     public async Task ClearSeededDataAsync_WithCustomEmailPattern_ShouldDeleteConfiguredEmails()
     {
         // Arrange

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -140,6 +140,89 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
+    // --- Co-loaded + SNAP/TANF: streamline to IAL2 without Socure ---
+
+    [Fact]
+    public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndSnapIdWithValue()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "snapAccountId", idValue: "123456789");
+        var user = new User
+        {
+            Id = command.UserId,
+            Email = "test@example.com",
+            IsCoLoaded = true,
+            IdProofingAttemptCount = 0
+        };
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("matched", result.Value.Result);
+        Assert.Equal(IdProofingStatus.Completed, user.IdProofingStatus);
+        Assert.Equal(UserIalLevel.IAL2, user.IalLevel);
+        Assert.NotNull(user.IdProofingCompletedAt);
+        Assert.Equal(0, user.IdProofingAttemptCount);
+
+        await socureClient.DidNotReceive()
+            .RunIdProofingAssessmentAsync(
+                Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSocure_WhenNotCoLoadedAndSnapIdWithValue()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "snapPersonId", idValue: "987654321");
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com", IsCoLoaded = false });
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        socureClient.RunIdProofingAssessmentAsync(
+                command.UserId, "test@example.com", command.DateOfBirth,
+                command.IdType, command.IdValue, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.Success(
+                new IdProofingAssessmentResult(IdProofingOutcome.Matched, AllowIdRetry: false)));
+
+        await handler.Handle(command, CancellationToken.None);
+
+        await socureClient.Received(1)
+            .RunIdProofingAssessmentAsync(
+                command.UserId, "test@example.com", command.DateOfBirth,
+                command.IdType, command.IdValue, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSocure_WhenCoLoadedAndSnapIdButIdValueMissing()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "snapAccountId", idValue: null);
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com", IsCoLoaded = true });
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        socureClient.RunIdProofingAssessmentAsync(
+                Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.Success(
+                new IdProofingAssessmentResult(IdProofingOutcome.Matched, AllowIdRetry: false)));
+
+        await handler.Handle(command, CancellationToken.None);
+
+        await socureClient.Received(1)
+            .RunIdProofingAssessmentAsync(
+                Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
     // --- Socure assessment: Matched ---
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -143,15 +143,16 @@ public class SubmitIdProofingCommandHandlerTests
     // --- Co-loaded + SNAP/TANF: streamline to IAL2 without Socure ---
 
     [Fact]
-    public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndSnapIdWithValue()
+    public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndSnapAccountMatchesUserSnapId()
     {
         var handler = CreateHandler();
-        var command = CreateValidCommand(idType: "snapAccountId", idValue: "123456789");
+        var command = CreateValidCommand(idType: "snapAccountId", idValue: "SNAP-CO-001");
         var user = new User
         {
             Id = command.UserId,
             Email = "test@example.com",
             IsCoLoaded = true,
+            SnapId = "SNAP-CO-001",
             IdProofingAttemptCount = 0
         };
 
@@ -159,6 +160,12 @@ public class SubmitIdProofingCommandHandlerTests
             .Returns(user);
         challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns((DocVerificationChallenge?)null);
+        householdRepository.GetHouseholdByEmailAsync(
+                user.Email,
+                Arg.Any<PiiVisibility>(),
+                user.IalLevel,
+                Arg.Any<CancellationToken>())
+            .Returns((HouseholdData?)null);
 
         var result = await handler.Handle(command, CancellationToken.None);
 
@@ -168,6 +175,93 @@ public class SubmitIdProofingCommandHandlerTests
         Assert.Equal(UserIalLevel.IAL2, user.IalLevel);
         Assert.NotNull(user.IdProofingCompletedAt);
         Assert.Equal(0, user.IdProofingAttemptCount);
+
+        await socureClient.DidNotReceive()
+            .RunIdProofingAssessmentAsync(
+                Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndSnapPersonMatchesHouseholdCase()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "snapPersonId", idValue: "SNAP-PERSON-CO-001");
+        var user = new User
+        {
+            Id = command.UserId,
+            Email = "test@example.com",
+            IsCoLoaded = true,
+            IdProofingAttemptCount = 0
+        };
+        var household = new HouseholdData
+        {
+            SummerEbtCases =
+            [
+                new SummerEbtCase
+                {
+                    IsCoLoaded = true,
+                    IssuanceType = IssuanceType.SnapEbtCard,
+                    ApplicationStudentId = "SNAP-PERSON-CO-001"
+                }
+            ]
+        };
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        householdRepository.GetHouseholdByEmailAsync(
+                user.Email,
+                Arg.Any<PiiVisibility>(),
+                user.IalLevel,
+                Arg.Any<CancellationToken>())
+            .Returns(household);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("matched", result.Value.Result);
+
+        await socureClient.DidNotReceive()
+            .RunIdProofingAssessmentAsync(
+                Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailedAndIncrementAttempts_WhenCoLoadedBenefitIdDoesNotMatch()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "snapAccountId", idValue: "wrong-id");
+        var user = new User
+        {
+            Id = command.UserId,
+            Email = "test@example.com",
+            IsCoLoaded = true,
+            SnapId = "SNAP-CO-001",
+            IdProofingAttemptCount = 0
+        };
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        householdRepository.GetHouseholdByEmailAsync(
+                user.Email,
+                Arg.Any<PiiVisibility>(),
+                user.IalLevel,
+                Arg.Any<CancellationToken>())
+            .Returns((HouseholdData?)null);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("failed", result.Value.Result);
+        Assert.Equal("idProofingFailed", result.Value.OffboardingReason);
+        Assert.True(result.Value.AllowIdRetry);
+        Assert.Equal(1, user.IdProofingAttemptCount);
+        await userRepository.Received(1).UpdateUserAsync(user, Arg.Any<CancellationToken>());
 
         await socureClient.DidNotReceive()
             .RunIdProofingAssessmentAsync(

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -140,7 +140,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
-    // --- Co-loaded + SNAP/TANF: streamline to IAL2 without Socure ---
+    // --- Co-loaded + SNAP/TANF: streamline to IAL1+ without Socure ---
 
     [Fact]
     public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndSnapAccountMatchesUserSnapId()
@@ -172,7 +172,7 @@ public class SubmitIdProofingCommandHandlerTests
         Assert.True(result.IsSuccess);
         Assert.Equal("matched", result.Value.Result);
         Assert.Equal(IdProofingStatus.Completed, user.IdProofingStatus);
-        Assert.Equal(UserIalLevel.IAL2, user.IalLevel);
+        Assert.Equal(UserIalLevel.IAL1plus, user.IalLevel);
         Assert.NotNull(user.IdProofingCompletedAt);
         Assert.Equal(0, user.IdProofingAttemptCount);
 
@@ -222,6 +222,8 @@ public class SubmitIdProofingCommandHandlerTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal("matched", result.Value.Result);
+        Assert.Equal(UserIalLevel.IAL1plus, user.IalLevel);
+        Assert.Equal(IdProofingStatus.Completed, user.IdProofingStatus);
 
         await socureClient.DidNotReceive()
             .RunIdProofingAssessmentAsync(

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -143,6 +143,54 @@ public class SubmitIdProofingCommandHandlerTests
     // --- Co-loaded + SNAP/TANF: streamline to IAL1+ without Socure ---
 
     [Fact]
+    public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndWarehouseIcDobMatches()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(
+            dob: "1984-03-05",
+            idType: "snapAccountId",
+            idValue: "IC000001");
+        var user = new User
+        {
+            Id = command.UserId,
+            Email = "test@example.com",
+            IsCoLoaded = true,
+            IdProofingAttemptCount = 0
+        };
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        householdRepository.TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+                "IC000001",
+                new DateOnly(1984, 3, 5),
+                Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("matched", result.Value.Result);
+        Assert.Equal(UserIalLevel.IAL1plus, user.IalLevel);
+        Assert.Equal(IdProofingStatus.Completed, user.IdProofingStatus);
+        await householdRepository.Received(1).TryMatchCoLoadedGuardianByBenefitIdAndDobAsync(
+            "IC000001",
+            new DateOnly(1984, 3, 5),
+            Arg.Any<CancellationToken>());
+        await householdRepository.DidNotReceive()
+            .GetHouseholdByEmailAsync(
+                Arg.Any<string>(),
+                Arg.Any<PiiVisibility>(),
+                Arg.Any<UserIalLevel>(),
+                Arg.Any<CancellationToken>());
+        await socureClient.DidNotReceive()
+            .RunIdProofingAssessmentAsync(
+                Arg.Any<int>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_ShouldCompleteProofingWithoutSocure_WhenCoLoadedAndSnapAccountMatchesUserSnapId()
     {
         var handler = CreateHandler();


### PR DESCRIPTION
#### 🔗 Jira ticket

[DC-90](https://codeforamerica.atlassian.net/browse/DC-90)
#### ✍️ Description

This work completes DC-135 by letting co-loaded guardians finish SNAP/TANF-based id proofing without calling Socure when their submitted benefit identifier and date of birth align with state rules. The handler first asks the state plugin whether the IC + guardian DOB pair matches warehouse data (`TryMatchCoLoadedGuardianByBenefitIdAndDobAsync`), then falls back to the existing on-file SNAP/TANF match against portal user/household data. Successful matches complete id proofing and raise the user to IAL1+. A DateOfBirth field is added to Users (with EF migration) so co-loaded matching and persistence stay consistent with the rest of the domain model.

#### 🔗 Links to related PRs
<!-- If applicable, include links to dependent or related PRs in this or other repos  -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig


[DC-135]: https://codeforamerica.atlassian.net/browse/DC-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DC-90]: https://codeforamerica.atlassian.net/browse/DC-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ