### PR TITLE
chore(deps): patch MailKit and System.Security.Cryptography.Xml vulnerabilities

### DIFF
--- a/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
+++ b/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MailKit" Version="4.15.1" />
+      <PackageReference Include="MailKit" Version="4.16.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
         <PrivateAssets>all</PrivateAssets>
@@ -41,6 +41,13 @@
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
       <PackageReference Include="Microsoft.FeatureManagement" Version="3.3.0" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
+      <!--
+        Pinned to override the transitive 9.0.0 pulled in by Microsoft.EntityFrameworkCore.Tools →
+        Microsoft.Build.Tasks.Core. 9.0.0 is flagged by NU1903 for CVE-2026-33116 and CVE-2026-26171
+        (DoS). 9.0.15 is the first patched release on the 9.x line. Remove this pin once
+        Microsoft.Build.Tasks.Core updates its transitive dependency.
+      -->
+      <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
     </ItemGroup>
 
   <!-- State connector as sibling repo only. Sibling under parent of portal, or CI path. -->


### PR DESCRIPTION
#### Jira ticket
_No ticket — clears GitHub Dependabot alerts for 3 advisories (2 high, 1 moderate) flagged on the default branch._

#### Description

Resolves the three NU1902 / NU1903 package vulnerability warnings that build logs have been emitting for every project in the solution.

**MailKit 4.15.1 → 4.16.0** (direct reference in `Infrastructure.csproj`)
- Fixes GHSA-9j88-vvj5-vhgr (moderate): STARTTLS response injection via unflushed stream buffer that enables SASL mechanism downgrade
- Patch release bump; no API changes

**System.Security.Cryptography.Xml → 9.0.15** (new explicit transitive pin in `Infrastructure.csproj`)
- Fixes GHSA-37gx-xxp4-5rgx (high): CVE-2026-33116 .NET DoS
- Fixes GHSA-w3x6-4m5h-cxqf (high): CVE-2026-26171 .NET DoS
- Previously pulled in at 9.0.0 transitively via `Microsoft.EntityFrameworkCore.Tools` → `Microsoft.Build.Tasks.Core 17.14.28`. Adding an explicit top-level `<PackageReference>` overrides the transitive.
- Pinned to 9.0.15 (first patched 9.x release) to stay aligned with the rest of the .NET 9 baseline EF Core tooling expects.
- Inline comment in the csproj documents why the pin exists and when it can be removed (once upstream `Microsoft.Build.Tasks.Core` updates its transitive dependency).

#### 🔗 Links to related PRs
_None._

#### ✅ Validation

Ran a live end-to-end smoke test locally against docker-compose services (mssql, mailpit, redis), not just unit tests — because a package bump can pass tests but break at runtime, and MailKit specifically was worth exercising on the wire.

| Check | Result |
|---|---|
| `dotnet list package --vulnerable --include-transitive` on Api + Infrastructure | ✅ "no vulnerable packages" |
| Full solution build | ✅ 0 errors, 0 NU warnings |
| Unit test suite (836 tests) | ✅ all pass |
| API boots with new deps | ✅ "SEBT Portal API started successfully" |
| EF Core migrations (exercises the crypto-xml transitive pin path via `Microsoft.Build.Tasks.Core`) | ✅ "Database migrations completed successfully" |
| HTTP endpoint responsive | ✅ `GET /swagger/index.html` → 200 |
| **MailKit 4.16.0 SMTP path end-to-end** (STARTTLS-patched code on the wire) | ✅ `POST /api/auth/otp/request` → 201; OTP email delivered to Mailpit inbox with expected subject |
| User seeding | ✅ 20 dev users seeded |

#### ✅ Completion tasks
- [x] Added relevant tests — _n/a, dependency version bump; existing test suite validates behavior_
- [x] Meets acceptance criteria in ticket — _clears the flagged Dependabot advisories_
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu — _n/a_
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — _n/a_
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — _n/a_
  - [ ] If appsetttings are changed, update in AWS AppConfig — _n/a_