### PR TITLE
chore: improve CLAUDE.md accuracy and completeness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## VS Code
 .vscode/
 
+## Git worktrees
+.worktrees/
+
 ## macOS Cruft
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ We're colleagues working together. Neither of us is afraid to admit we don't kno
 ### 🔴 Always Explicitly Ask a Human First!
 - Rewriting working code from scratch
 - Changing core business logic or removing functionality
-- Architectural changes. Architectural decisions are recorded as ADRs in [docs/adr/](./docs/adr/). Consult existing ADRs before proposing changes that affect architecture.
+- Architectural changes. Architectural decisions are recorded as ADRs in [docs/adr/](./docs/adr/). Consult existing ADRs before proposing changes that affect architecture. Note: some ADR numbers are accidentally reused (e.g., 0007) and may be cleaned up later — always reference ADRs by filename, not number.
 - Security modifications
 
 ## Designing Solutions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ We're colleagues working together. Neither of us is afraid to admit we don't kno
 - Preserve comments. They're documentation, not clutter.
 - Write evergreen code. Describe what code does, not when it was written. (i.e. avoid "newFunction")
 - All user-facing strings must go through i18next. Never hardcode display text in components — reference keys via the translation functions.
-- **Locale JSON files are generated — NEVER hand-edit them.** They are produced by `packages/design-system/content/scripts/generate-locales.js` from CSV exports in `packages/design-system/content/states/`. To add or change content: update the source Google Sheet, re-export the CSV, and re-run the generator (`pnpm copy:generate`). If a key is missing, note it as a content gap to resolve in the spreadsheet — do not add it directly to the JSON.
+- **Locale JSON files are generated — NEVER hand-edit them.** They are produced by `packages/design-system/content/scripts/generate-locales.js` from CSV exports in `packages/design-system/content/states/`. To add or change content: update the source Google Sheet, re-export the CSV, and re-run the generator (run `pnpm copy:generate` from within `src/SEBT.Portal.Web/` or `src/SEBT.EnrollmentChecker.Web/`). This also runs automatically via the `predev` and `prebuild` hooks. If a key is missing, note it as a content gap to resolve in the spreadsheet — do not add it directly to the JSON.
 
 ### Code style
 - C#: 4-space indent, Allman brace style (braces on own line), nullable reference types enabled (see `.editorconfig`)
@@ -52,13 +52,9 @@ We're colleagues working together. Neither of us is afraid to admit we don't kno
 - Services expose documented REST APIs.
 - This project uses Swashbuckle to auto-generate OpenAPI docs from controller attributes. When adding or changing API endpoints, ensure controller actions have appropriate route, HTTP method, and response type attributes so the generated spec stays accurate.
 ### 3. Design for deployment
-- Package services in containers with clear deployment documentation.
-- Use docker-compose.yml to define and run the complete application stack and manage services, networking, and dependencies.
-- Use multi-stage builds and slim images (like node:24-alpine, etc.) to create small, secure containers.
-- Create a non-root user in your Dockerfile and run the container process as that user.
-- Docker Compose is to create a reliable, configurable, and secure environment for your multi-container application.
-- Externalize all configuration! Configure through environment variables, feature flags, etc.
-- Load all secrets from Docker secret files (/run/secrets) or environment variables - NEVER hard code secrets in the image.
+Our government partners require containers that pass security review. Every Dockerfile and `compose.yaml` change must follow these standards:
+- Multi-stage builds with slim base images (e.g., `node:24-alpine`). Run as a non-root user.
+- Externalize all configuration via environment variables or feature flags. Load secrets from Docker secret files (`/run/secrets`) or environment variables — NEVER hardcode in the image.
 ### 4. Write for handoff
 - Write code assuming the state government partner agency will maintain it without us.
 - Include clear README files, architecture decision records, and inline documentation explaining the "why" behind any non-obvious choices.
@@ -73,12 +69,12 @@ We're colleagues working together. Neither of us is afraid to admit we don't kno
   - Key architectural libraries: next, react, i18next, react-i18next, tanstack/react-query, zod 
   - Package manager: pnpm
   - Design system: USWDS, with design tokens specified for each state
-- Containerization: Docker with docker-compose for local development
+- Containerization: Docker with Docker Compose for local development
 
 ## Testing
 We follow a test-driven development (TDD) approach: write tests first to fail, then write the implementation to make them pass.
 
-- **Backend**: xUnit for test framework, NSubstitute for mocking, Bogus for test data generation (see ADR-0007 on the factory pattern). Integration tests use Testcontainers with real MSSQL instances.
+- **Backend**: xUnit for test framework, NSubstitute for mocking, Bogus for test data generation (see [docs/adr/0007-bogus-factory-pattern-for-test-data.md](./docs/adr/0007-bogus-factory-pattern-for-test-data.md)). Integration tests use Testcontainers with real MSSQL instances.
 - **Frontend**: Vitest with React Testing Library for unit tests, Playwright for E2E tests.
 - New functionality must include tests. Prefer writing the test before the implementation.
 
@@ -119,11 +115,20 @@ pnpm dev                  # Start API + Web concurrently
 ```bash
 pnpm api:build            # Backend (Debug)
 pnpm api:test             # All backend tests
+pnpm api:test:unit        # Backend unit tests only (excludes Testcontainers/external APIs)
 dotnet test --filter "FullyQualifiedName~MyTest"  # Single backend test
 cd src/SEBT.Portal.Web && pnpm test              # Frontend tests (Vitest)
 cd src/SEBT.Portal.Web && pnpm test:e2e          # Playwright E2E tests
 pnpm ci:build             # Full Release build
 pnpm ci:test              # Full Release test suite
+```
+
+### State-Specific Development
+```bash
+pnpm dev:dc               # Build DC plugin + start API & Web for DC
+pnpm dev:co               # Build CO plugin + start API & Web for CO
+pnpm api:build-dc         # Build DC connector plugin only
+pnpm api:build-co         # Build CO connector plugin only
 ```
 
 ### Database Migrations (EF Core)
@@ -148,15 +153,22 @@ This is a .NET 10 + Next.js 16 application following Clean Architecture. For det
 - **UseCases** — Application layer: command/query handlers for auth, households
 - **Core** — Domain models, service interfaces, exceptions, settings
 - **Infrastructure** — EF Core DbContext, repositories, service implementations, migrations
+- **Infrastructure.Seeding** — Development-only data seeding services
 - **Kernel** / **Kernel.AspNetCore** — Cross-cutting base classes and ASP.NET extensions
 - **Web** — Next.js 16 frontend (React 19, USWDS 3.13, i18next)
-- **Tests** — xUnit + NSubstitute + Bogus + Testcontainers (MSSQL)
+- **EnrollmentChecker.Web** — Next.js enrollment-check standalone app (separate pnpm workspace member)
+- **TestUtilities** — Shared test helpers (Bogus factories, builders)
+- **Tests** / **UseCases.Tests** — xUnit + NSubstitute + Bogus + Testcontainers (MSSQL)
+
+#### Workspace Packages (`packages/`)
+- **design-system** — USWDS design tokens, locale generation scripts, shared content
+- **analytics** — Analytics instrumentation library
 
 ### Layer boundaries
 - Inner layers (Kernel, Core, UseCases) must not reference web/HTTP concepts (ProblemDetails, status codes, headers, controllers). They define abstractions; outer layers (Api, Web) decide how to serialize and transport them.
 
 ### Multi-State Plugin System
-State-specific behavior uses MEF (System.Composition) plugins loaded at runtime from `plugins-{state}/` directories. Plugin contracts live in the separate `sebt-self-service-portal-state-connector` repo; implementations live in per-state repos (`-dc-connector`, `-co-connector`). The `STATE` env var controls which state config overlay loads. See ADR-0007 for the design rationale.
+State-specific behavior uses MEF (System.Composition) plugins loaded at runtime from `plugins-{state}/` directories. Plugin contracts live in the separate `sebt-self-service-portal-state-connector` repo; implementations live in per-state repos (`-dc-connector`, `-co-connector`). The `STATE` env var controls which state config overlay loads. See [docs/adr/0007-multi-state-plugin-approach.md](./docs/adr/0007-multi-state-plugin-approach.md) for the design rationale.
 
 **Plugin development inner loop:** The state-connector repo builds its interface package to `~/nuget-store/` as a local NuGet source. The API project and state connector repos (e.g., `-dc-connector`) reference that package and have post-build targets that copy compiled DLLs into this repo's `src/SEBT.Portal.Api/plugins-{state}/` directory. After building a connector, restart the API to pick up changes.
 


### PR DESCRIPTION
## Summary
- Fix `docker-compose.yml` → `compose.yaml` reference
- Disambiguate ADR-0007 links with full filenames
- Add missing projects to Solution Layers (EnrollmentChecker.Web, Infrastructure.Seeding, TestUtilities, UseCases.Tests, workspace packages)
- Clarify `pnpm copy:generate` is per-app with `predev` auto-run
- Document state-specific dev commands (`dev:dc`, `dev:co`, `api:test:unit`)
- Add `.worktrees/` to `.gitignore`

## Test plan
- [ ] Verify all referenced file paths/commands are accurate
- [ ] Confirm no broken markdown links

🤖 Generated with [Claude Code](https://claude.com/claude-code)