### PR TITLE
DC-318: resolve Smarty HttpClient DI lifetime mismatch

### DIFF
--- a/src/SEBT.Portal.Infrastructure/Dependencies.cs
+++ b/src/SEBT.Portal.Infrastructure/Dependencies.cs
@@ -52,7 +52,10 @@ public static class Dependencies
         // Smarty address verification (or pass-through when disabled)
         services.AddHttpClient("Smarty", (sp, client) =>
         {
-            var smarty = sp.GetRequiredService<IOptionsSnapshot<SmartySettings>>().Value;
+            // IOptionsMonitor (singleton) instead of IOptionsSnapshot (scoped) — the
+            // AddHttpClient delegate receives the root IServiceProvider, so scoped
+            // services cannot be resolved here.
+            var smarty = sp.GetRequiredService<IOptionsMonitor<SmartySettings>>().CurrentValue;
             var baseUrl = string.IsNullOrWhiteSpace(smarty.BaseUrl)
                 ? "https://us-street.api.smartystreets.com"
                 : smarty.BaseUrl.TrimEnd('/');

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/DependenciesTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/DependenciesTests.cs
@@ -32,4 +32,41 @@ public class DependenciesTests
         Assert.Contains("UseMockHouseholdData is false", ex.Message);
         Assert.Contains("no household plugin", ex.Message);
     }
+
+    [Fact]
+    public void CreateSmartyHttpClient_CanBeCreatedFromScope_WhenSmartyEnabled()
+    {
+        // Arrange — build a real DI container with Smarty enabled and scope
+        // validation on, mimicking how ASP.NET Core validates service lifetimes.
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Smarty:Enabled"] = "true",
+                ["Smarty:AuthId"] = "test-id",
+                ["Smarty:AuthToken"] = "test-token",
+                ["Smarty:BaseUrl"] = "https://us-street.api.smartystreets.com",
+            })
+            .Build();
+
+        services.AddSingleton<IConfiguration>(config);
+        services.AddLogging();
+        services.AddPortalInfrastructureAppSettings(config);
+        services.AddPortalInfrastructureServices(config);
+
+        var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true
+        });
+
+        // Act — creating the named HttpClient triggers the configuration delegate
+        // which must resolve options from the root provider.
+        using var scope = provider.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient("Smarty");
+
+        // Assert
+        Assert.NotNull(client);
+        Assert.Equal(new Uri("https://us-street.api.smartystreets.com/"), client.BaseAddress);
+    }
 }


### PR DESCRIPTION
## Jira ticket
[DC-318](https://codeforamerica.atlassian.net/browse/DC-318?atlOrigin=eyJpIjoiMGZiNGViYjExYThjNGFiZjk1OWU1ODk4MTcxY2IyYmEiLCJwIjoiaiJ9)

## Description
The `AddHttpClient("Smarty", ...)` configuration delegate in `Dependencies.cs` was resolving `IOptionsSnapshot<SmartySettings>` (scoped) from the root `IServiceProvider`. `IHttpClientFactory` is a singleton, so its configuration delegates always receive the root provider — resolving a scoped service from root throws `InvalidOperationException`.

**Root cause:** `IOptionsSnapshot<T>` is scoped; `AddHttpClient` delegates run in singleton context.

**Fix:** Switch to `IOptionsMonitor<T>.CurrentValue` (singleton, supports live reload).

**Why it worked locally:** In local dev, state overlays (`appsettings.dc.json`) set `Smarty:Enabled = false`, so the `PassThroughAddressUpdateService` was used and the buggy HttpClient delegate never executed. In AWS, Smarty was enabled, triggering the code path.

## Related PRs
None

## Completion checklist
- [x] Tests written and passing (751 unit tests, 0 failures)
- [x] TDD approach: wrote failing test first, then fixed
- [x] No new dependencies added
- [x] Regression test prevents future lifetime mismatches in HttpClient delegates

## Test plan
- [ ] Deploy to dev-dc or dev-co with `Smarty:Enabled = true` and confirm address update no longer throws
- [ ] Verify existing address update behavior unchanged when Smarty is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DC-318]: https://codeforamerica.atlassian.net/browse/DC-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ