### PR TITLE
DC-218(bug): CSP violations, onProgress call in Socure Adapter crash fix

### DIFF
--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/adapters/socure-adapter.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/adapters/socure-adapter.test.ts
@@ -103,6 +103,21 @@ describe('SocureDocVAdapter', () => {
     expect(window.SocureDocVSDK!.launch).toHaveBeenCalledTimes(1)
   })
 
+  it('defaults onProgress to a no-op when caller omits it', async () => {
+    installMockSocureGlobal()
+    const adapter = new SocureDocVAdapter()
+    const { onProgress: _omit, ...configWithoutProgress } = createTestConfig()
+
+    await adapter.launch(configWithoutProgress)
+
+    const launchMock = window.SocureDocVSDK!.launch as ReturnType<typeof vi.fn>
+    const launchArgs = launchMock.mock.calls[0]
+    expect(launchArgs).toBeDefined()
+    const sdkOptions = launchArgs![3] as { onProgress: unknown }
+    expect(typeof sdkOptions.onProgress).toBe('function')
+    expect(() => (sdkOptions.onProgress as () => void)()).not.toThrow()
+  })
+
   it('swallows errors from SocureDocVSDK.reset()', () => {
     window.SocureDocVSDK = {
       launch: vi.fn(),

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/adapters/socure-adapter.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/adapters/socure-adapter.ts
@@ -79,13 +79,19 @@ export class SocureDocVAdapter implements DocVAdapter {
       throw new Error('SocureDocVSDK not available after script load')
     }
 
+    // Socure's SDK invokes onProgress internally without a typeof check, so
+    // passing undefined causes a runtime "TypeError: s is not a function"
+    // once the SDK reaches its step-up flow. Default to a no-op so callers
+    // that don't care about progress events still get a working capture UI.
+    const onProgress = config.onProgress ?? (() => {})
+
     window.SocureDocVSDK.launch(config.sdkKey, config.token, `#${config.containerId}`, {
       type: 'docv',
       autoOpenTabOnMobile: true,
       closeCaptureWindowOnComplete: true,
       onSuccess: config.onSuccess,
       onError: config.onError,
-      onProgress: config.onProgress
+      onProgress
     })
   }
 

--- a/src/SEBT.Portal.Web/src/proxy.ts
+++ b/src/SEBT.Portal.Web/src/proxy.ts
@@ -44,19 +44,28 @@ export function proxy(request: NextRequest) {
   // Only add upgrade-insecure-requests when actually served over HTTPS.
   const upgradeInsecure = !isDev && isHttps ? 'upgrade-insecure-requests;' : ''
 
-  // Build CSP header with nonce for script and style sources
-  // Development: Allow unsafe-eval for Next.js hot reload, unsafe-inline for styles (no nonce for styles)
-  // Production: Strict nonce-based policy with strict-dynamic for script loading
+  // Build CSP header with nonce for scripts; 'unsafe-inline' for styles.
+  // Development: Allow unsafe-eval for Next.js hot reload.
+  // Production: Strict nonce-based policy with strict-dynamic for script loading.
   //
-  // Note: When nonce is present, 'unsafe-inline' is ignored by browsers.
-  // In dev, we skip style nonce to allow HMR style injection.
+  // Script policy is strict (nonce + strict-dynamic). We intentionally use
+  // 'unsafe-inline' for style-src because Socure's Doc Verify Web SDK relies
+  // on styled-components, which injects <style> tags at runtime that can't
+  // carry our per-request nonce. A nonce-based style policy silently ignores
+  // 'unsafe-inline', so there is no way to keep both working together. Styles
+  // are a meaningfully lower-value injection target than scripts, and our
+  // other defenses (frame-ancestors 'none', no dangerouslySetInnerHTML,
+  // React's default escaping) remain in place.
+  //
+  // 'https://browser-intake-datadoghq.com' in connect-src is Socure's embedded
+  // Datadog RUM telemetry endpoint — required by the Doc Verify SDK.
   const cspHeader = `
     default-src 'self';
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://www.googletagmanager.com https://sdk.dv.socure.io ${isDev ? "'unsafe-eval'" : ''};
-    style-src 'self' ${isDev ? "'unsafe-inline'" : `'nonce-${nonce}'`} https://fonts.googleapis.com https://verify-v2.socure.com;
+    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://verify-v2.socure.com;
     font-src 'self' https://fonts.gstatic.com https://verify-v2.socure.com;
     img-src 'self' data: https: https://www.google-analytics.com;
-    connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://auth.pingone.com https://*.socure.com https://*.socure.io ${isDev ? 'ws://localhost:* http://localhost:*' : ''};
+    connect-src 'self' https://www.google-analytics.com https://*.google-analytics.com https://www.googletagmanager.com https://auth.pingone.com https://*.socure.com https://*.socure.io https://browser-intake-datadoghq.com ${isDev ? 'ws://localhost:* http://localhost:*' : ''};
     frame-src https://verify-v2.socure.com;
     child-src https://verify-v2.socure.com;
     worker-src 'self';


### PR DESCRIPTION

#### 🔗 Jira ticket
[DC-218](https://codeforamerica.atlassian.net/browse/DC-218)

#### ✍️ Description
Fix CSP violations and a latent crash that were breaking the Socure Doc Verify flow in DC dev.  The following changes are:

- Changes in `proxy.ts` to have verify.socure.com and datadog be `unsafe-inline`
- Update `socure-adapter.ts` to handle undefined onProgress callback

#### 🔗 Links to related PRs
<!-- None -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [x] If new environment variables are added, update in Tofu — _N/A, no new env vars_
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — _N/A, no new secrets_
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — _N/A, no appsetting changes_
  - [x] If appsetttings are changed, update in AWS AppConfig — _N/A_

#### 🧪 Manual verification
1. Wwalk through Login -> ID Proofing -> Doc Verify. Console should no longer show the Socure/Datadog RUM `connect-src` violations.
2. You should, at least, hit this screen without any errors: 
<img width="1256" height="489" alt="Screenshot 2026-04-22 at 3 26 00 PM" src="https://github.com/user-attachments/assets/534c195a-54b6-4cf2-a66f-6bd984686541" />

3. If you want test this like it's on a non-local environment, one easy way to do so is to modify your `etc/hosts/` to map a local hostname to localhost.  Let me know if I can help with this!

[DC-218]: https://codeforamerica.atlassian.net/browse/DC-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ