### PR TITLE
DC-313: Enforce data annotation validation on startup for options classes

### DIFF
--- a/sebt-portal.code-workspace
+++ b/sebt-portal.code-workspace
@@ -37,6 +37,7 @@
     "files.associations": {
       "*.scss": "scss",
       "*.json": "json",
+      "appsettings*.json": "jsonc",
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -62,6 +62,7 @@
     "SecretKey": "OverrideInProductionUseEnvVarIDENTIFIERHASHER__SECRETKEY"
   },
   "JwtSettings": {
+    // Intentionally empty — overridden by Secrets Manager via Tofu in deployed environments
     "SecretKey": "",
     "Issuer": "SEBT.Portal.Api",
     "Audience": "SEBT.Portal.Web",

--- a/src/SEBT.Portal.Infrastructure/Dependencies.cs
+++ b/src/SEBT.Portal.Infrastructure/Dependencies.cs
@@ -208,17 +208,21 @@ public static class Dependencies
     {
 
         services.AddOptionsWithValidateOnStart<EmailOtpSenderServiceSettings>()
-            .BindConfiguration(EmailOtpSenderServiceSettings.SectionName);
+            .BindConfiguration(EmailOtpSenderServiceSettings.SectionName)
+            .ValidateDataAnnotations();
         services.AddOptionsWithValidateOnStart<SmtpClientSettings>()
             .BindConfiguration(SmtpClientSettings.SectionName);
         services.AddOptionsWithValidateOnStart<OtpRateLimitSettings>()
-            .BindConfiguration(OtpRateLimitSettings.SectionName);
+            .BindConfiguration(OtpRateLimitSettings.SectionName)
+            .ValidateDataAnnotations();
         services.AddOptionsWithValidateOnStart<JwtSettings>()
-            .BindConfiguration(JwtSettings.SectionName);
+            .BindConfiguration(JwtSettings.SectionName)
+            .ValidateDataAnnotations();
         services.AddOptions<StateHouseholdIdSettings>()
             .BindConfiguration(StateHouseholdIdSettings.SectionName);
         services.AddOptionsWithValidateOnStart<IdentifierHasherSettings>()
-            .BindConfiguration(IdentifierHasherSettings.SectionName);
+            .BindConfiguration(IdentifierHasherSettings.SectionName)
+            .ValidateDataAnnotations();
         services.AddSingleton<IValidateOptions<IdProofingRequirementsSettings>, IdProofingRequirementsSettingsValidator>();
         services.AddOptionsWithValidateOnStart<IdProofingRequirementsSettings>()
             .BindConfiguration(IdProofingRequirementsSettings.SectionName);
@@ -244,17 +248,20 @@ public static class Dependencies
             });
 
         services.AddOptionsWithValidateOnStart<EnrollmentCheckRateLimitSettings>()
-            .BindConfiguration(EnrollmentCheckRateLimitSettings.SectionName);
+            .BindConfiguration(EnrollmentCheckRateLimitSettings.SectionName)
+            .ValidateDataAnnotations();
 
         services.AddOptionsWithValidateOnStart<WebhookRateLimitSettings>()
-            .BindConfiguration(WebhookRateLimitSettings.SectionName);
+            .BindConfiguration(WebhookRateLimitSettings.SectionName)
+            .ValidateDataAnnotations();
 
         services.AddOptions<SeedingSettings>()
             .BindConfiguration(SeedingSettings.SectionName);
 
         services.AddSingleton<IValidateOptions<SocureSettings>, SocureSettingsValidator>();
         services.AddOptionsWithValidateOnStart<SocureSettings>()
-            .BindConfiguration(SocureSettings.SectionName);
+            .BindConfiguration(SocureSettings.SectionName)
+            .ValidateDataAnnotations();
 
         services.AddSingleton<IValidateOptions<SelfServiceRulesSettings>, SelfServiceRulesSettingsValidator>();
         services.AddOptionsWithValidateOnStart<SelfServiceRulesSettings>()
@@ -262,7 +269,8 @@ public static class Dependencies
 
         services.AddSingleton<IValidateOptions<SmartySettings>, SmartySettingsValidator>();
         services.AddOptionsWithValidateOnStart<SmartySettings>()
-            .BindConfiguration(SmartySettings.SectionName);
+            .BindConfiguration(SmartySettings.SectionName)
+            .ValidateDataAnnotations();
         services.AddOptions<AddressValidationPolicySettings>()
             .BindConfiguration(AddressValidationPolicySettings.SectionName);
         services.AddOptions<AddressValidationDataSettings>()

--- a/test/SEBT.Portal.Tests/Integration/JwtSettingsStartupValidationTests.cs
+++ b/test/SEBT.Portal.Tests/Integration/JwtSettingsStartupValidationTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SEBT.Portal.Core.Services;
+using SEBT.Portal.Infrastructure.Services;
+
+namespace SEBT.Portal.Tests.Integration;
+
+/// <summary>
+/// Proves the app fails to start when JwtSettings.SecretKey is missing or too short.
+/// DC-313: Without ValidateDataAnnotations() on the JwtSettings registration,
+/// the [Required] and [MinLength(32)] attributes are not enforced and the app
+/// happily starts with an empty signing key — a critical security vulnerability.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class JwtSettingsStartupValidationTests : IDisposable
+{
+    private static readonly string[] EnvVarKeys =
+    [
+        "PluginAssemblyPaths__0",
+        "PluginAssemblyPaths__1",
+        "JwtSettings__SecretKey",
+        "STATE",
+        "Oidc__DiscoveryEndpoint",
+        "Oidc__ClientId",
+        "Oidc__CallbackRedirectUri",
+        "Oidc__CompleteLoginSigningKey",
+        "ConnectionStrings__Redis",
+        "MinimumIal__ApplicationCases",
+        "MinimumIal__CoLoadedStreamlineCases",
+        "MinimumIal__NonCoLoadedStreamlineCases"
+    ];
+
+    public JwtSettingsStartupValidationTests()
+    {
+        // Set all required config EXCEPT JwtSettings__SecretKey
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", "plugins-none");
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", "plugins-none");
+        Environment.SetEnvironmentVariable("STATE", "co");
+        Environment.SetEnvironmentVariable("Oidc__DiscoveryEndpoint", "https://auth.example.com/.well-known/openid-configuration");
+        Environment.SetEnvironmentVariable("Oidc__ClientId", "test-client");
+        Environment.SetEnvironmentVariable("Oidc__CallbackRedirectUri", "http://localhost:3000/callback");
+        Environment.SetEnvironmentVariable("Oidc__CompleteLoginSigningKey",
+            "integration-test-secret-key-at-least-32-chars!");
+        Environment.SetEnvironmentVariable("ConnectionStrings__Redis", "");
+        Environment.SetEnvironmentVariable("MinimumIal__ApplicationCases", "IAL1");
+        Environment.SetEnvironmentVariable("MinimumIal__CoLoadedStreamlineCases", "IAL1");
+        Environment.SetEnvironmentVariable("MinimumIal__NonCoLoadedStreamlineCases", "IAL1plus");
+    }
+
+    [Fact]
+    public void Startup_WithEmptyJwtSecretKey_ThrowsOptionsValidationException()
+    {
+        // appsettings.json has SecretKey: "" and we deliberately don't override it
+        Environment.SetEnvironmentVariable("JwtSettings__SecretKey", "");
+
+        using var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    ReplaceWithMock<IDatabaseMigrator>(services);
+                    ReplaceWithMock<IDatabaseSeeder>(services);
+                });
+            });
+
+        // ValidateOnStart triggers during host startup — CreateClient() surfaces the failure
+        var ex = Assert.Throws<OptionsValidationException>(() => factory.CreateClient());
+        Assert.Contains("SecretKey", ex.Message);
+    }
+
+    [Fact]
+    public void Startup_WithTooShortJwtSecretKey_ThrowsOptionsValidationException()
+    {
+        Environment.SetEnvironmentVariable("JwtSettings__SecretKey", "too-short");
+
+        using var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureServices(services =>
+                {
+                    ReplaceWithMock<IDatabaseMigrator>(services);
+                    ReplaceWithMock<IDatabaseSeeder>(services);
+                });
+            });
+
+        var ex = Assert.Throws<OptionsValidationException>(() => factory.CreateClient());
+        Assert.Contains("SecretKey", ex.Message);
+    }
+
+    private static void ReplaceWithMock<TService>(IServiceCollection services) where TService : class
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(TService));
+        if (descriptor != null)
+        {
+            services.Remove(descriptor);
+        }
+
+        services.AddScoped(_ => Substitute.For<TService>());
+    }
+
+    public void Dispose()
+    {
+        foreach (var key in EnvVarKeys)
+            Environment.SetEnvironmentVariable(key, null);
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/JwtSecretKeyValidationTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/JwtSecretKeyValidationTests.cs
@@ -32,7 +32,8 @@ public class JwtSecretKeyValidationTests
             new IdProofingValiditySettings { ValidityDays = 1826 },
             NullLogger<OidcVerificationClaimTranslator>.Instance);
 
-        return new JwtTokenService(jwtOptions, validityOptions, translator);
+        return new JwtTokenService(jwtOptions, validityOptions, translator,
+            NullLogger<JwtTokenService>.Instance);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/JwtSecretKeyValidationTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/JwtSecretKeyValidationTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Infrastructure.Services;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Services;
+
+/// <summary>
+/// Proves that JwtTokenService rejects empty or too-short SecretKey values.
+/// DC-313: Without this guard, an empty key signs tokens with HMAC-SHA256 over
+/// a zero-length secret — tokens are technically "signed" but trivially forgeable.
+/// </summary>
+public class JwtSecretKeyValidationTests
+{
+    private static JwtTokenService CreateService(string secretKey)
+    {
+        var jwtOptions = Substitute.For<IOptions<JwtSettings>>();
+        jwtOptions.Value.Returns(new JwtSettings
+        {
+            SecretKey = secretKey,
+            Issuer = "TestIssuer",
+            Audience = "TestAudience",
+            ExpirationMinutes = 60
+        });
+
+        var validityOptions = Substitute.For<IOptions<IdProofingValiditySettings>>();
+        validityOptions.Value.Returns(new IdProofingValiditySettings { ValidityDays = 1826 });
+
+        var translator = new OidcVerificationClaimTranslator(
+            new OidcVerificationClaimSettings(),
+            new IdProofingValiditySettings { ValidityDays = 1826 },
+            NullLogger<OidcVerificationClaimTranslator>.Instance);
+
+        return new JwtTokenService(jwtOptions, validityOptions, translator);
+    }
+
+    [Fact]
+    public void BuildAndSignToken_EmptySecretKey_Throws()
+    {
+        var service = CreateService("");
+        var claims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.ThrowsAny<Exception>(
+            () => service.BuildAndSignToken(1, "user@example.com", claims));
+    }
+
+    [Fact]
+    public void BuildAndSignToken_ShortSecretKey_Throws()
+    {
+        var service = CreateService("too-short");
+        var claims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.ThrowsAny<Exception>(
+            () => service.BuildAndSignToken(1, "user@example.com", claims));
+    }
+
+    [Fact]
+    public void BuildAndSignToken_ValidSecretKey_Succeeds()
+    {
+        var service = CreateService("TestSecretKeyMustBeAtLeast32CharactersLongForSecurity");
+        var claims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var token = service.BuildAndSignToken(1, "user@example.com", claims);
+
+        Assert.False(string.IsNullOrEmpty(token));
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
DC-313

#### ✍️ Description
`AddOptionsWithValidateOnStart<T>()` only controls *when* validation runs (at startup vs. on first access) — it does **not** register any validators. Without an explicit `.ValidateDataAnnotations()` call, the `[Required]`, `[MinLength]`, `[Range]`, and `[EmailAddress]` attributes on settings classes were decorative and never enforced.

**Impact:** The app could start with invalid configuration (e.g., empty `JwtSettings.SecretKey`) and pass health checks, then fail at runtime on first use. The crypto library (`SymmetricSecurityKey`) does reject empty/short keys at token-mint time, so tokens were never signed with an empty key — but the app shouldn't start at all with invalid config.

**Changes:**
- Added `.ValidateDataAnnotations()` to all 8 settings registrations that carry data annotations (`JwtSettings`, `IdentifierHasherSettings`, `EmailOtpSenderServiceSettings`, `OtpRateLimitSettings`, `EnrollmentCheckRateLimitSettings`, `WebhookRateLimitSettings`, `SocureSettings`, `SmartySettings`)
- Added unit tests proving the crypto library rejects empty/short JWT signing keys
- Added integration tests proving the app now refuses to start without a valid SecretKey
- Added JSONC comment to `appsettings.json` explaining why `SecretKey` is intentionally empty (overridden by Secrets Manager via Tofu)
- Configured VS Code workspace to treat `appsettings*.json` as JSONC so comments don't trigger lint warnings

#### 🔗 Links to related PRs
None

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [x] If new environment variables are added, update in Tofu — N/A, no new env vars
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — N/A, no new secrets
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — N/A, no new appsettings
  - [x] If appsetttings are changed, update in AWS AppConfig — Only a comment was added, no value changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)