### PR TITLE
DC Fix: seeding operations related to IdProofingCompletedAt for IAL1

### DIFF
--- a/src/SEBT.Portal.TestUtilities/Helpers/UserFactory.cs
+++ b/src/SEBT.Portal.TestUtilities/Helpers/UserFactory.cs
@@ -18,7 +18,7 @@ public static class UserFactory
         .RuleFor(u => u.IalLevel, f => f.PickRandom<UserIalLevel>())
         .RuleFor(u => u.IdProofingSessionId, f => f.Random.Guid().ToString())
         .RuleFor(u => u.IdProofingCompletedAt, (f, u) =>
-            u.IalLevel is UserIalLevel.IAL1 or UserIalLevel.IAL1plus or UserIalLevel.IAL2
+            u.IalLevel is UserIalLevel.IAL1plus or UserIalLevel.IAL2
                 ? f.Date.Recent(30)
                 : null)
         .RuleFor(u => u.IsCoLoaded, f => f.Random.Bool(0.3f))
@@ -101,8 +101,8 @@ public static class UserFactory
                 : IdProofingStatus.NotStarted;
             u.IalLevel = ialLevel;
 
-            // Set related dates when user has achieved an IAL level
-            if (ialLevel is UserIalLevel.IAL1 or UserIalLevel.IAL1plus or UserIalLevel.IAL2)
+            // IAL1+ / IAL2 store a proofing completion timestamp (matches DatabaseSeeder mock seeding).
+            if (ialLevel is UserIalLevel.IAL1plus or UserIalLevel.IAL2)
             {
                 var faker = new Faker();
                 u.IdProofingCompletedAt = faker.Date.Recent(30);

--- a/test/SEBT.Portal.Tests/Unit/Helpers/UserFactoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Helpers/UserFactoryTests.cs
@@ -1,0 +1,35 @@
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.TestUtilities.Helpers;
+
+namespace SEBT.Portal.Tests.Unit.Helpers;
+
+public class UserFactoryTests
+{
+    [Fact]
+    public void CreateUserWithStatus_IAL1_ShouldNotSetIdProofingCompletedAt()
+    {
+        var user = UserFactory.CreateUserWithStatus(UserIalLevel.IAL1);
+
+        Assert.Equal(UserIalLevel.IAL1, user.IalLevel);
+        Assert.Null(user.IdProofingCompletedAt);
+    }
+
+    [Fact]
+    public void CreateUser_WhenBogusProducesIal1_ShouldNotSetIdProofingCompletedAt()
+    {
+        var sawIal1 = false;
+        for (var i = 0; i < 400; i++)
+        {
+            var user = UserFactory.CreateUser();
+            if (user.IalLevel != UserIalLevel.IAL1)
+            {
+                continue;
+            }
+
+            sawIal1 = true;
+            Assert.Null(user.IdProofingCompletedAt);
+        }
+
+        Assert.True(sawIal1, "Expected at least one IAL1 user so the Bogus IAL/completed-at rule can be exercised.");
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
None

#### ✍️ Description
Fixes the seeder so it more accurate represents that users wouldn't have `IdProofingCompletedAt` set if their IAL level is 0 or 1.  See <img width="1052" height="557" alt="Screenshot 2026-04-23 at 1 27 13 PM" src="https://github.com/user-attachments/assets/62a19fd4-f82a-4bd4-8850-c35a6b6755b9" />.  Both `IdProofingCompletedAt` and its expire variant should be `null`

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
