### PR TITLE
Bugfix DC-296 - Socure data validation/IAL elevation

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/IdProofing/WebhookController.cs
+++ b/src/SEBT.Portal.Api/Controllers/IdProofing/WebhookController.cs
@@ -47,8 +47,12 @@ public class WebhookController(
         var command = new ProcessWebhookCommand
         {
             EventId = payload.EventId ?? string.Empty,
+            EventType = payload.EventType,
             EvalId = payload.Data?.EvalId,
             ReferenceId = ExtractReferenceId(payload),
+            // Top-level workflow decision is authoritative for routing (DC-296).
+            WorkflowDecision = payload.Data?.Decision,
+            // DocV enrichment decision is kept for diagnostic logging, not routing.
             DocumentDecision = ExtractDocumentDecision(payload),
             WebhookSignature = bearerToken
         };

--- a/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
+++ b/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
@@ -34,6 +34,7 @@
       <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.4.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.4" />
       <PackageReference Include="Bogus" Version="35.6.5" />
+      <PackageReference Include="libphonenumber-csharp" Version="9.0.27" />
       <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />

--- a/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
@@ -45,7 +45,22 @@ public class HttpSocureClient(
     {
         var settings = socureSettingsSnapshot.Value;
 
-        var request = BuildEvaluationRequest(userId, email, dateOfBirth, idType, idValue, settings, ipAddress, phoneNumber, givenName, familyName, address, diSessionToken);
+        // Normalize phone to E.164 at the Socure boundary. Defense-in-depth:
+        // malformed upstream values (e.g. seed-data artifacts) must not reach the API.
+        var normalizedPhone = PhoneNormalizer.Normalize(phoneNumber);
+        if (normalizedPhone is null && !string.IsNullOrWhiteSpace(phoneNumber))
+        {
+            logger.LogWarning("Phone number could not be normalized to E.164; dropping from Socure payload");
+        }
+        var e164Phone = normalizedPhone is null ? null : $"+1{normalizedPhone}";
+
+        // Truncate names to OpenAPI Individual maxLength (240). Names are CMS-sourced and
+        // never user-entered, so the FE cannot police this. Truncation is preferred over
+        // rejection: the name itself is valid, just over-long.
+        var truncatedGivenName = TruncateNameOrWarn(givenName, nameof(givenName));
+        var truncatedFamilyName = TruncateNameOrWarn(familyName, nameof(familyName));
+
+        var request = BuildEvaluationRequest(userId, email, dateOfBirth, idType, idValue, settings, ipAddress, e164Phone, truncatedGivenName, truncatedFamilyName, address, diSessionToken);
         var jsonContent = JsonSerializer.Serialize(request, JsonOptions);
 
         var httpClient = httpClientFactory.CreateClient("Socure");
@@ -178,12 +193,34 @@ public class HttpSocureClient(
 
         return new SocureEvaluationRequest
         {
-            Id = userId.ToString(),
+            // Per OpenAPI ConsumerOnboarding.id: must be unique per evaluation. Reusing an id
+            // causes RiskOS to treat the request as a re-run and can impact downstream workflows.
+            // The customer/transaction identifier stays on individual.id (userId).
+            Id = Guid.NewGuid().ToString(),
             Workflow = settings.Workflow,
             Timestamp = DateTime.UtcNow.ToString("o"),
             Data = new SocureEvaluationRequestData { Individual = individual }
         };
     }
+
+    /// <summary>
+    /// Truncates a name to <see cref="MaxNameLength"/> characters if needed, logging a warning.
+    /// OpenAPI Individual.given_name and Individual.family_name both specify maxLength: 240.
+    /// </summary>
+    private string? TruncateNameOrWarn(string? name, string fieldName)
+    {
+        if (name is null || name.Length <= MaxNameLength)
+        {
+            return name;
+        }
+
+        logger.LogWarning(
+            "Name field {FieldName} exceeded {MaxLength} chars ({ActualLength}); truncating for Socure payload",
+            fieldName, MaxNameLength, name.Length);
+        return name[..MaxNameLength];
+    }
+
+    private const int MaxNameLength = 240;
 
     private static SocureAddress? MapAddress(Address? address)
     {

--- a/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
@@ -205,26 +205,74 @@ public class JwtTokenService : ILocalLoginTokenService, IOidcTokenService, ISess
             .Where(c => !string.IsNullOrEmpty(c.Value))
             .ToDictionary(c => c.Type, c => c.Value, StringComparer.OrdinalIgnoreCase);
 
-        // Resolve IAL: prefer existing JWT claim, fall back to user entity
-        if (!existingClaims.ContainsKey(JwtClaimTypes.Ial))
-        {
-            existingClaims[JwtClaimTypes.Ial] = user.IalLevel switch
-            {
-                UserIalLevel.IAL1plus => "1plus",
-                UserIalLevel.IAL2 => "2",
-                _ => "1"
-            };
-        }
+        // Resolve IAL: use whichever is higher between the existing session claim
+        // and the DB value. This lets the post-DocV elevation (DB=IAL2, claim=IAL1)
+        // take effect on refresh, without ever allowing a stale or admin-edited DB
+        // downgrade to supersede a current claim (defense-in-depth).
+        var existingIalClaim = existingClaims.GetValueOrDefault(JwtClaimTypes.Ial);
+        var dbIalClaim = FormatIal(user.IalLevel);
+        existingClaims[JwtClaimTypes.Ial] = RankIal(dbIalClaim) > RankIal(existingIalClaim)
+            ? dbIalClaim
+            : existingIalClaim ?? dbIalClaim;
 
-        if (!existingClaims.ContainsKey(JwtClaimTypes.IdProofingStatus))
+        // Resolve IdProofingStatus: elevate to Completed when the DB reflects a
+        // successful DocV webhook. Any other DB state defers to the existing claim
+        // to avoid unintended downgrades (e.g., transient InProgress overwriting
+        // a still-valid Completed session).
+        var existingStatusClaim = existingClaims.GetValueOrDefault(JwtClaimTypes.IdProofingStatus);
+        if (user.IdProofingStatus == IdProofingStatus.Completed)
         {
-            existingClaims[JwtClaimTypes.IdProofingStatus] = ((int)user.IdProofingStatus).ToString();
+            existingClaims[JwtClaimTypes.IdProofingStatus] =
+                ((int)IdProofingStatus.Completed).ToString();
+
+            // Completed status must carry a completion timestamp. The BuildAndSignToken
+            // invariant enforces this; repopulate from the DB so elevation is consistent.
+            if (user.IdProofingCompletedAt.HasValue)
+            {
+                var completedAtOffset = new DateTimeOffset(
+                    user.IdProofingCompletedAt.Value, TimeSpan.Zero);
+                existingClaims[JwtClaimTypes.IdProofingCompletedAt] =
+                    completedAtOffset.ToUnixTimeSeconds().ToString();
+
+                var expiresAt = user.IdProofingCompletedAt.Value
+                    .AddDays(_validitySettings.ValidityDays);
+                existingClaims[JwtClaimTypes.IdProofingExpiresAt] =
+                    new DateTimeOffset(expiresAt, TimeSpan.Zero).ToUnixTimeSeconds().ToString();
+            }
+        }
+        else if (existingStatusClaim == null)
+        {
+            existingClaims[JwtClaimTypes.IdProofingStatus] =
+                ((int)user.IdProofingStatus).ToString();
         }
 
         var email = existingClaims.GetValueOrDefault(JwtRegisteredClaimNames.Email) ?? "";
 
         return BuildAndSignToken(user.Id, email, existingClaims);
     }
+
+    /// <summary>
+    /// Comparable rank for an IAL claim string. Higher rank = stronger assurance.
+    /// Used by <see cref="GenerateForSessionRefresh"/> to pick the elevated value.
+    /// </summary>
+    private static int RankIal(string? ial) => ial switch
+    {
+        "2" => 3,
+        "1plus" => 2,
+        "1" => 1,
+        _ => 0
+    };
+
+    /// <summary>
+    /// Formats a <see cref="UserIalLevel"/> as the JWT claim string.
+    /// </summary>
+    private static string FormatIal(UserIalLevel level) => level switch
+    {
+        UserIalLevel.IAL2 => "2",
+        UserIalLevel.IAL1plus => "1plus",
+        UserIalLevel.IAL1 => "1",
+        _ => "1"
+    };
 
     // ──────────────────────────────────────────────
     //  Shared JWT construction

--- a/src/SEBT.Portal.Infrastructure/Services/PhoneNormalizer.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/PhoneNormalizer.cs
@@ -1,0 +1,36 @@
+using PhoneNumbers;
+
+namespace SEBT.Portal.Infrastructure.Services;
+
+/// <summary>
+/// Normalizes phone numbers to 10-digit US national format using libphonenumber.
+/// Ported from the CO connector's PhoneNormalizer to keep parsing behavior consistent across plugins.
+/// </summary>
+internal static class PhoneNormalizer
+{
+    private static readonly PhoneNumberUtil PhoneUtil = PhoneNumberUtil.GetInstance();
+
+    /// <summary>
+    /// Parses and validates a phone number as a US number, returning the 10-digit
+    /// national number (e.g. "8185551234") or null if invalid.
+    /// </summary>
+    internal static string? Normalize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        try
+        {
+            var number = PhoneUtil.Parse(value, "US");
+
+            if (!PhoneUtil.IsValidNumberForRegion(number, "US"))
+                return null;
+
+            return number.NationalNumber.ToString();
+        }
+        catch (NumberParseException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SEBT.Portal.Infrastructure/Services/Socure/SocureExcludedIdentifierTypes.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/Socure/SocureExcludedIdentifierTypes.cs
@@ -4,12 +4,18 @@ namespace SEBT.Portal.Infrastructure.Services.Socure;
 
 /// <summary>
 /// Benefit-program identifiers are not sent on Socure evaluation requests; see <see cref="IdProofingBenefitIdentifierTypes"/>.
+/// Medicaid IDs are also excluded because they do not match Socure's <c>national_id</c> schema
+/// (exactly 4 or 9 digits), so they stay as a state-plugin-only identifier.
 /// </summary>
 internal static class SocureExcludedIdentifierTypes
 {
     /// <summary>
-    /// When true, <c>national_id</c> must not be set for this portal id type (SNAP/TANF stay in-portal).
+    /// When true, <c>national_id</c> must not be set for this portal id type.
+    /// SNAP/TANF stay in-portal (matched against co-loaded records) and Medicaid is excluded
+    /// because its 7 or 8 digit format is incompatible with Socure's national_id schema.
+    /// Comparison is ordinal to match the existing <see cref="IdProofingBenefitIdentifierTypes"/> convention.
     /// </summary>
     public static bool IsExcludedFromSocurePayload(string? idType) =>
-        IdProofingBenefitIdentifierTypes.IsSnapOrTanfPortalSelection(idType);
+        IdProofingBenefitIdentifierTypes.IsSnapOrTanfPortalSelection(idType)
+        || string.Equals(idType, "medicaidId", StringComparison.Ordinal);
 }

--- a/src/SEBT.Portal.TestUtilities/Helpers/HouseholdFactory.cs
+++ b/src/SEBT.Portal.TestUtilities/Helpers/HouseholdFactory.cs
@@ -13,7 +13,9 @@ public static class HouseholdFactory
 {
     private static readonly Faker<HouseholdData> HouseholdDataFaker = new Faker<HouseholdData>()
         .RuleFor(h => h.Email, f => f.Internet.Email().ToLowerInvariant())
-        .RuleFor(h => h.Phone, f => f.Phone.PhoneNumber("###-####"))
+        // Generate a valid US 10-digit phone. Area code starts 2-9 and exchange
+        // starts 2-9 per NANP rules so libphonenumber accepts the result.
+        .RuleFor(h => h.Phone, f => $"{f.Random.Int(2, 9)}{f.Random.Int(0, 99):D2}{f.Random.Int(2, 9)}{f.Random.Int(0, 99):D2}{f.Random.Int(0, 9999):D4}")
         .RuleFor(h => h.BenefitIssuanceType, f => f.PickRandom<BenefitIssuanceType>())
         .RuleFor(h => h.SummerEbtCases, _ => new List<SummerEbtCase>())
         .RuleFor(h => h.Applications, f => GenerateApplications(f))

--- a/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommand.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommand.cs
@@ -35,10 +35,25 @@ public class ProcessWebhookCommand : ICommand
 
     /// <summary>
     /// The document verification decision value from Socure's data_enrichments.
-    /// Expected values: "accept", "reject", or similar Socure-defined outcomes.
+    /// Kept for diagnostic logging; routing decisions use <see cref="WorkflowDecision"/>.
     /// </summary>
     [RegularExpression(NoControlChars, ErrorMessage = ControlCharError)]
     public string? DocumentDecision { get; init; }
+
+    /// <summary>
+    /// The top-level workflow decision from Socure (e.g., "ACCEPT", "REJECT", "RESUBMIT", "REVIEW").
+    /// This is the authoritative routing decision: it reflects the full workflow outcome
+    /// including Digital Intelligence signals, not just the DocV enrichment.
+    /// </summary>
+    [RegularExpression(NoControlChars, ErrorMessage = ControlCharError)]
+    public string? WorkflowDecision { get; init; }
+
+    /// <summary>
+    /// The Socure webhook event type (e.g., "evaluation_completed", "evaluation_paused").
+    /// Paused events are intermediate and do not carry a terminal decision.
+    /// </summary>
+    [RegularExpression(NoControlChars, ErrorMessage = ControlCharError)]
+    public string? EventType { get; init; }
 
     /// <summary>
     /// The raw webhook signature header for validation.

--- a/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
@@ -80,21 +80,27 @@ public class ProcessWebhookCommandHandler(
             return Result.Success();
         }
 
-        // Determine the new status from the document decision
-        if (IsIntermediateDecision(command.DocumentDecision))
+        // Paused events are intermediate. No terminal decision yet, challenge stays Pending.
+        if (string.Equals(command.EventType, "evaluation_paused", StringComparison.OrdinalIgnoreCase))
         {
             logger.LogInformation(
-                "Webhook event {EventId}: intermediate decision {Decision}, challenge {ChallengeId} stays Pending",
-                SanitizeForLogging(command.EventId), SanitizeForLogging(command.DocumentDecision), challenge.PublicId);
+                "Webhook event {EventId}: evaluation_paused, challenge {ChallengeId} stays Pending",
+                SanitizeForLogging(command.EventId), challenge.PublicId);
             return Result.Success();
         }
 
-        var newStatus = MapDecisionToStatus(command.DocumentDecision);
+        // Route on the top-level workflow decision (DC-296). The DocV enrichment decision is
+        // diagnostic only: it reflects document quality alone and can disagree with the
+        // workflow outcome when Digital Intelligence signals drive a reject.
+        var newStatus = MapWorkflowDecisionToStatus(command.WorkflowDecision);
         if (newStatus == null)
         {
             logger.LogWarning(
-                "Webhook event {EventId} has unrecognized document decision: {Decision}",
-                SanitizeForLogging(command.EventId), SanitizeForLogging(command.DocumentDecision));
+                "Webhook event {EventId} has unrecognized workflow decision: {WorkflowDecision} " +
+                "(DocV enrichment decision was {DocumentDecision})",
+                SanitizeForLogging(command.EventId),
+                SanitizeForLogging(command.WorkflowDecision),
+                SanitizeForLogging(command.DocumentDecision));
             return Result.Success();
         }
 
@@ -189,21 +195,23 @@ public class ProcessWebhookCommandHandler(
     }
 
     /// <summary>
-    /// Returns true for Socure decisions that mean "not done yet" — the challenge stays Pending.
-    /// review: escalated to manual human review, follow-up webhook will arrive.
-    /// resubmit: document quality insufficient, user can retry within the existing session.
+    /// Maps the top-level Socure workflow decision to our DocV challenge status (DC-296).
+    /// ACCEPT -> Verified.
+    /// REJECT -> Rejected.
+    /// RESUBMIT -> Rejected. The workflow terminated (e.g. user declined on the Capture App
+    /// before uploading). Treated as terminal rejection here; DC-138 resubmit scaffold will
+    /// refine this once in-session retries are supported.
+    /// REVIEW -> Rejected. DC does not use human review queues, so we treat review as a safe
+    /// default reject.
     /// </summary>
-    private static bool IsIntermediateDecision(string? decision)
+    private static DocVerificationStatus? MapWorkflowDecisionToStatus(string? decision)
     {
-        return decision?.ToLowerInvariant() is "review" or "resubmit";
-    }
-
-    private static DocVerificationStatus? MapDecisionToStatus(string? decision)
-    {
-        return decision?.ToLowerInvariant() switch
+        return decision?.ToUpperInvariant() switch
         {
-            "accept" => DocVerificationStatus.Verified,
-            "reject" => DocVerificationStatus.Rejected,
+            "ACCEPT" => DocVerificationStatus.Verified,
+            "REJECT" => DocVerificationStatus.Rejected,
+            "RESUBMIT" => DocVerificationStatus.Rejected,
+            "REVIEW" => DocVerificationStatus.Rejected,
             _ => null
         };
     }

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -58,6 +58,21 @@ public class SubmitIdProofingCommandHandler(
                 "DateOfBirth must be a valid date in yyyy-MM-dd format.");
         }
 
+        // Defense-in-depth: SSN/ITIN must be exactly 9 digits after stripping non-digit
+        // characters. OpenAPI permits 4-digit partial SSNs, but product decision for DC-296
+        // is full 9 only (aligned with the frontend schema). Other id types have different
+        // format rules and are not policed here.
+        if (IsSsnOrItin(command.IdType)
+            && !IsExactlyNineDigitsAfterStripping(command.IdValue))
+        {
+            logger.LogWarning(
+                "ID proofing submission rejected for user {UserId}: IdValue for SSN/ITIN is not 9 digits",
+                command.UserId);
+            return Result<SubmitIdProofingResponse>.ValidationFailed(
+                nameof(SubmitIdProofingCommand.IdValue),
+                "IdValue must be 9 digits for SSN or ITIN.");
+        }
+
         // Load the user — needed for email (passed to Socure)
         var user = await userRepository.GetUserByIdAsync(command.UserId, cancellationToken);
         if (user == null)
@@ -369,5 +384,33 @@ public class SubmitIdProofingCommandHandler(
                 "documentVerificationRequired",
                 ChallengeId: challenge.PublicId,
                 AllowIdRetry: allowIdRetry));
+    }
+
+    private static bool IsSsnOrItin(string? idType)
+    {
+        return string.Equals(idType, "ssn", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(idType, "itin", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExactlyNineDigitsAfterStripping(string? idValue)
+    {
+        if (idValue is null)
+        {
+            return false;
+        }
+
+        var digitCount = 0;
+        foreach (var ch in idValue)
+        {
+            if (char.IsDigit(ch))
+            {
+                digitCount++;
+                if (digitCount > 9)
+                {
+                    return false;
+                }
+            }
+        }
+        return digitCount == 9;
     }
 }

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.test.tsx
@@ -42,7 +42,7 @@ import OffBoardingPage from './page'
 const mockGetState = vi.mocked(getState)
 const mockGetStateLinks = vi.mocked(getStateLinks)
 
-async function renderPage(searchParams: { canApply?: string } = {}) {
+async function renderPage(searchParams: { canApply?: string; reason?: string } = {}) {
   const page = await OffBoardingPage({
     searchParams: Promise.resolve(searchParams)
   })
@@ -155,6 +155,59 @@ describe('OffBoardingPage', () => {
 
       const content = screen.getByTestId('off-boarding-content')
       expect(content).toHaveAttribute('data-back-href', '/login/id-proofing')
+    })
+  })
+
+  describe('searchParams.reason branching', () => {
+    it('renders noIdProvided-specific title and body when reason is noIdProvided', async () => {
+      await renderPage({ reason: 'noIdProvided' })
+
+      const content = screen.getByTestId('off-boarding-content')
+      expect(content).toHaveAttribute('data-title', 'We need an ID to verify you')
+      expect(content).toHaveAttribute(
+        'data-body',
+        "To confirm your identity, we need one of the listed IDs. If you don't have any of these IDs, contact us for help."
+      )
+    })
+
+    it('forces canApply to false for noIdProvided regardless of query param', async () => {
+      await renderPage({ reason: 'noIdProvided', canApply: 'true' })
+
+      const content = screen.getByTestId('off-boarding-content')
+      expect(content).toHaveAttribute('data-can-apply', 'false')
+    })
+
+    it('falls back to generic offBoarding copy when reason is absent', async () => {
+      await renderPage({})
+
+      const content = screen.getByTestId('off-boarding-content')
+      expect(content).toHaveAttribute('data-title', 'offBoarding:title')
+      expect(content).toHaveAttribute('data-body', 'offBoarding:body1')
+    })
+
+    it('falls back to generic copy for unknown reasons', async () => {
+      await renderPage({ reason: 'somethingElse' })
+
+      const content = screen.getByTestId('off-boarding-content')
+      expect(content).toHaveAttribute('data-title', 'offBoarding:title')
+    })
+
+    it('renders docVerificationFailed-specific title and body when reason is docVerificationFailed', async () => {
+      await renderPage({ reason: 'docVerificationFailed' })
+
+      const content = screen.getByTestId('off-boarding-content')
+      expect(content).toHaveAttribute('data-title', "We couldn't verify your identity")
+      expect(content).toHaveAttribute(
+        'data-body',
+        "Your document couldn't be verified. You can try again with a different ID, or contact us if you need help."
+      )
+    })
+
+    it('forces canApply to false for docVerificationFailed regardless of query param', async () => {
+      await renderPage({ reason: 'docVerificationFailed', canApply: 'true' })
+
+      const content = screen.getByTestId('off-boarding-content')
+      expect(content).toHaveAttribute('data-can-apply', 'false')
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.tsx
@@ -3,12 +3,12 @@ import { getTranslations } from '@/lib/translations'
 import { getState, getStateLinks } from '@sebt/design-system'
 
 interface OffBoardingPageProps {
-  searchParams: Promise<{ canApply?: string }>
+  searchParams: Promise<{ canApply?: string; reason?: string }>
 }
 
 export default async function OffBoardingPage({ searchParams }: OffBoardingPageProps) {
   const params = await searchParams
-  const canApply = params.canApply !== 'false'
+  const canApplyParam = params.canApply !== 'false'
 
   const state = getState()
   const links = getStateLinks(state)
@@ -19,13 +19,34 @@ export default async function OffBoardingPage({ searchParams }: OffBoardingPageP
   const contactHref =
     links.help.contactUs !== '#' ? links.help.contactUs : (links.help.helpDeskEmail ?? '#')
 
+  // Reason-specific copy. Each branch overrides the generic offBoarding.json text
+  // (which reads like a DocV lead-in) with tone-appropriate messaging, and forces
+  // canApply=false to suppress the Apply-now block until product decides which
+  // failure modes allow re-application.
+  // TODO: Replace hardcoded strings with t(...) keys once they exist in dc.csv.
+  let title = t('title')
+  let body = t('body1')
+  let canApply = canApplyParam
+
+  if (params.reason === 'noIdProvided') {
+    title = 'We need an ID to verify you'
+    body =
+      "To confirm your identity, we need one of the listed IDs. If you don't have any of these IDs, contact us for help."
+    canApply = false
+  } else if (params.reason === 'docVerificationFailed') {
+    title = "We couldn't verify your identity"
+    body =
+      "Your document couldn't be verified. You can try again with a different ID, or contact us if you need help."
+    canApply = false
+  }
+
   return (
     <div className="usa-section">
       <div className="grid-container maxw-tablet">
         <section aria-labelledby="off-boarding-title">
           <OffBoardingContent
-            title={t('title')}
-            body={t('body1')}
+            title={title}
+            body={body}
             backHref="/login/id-proofing"
             contactHref={contactHref}
             // TODO: Use t('action1') once key is available in dc.csv

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/page.tsx
@@ -15,35 +15,49 @@ const DC_ID_OPTIONS: IdOption[] = [
   {
     value: 'ssn',
     labelKey: 'optionLabelSsn',
-    inputLabelKey: 'labelSsn'
+    inputLabelKey: 'labelSsn',
+    // SSN is federally 9 digits. Shared Zod schema also enforces this.
+    validation: { digits: 9 }
   },
   {
     value: 'itin',
     labelKey: 'optionLabelItin',
-    inputLabelKey: 'labelItin'
+    inputLabelKey: 'labelItin',
+    // ITIN is federally 9 digits. Shared Zod schema also enforces this.
+    validation: { digits: 9 }
   },
   {
     value: 'medicaidId',
     labelKey: 'optionLabelMedicaidId',
     helperKey: 'optionHelperMedicaidId',
-    inputLabelKey: 'labelMedicaidId'
+    inputLabelKey: 'labelMedicaidId',
+    // DC CSV: "typically 7 or 8 digits long".
+    validation: { digits: [7, 8] }
   },
   {
     value: 'snapAccountId',
     labelKey: 'optionAccountId',
     helperKey: 'optionHelperAccountId',
-    inputLabelKey: 'labelAccountId'
+    inputLabelKey: 'labelAccountId',
+    // DC CSV: "typically 7 or 8 digits long".
+    validation: { digits: [7, 8] }
   },
   {
     value: 'snapPersonId',
     labelKey: 'optionPersonId',
     helperKey: 'optionHelperPersonId',
-    inputLabelKey: 'labelPersonId'
+    inputLabelKey: 'labelPersonId',
+    // DC CSV: "typically 7 or 8 digits long".
+    validation: { digits: [7, 8] }
   },
   {
     value: 'none',
-    // TODO: Use t('optionLabelNone') once key is available in dc.csv
-    labelKey: 'optionLabelNone'
+    // Cross-namespace lookup: the label key "noneOfTheAbove" lives in the
+    // common namespace (sourced from CSV row "GLOBAL - Option - None of the
+    // above"). The form's useTranslation() targets the idProofing namespace,
+    // so the "common:" prefix tells i18next to resolve from common instead.
+    labelKey: 'common:noneOfTheAbove'
+    // No validation: "none of the above" skips the ID value input entirely.
   }
 ]
 

--- a/src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/schema.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/schema.test.ts
@@ -1,0 +1,197 @@
+/**
+ * SubmitIdProofingRequestSchema unit tests.
+ *
+ * Phase 1 of DC-296 guards against malformed payloads reaching the backend
+ * (and therefore Socure). These cases cover:
+ *   - SSN/ITIN must be exactly 9 digits after stripping non-digits.
+ *   - DOB must be a real calendar date, not in the future, not >120 years ago.
+ *
+ * snapAccountId, snapPersonId, and medicaidId are intentionally not shape-checked
+ * here: snap ids are excluded from Socure enrichment, and medicaidId length has
+ * an open product/policy question (DC CSV says "7 or 8 digits", Socure expects
+ * "4 or 9").
+ */
+import { describe, expect, it } from 'vitest'
+
+import { SubmitIdProofingRequestSchema } from './schema'
+
+// Base payload with a known-good DOB. Tests override only what they exercise.
+const GOOD_DOB = { month: '03', day: '10', year: '1990' }
+
+function basePayload(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    dateOfBirth: GOOD_DOB,
+    idType: 'ssn' as const,
+    idValue: '999999999',
+    ...overrides
+  }
+}
+
+function issueOnPath(
+  result: ReturnType<typeof SubmitIdProofingRequestSchema.safeParse>,
+  path: string
+) {
+  if (result.success) return undefined
+  return result.error.issues.find((i) => i.path.join('.') === path)
+}
+
+describe('SubmitIdProofingRequestSchema — SSN shape', () => {
+  it('accepts a 9-digit SSN', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(basePayload({ idValue: '123456789' }))
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an 8-digit SSN with an idValue error', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(basePayload({ idValue: '12345678' }))
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'idValue')).toBeDefined()
+  })
+
+  it('rejects a 10-digit SSN with an idValue error', () => {
+    // This is the exact failure mode observed in DC-296: 10 digits landed in
+    // Socure's national_id and triggered blanket 400s.
+    const result = SubmitIdProofingRequestSchema.safeParse(basePayload({ idValue: '1234567890' }))
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'idValue')).toBeDefined()
+  })
+
+  it('rejects a non-numeric SSN with an idValue error', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(basePayload({ idValue: 'abcdefghi' }))
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'idValue')).toBeDefined()
+  })
+})
+
+describe('SubmitIdProofingRequestSchema — ITIN shape', () => {
+  it('accepts a 9-digit ITIN', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({ idType: 'itin', idValue: '912345678' })
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an 8-digit ITIN with an idValue error', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({ idType: 'itin', idValue: '12345678' })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'idValue')).toBeDefined()
+  })
+
+  it('rejects a 10-digit ITIN with an idValue error', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({ idType: 'itin', idValue: '1234567890' })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'idValue')).toBeDefined()
+  })
+
+  it('rejects a non-numeric ITIN with an idValue error', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({ idType: 'itin', idValue: 'abcdefghi' })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'idValue')).toBeDefined()
+  })
+})
+
+describe('SubmitIdProofingRequestSchema — SSN/ITIN non-digit stripping', () => {
+  // The UI strips non-digits before submission, but defence-in-depth: validate
+  // against the digit-only form so a dashed input "555-44-3333" parses as 9.
+  it('accepts a dashed SSN whose digit count is 9', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(basePayload({ idValue: '555-44-3333' }))
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('SubmitIdProofingRequestSchema — DOB validation', () => {
+  it('rejects a DOB in the future', () => {
+    const future = new Date()
+    future.setFullYear(future.getFullYear() + 1)
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: {
+          month: String(future.getMonth() + 1).padStart(2, '0'),
+          day: String(future.getDate()).padStart(2, '0'),
+          year: String(future.getFullYear())
+        }
+      })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'dateOfBirth')).toBeDefined()
+  })
+
+  it('rejects Feb 30 as an invalid calendar date', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: { month: '02', day: '30', year: '1990' }
+      })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'dateOfBirth')).toBeDefined()
+  })
+
+  it('rejects Feb 29 in a non-leap year', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: { month: '02', day: '29', year: '2023' }
+      })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'dateOfBirth')).toBeDefined()
+  })
+
+  it('accepts Feb 29 in a leap year', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: { month: '02', day: '29', year: '2020' }
+      })
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a DOB more than 120 years ago', () => {
+    const tooOldYear = new Date().getFullYear() - 121
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: { month: '01', day: '15', year: String(tooOldYear) }
+      })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'dateOfBirth')).toBeDefined()
+  })
+
+  it('rejects a month outside 1-12', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: { month: '13', day: '15', year: '1990' }
+      })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'dateOfBirth')).toBeDefined()
+  })
+
+  it('rejects a day of 0', () => {
+    const result = SubmitIdProofingRequestSchema.safeParse(
+      basePayload({
+        idType: null,
+        idValue: null,
+        dateOfBirth: { month: '06', day: '00', year: '1990' }
+      })
+    )
+    expect(result.success).toBe(false)
+    expect(issueOnPath(result, 'dateOfBirth')).toBeDefined()
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/schema.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/schema.ts
@@ -5,6 +5,86 @@ import { z } from 'zod'
 export const IdTypeSchema = z.enum(['snapAccountId', 'snapPersonId', 'medicaidId', 'ssn', 'itin'])
 export type IdType = z.infer<typeof IdTypeSchema>
 
+// Phase 1 of DC-296: guard malformed national IDs and nonsense DOBs so they
+// never reach the backend (and therefore Socure). The UI input strips non-digit
+// characters on change, but this schema is the contract of last resort.
+const SSN_ITIN_DIGIT_COUNT = 9
+// Maximum plausible age. 120 years is the high end for a living person.
+// TODO(DC-296 follow-up): revisit with product if we want a tighter bound.
+const MAX_AGE_YEARS = 120
+// Medicaid ID shape is intentionally NOT validated here. DC CSV advertises
+// "7 or 8 digits" but Socure expects "4 or 9" — this is a separate open
+// product/policy question tracked outside DC-296.
+
+// Returns true when (month, day, year) describes a real calendar date. Rejects
+// Feb 30, Feb 29 in non-leap years, month 13, etc. Relies on JS Date rollover
+// behaviour: setting month=1 (Feb), day=30 produces March 2, so getMonth()
+// no longer equals the input.
+function isRealCalendarDate(year: number, month: number, day: number): boolean {
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return false
+  if (month < 1 || month > 12) return false
+  if (day < 1 || day > 31) return false
+  const d = new Date(year, month - 1, day)
+  return d.getFullYear() === year && d.getMonth() === month - 1 && d.getDate() === day
+}
+
+function validateDateOfBirth(
+  dob: { month: string; day: string; year: string },
+  ctx: z.RefinementCtx
+): void {
+  // Only run shape checks when all three fields are present. Empty-field
+  // required-ness is enforced at the form layer with field-level errors.
+  if (!dob.month || !dob.day || !dob.year) return
+
+  const month = Number(dob.month)
+  const day = Number(dob.day)
+  const year = Number(dob.year)
+
+  if (!isRealCalendarDate(year, month, day)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dateOfBirth'],
+      message: 'dateOfBirth must be a real calendar date'
+    })
+    return
+  }
+
+  const dobDate = new Date(year, month - 1, day)
+  const now = new Date()
+  if (dobDate.getTime() > now.getTime()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dateOfBirth'],
+      message: 'dateOfBirth cannot be in the future'
+    })
+    return
+  }
+
+  const oldestAllowed = new Date(now.getFullYear() - MAX_AGE_YEARS, now.getMonth(), now.getDate())
+  if (dobDate.getTime() < oldestAllowed.getTime()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dateOfBirth'],
+      message: `dateOfBirth cannot be more than ${MAX_AGE_YEARS} years ago`
+    })
+  }
+}
+
+function validateIdValueShape(idType: IdType, idValue: string, ctx: z.RefinementCtx): void {
+  if (idType === 'ssn' || idType === 'itin') {
+    const digits = idValue.replace(/\D/g, '')
+    if (digits.length !== SSN_ITIN_DIGIT_COUNT) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['idValue'],
+        message: `${idType} must be exactly ${SSN_ITIN_DIGIT_COUNT} digits`
+      })
+    }
+  }
+  // snapAccountId / snapPersonId: excluded from Socure payload, no shape check here.
+  // medicaidId: open product question, no shape check here.
+}
+
 export const SubmitIdProofingRequestSchema = z
   .object({
     dateOfBirth: z.object({
@@ -35,8 +115,12 @@ export const SubmitIdProofingRequestSchema = z
           path: ['idValue'],
           message: 'idValue is required when idType is not null'
         })
+      } else {
+        validateIdValueShape(data.idType, v, ctx)
       }
     }
+
+    validateDateOfBirth(data.dateOfBirth, ctx)
   })
 
 export type SubmitIdProofingRequest = z.infer<typeof SubmitIdProofingRequestSchema>

--- a/src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/useSubmitIdProofing.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/useSubmitIdProofing.test.tsx
@@ -111,7 +111,11 @@ describe('useSubmitIdProofing', () => {
         expect(result.current.isSuccess).toBe(true)
       })
 
-      expect(result.current.data).toEqual({ result: 'failed', canApply: true })
+      expect(result.current.data).toEqual({
+        result: 'failed',
+        canApply: true,
+        offboardingReason: 'noIdProvided'
+      })
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
@@ -13,15 +13,14 @@ import { DocVerifyPage } from './DocVerifyPage'
 const TEST_CONTACT_LINK = 'https://example.com/contact'
 const TEST_SDK_KEY = 'test-sdk-key'
 
-// Mock next/navigation
+// Mock next/navigation. The router object is memoized so useCallback deps that
+// include `router` stay stable across renders, matching the real Next.js hook.
 const mockPush = vi.fn()
 const mockReplace = vi.fn()
+const mockRouter = { push: mockPush, replace: mockReplace }
 let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: mockPush,
-    replace: mockReplace
-  }),
+  useRouter: () => mockRouter,
   useSearchParams: () => mockSearchParams
 }))
 
@@ -430,6 +429,85 @@ describe('DocVerifyPage', () => {
 
       // Challenge context should be cleared
       expect(sessionStorage.getItem('docVerify_challengeId')).toBeNull()
+    })
+
+    it('refreshes the JWT before navigating to dashboard on verified', async () => {
+      setChallengeContext('challenge-abc', 'pending')
+
+      // Record the order in which the refresh endpoint resolves and the
+      // router navigates. The dashboard carries stale IAL claims if we
+      // navigate before the fresh Set-Cookie arrives (DC-296 race).
+      const callOrder: string[] = []
+
+      server.use(
+        http.get('/api/id-proofing/status', () => {
+          return HttpResponse.json({ status: 'verified' })
+        }),
+        http.post('/api/auth/refresh', async () => {
+          // Simulate network latency so navigation cannot race ahead.
+          await new Promise((resolve) => setTimeout(resolve, 50))
+          callOrder.push('refresh')
+          return new HttpResponse(null, { status: 204 })
+        })
+      )
+
+      mockPush.mockImplementation((path: string) => {
+        if (path === '/dashboard') {
+          callOrder.push('navigate')
+        }
+      })
+
+      renderWithProviders(
+        <DocVerifyPage
+          contactLink={TEST_CONTACT_LINK}
+          sdkKey={TEST_SDK_KEY}
+        />
+      )
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/dashboard')
+      })
+
+      // Refresh must be awaited before navigation so the dashboard's first
+      // fetches carry the rotated JWT with IAL2.
+      expect(callOrder).toEqual(['refresh', 'navigate'])
+    })
+
+    it('still navigates to dashboard when refresh fails', async () => {
+      setChallengeContext('challenge-abc', 'pending')
+
+      let refreshCalled = false
+
+      server.use(
+        http.get('/api/id-proofing/status', () => {
+          return HttpResponse.json({ status: 'verified' })
+        }),
+        http.post('/api/auth/refresh', () => {
+          refreshCalled = true
+          return HttpResponse.json({ error: 'Server error' }, { status: 500 })
+        })
+      )
+
+      renderWithProviders(
+        <DocVerifyPage
+          contactLink={TEST_CONTACT_LINK}
+          sdkKey={TEST_SDK_KEY}
+        />
+      )
+
+      // A failed refresh must not trap the user on the "verified" screen.
+      // Allow extra time because the refresh mutation may retry on 5xx per
+      // useRefreshToken's retry policy before the catch fires.
+      await waitFor(
+        () => {
+          expect(mockPush).toHaveBeenCalledWith('/dashboard')
+        },
+        { timeout: 5000 }
+      )
+
+      // And refresh must have been attempted. Otherwise we would have shipped
+      // the original bug (navigating with stale JWT) alongside the fallback.
+      expect(refreshCalled).toBe(true)
     })
 
     it('navigates to off-boarding when status endpoint returns 404', async () => {

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
@@ -326,12 +326,12 @@ describe('DocVerifyPage', () => {
 
       await waitFor(
         () => {
-          expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding')
+          expect(mockPush).toHaveBeenCalledWith(
+            '/login/id-proofing/off-boarding?reason=docVerificationFailed'
+          )
         },
         { timeout: 1000 }
       )
-
-      expect(sessionStorage.getItem('offboarding_reason')).toBe('docVerificationFailed')
     })
   })
 
@@ -527,10 +527,10 @@ describe('DocVerifyPage', () => {
       )
 
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding')
+        expect(mockPush).toHaveBeenCalledWith(
+          '/login/id-proofing/off-boarding?reason=challengeNotFound'
+        )
       })
-
-      expect(sessionStorage.getItem('offboarding_reason')).toBe('challengeNotFound')
     })
 
     it('navigates to off-boarding when verification is rejected', async () => {
@@ -553,10 +553,10 @@ describe('DocVerifyPage', () => {
       )
 
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding')
+        expect(mockPush).toHaveBeenCalledWith(
+          '/login/id-proofing/off-boarding?reason=docVerificationFailed'
+        )
       })
-
-      expect(sessionStorage.getItem('offboarding_reason')).toBe('docVerificationFailed')
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
@@ -13,7 +13,7 @@ import {
   SK_SUB_STATE,
   SubState
 } from '@/features/auth/components/doc-verify/sessionKeys'
-import { useStartChallenge, useVerificationStatus } from '../../api'
+import { useRefreshToken, useStartChallenge, useVerificationStatus } from '../../api'
 import { createDocVAdapter, type DocVAdapter, type DocVAdapterConfig } from './adapters'
 import { DocVerifyCapture } from './DocVerifyCapture'
 import { DocVerifyInterstitial } from './DocVerifyInterstitial'
@@ -49,6 +49,7 @@ export function DocVerifyPage({ contactLink, sdkKey }: DocVerifyPageProps) {
   const searchParams = useSearchParams()
   const { t } = useTranslation('idProofing')
   const startChallenge = useStartChallenge()
+  const refreshToken = useRefreshToken()
 
   const [subState, setSubState] = useState<SubState>('interstitial')
   const [challengeId, setChallengeId] = useState<string | null>(null)
@@ -150,12 +151,34 @@ export function DocVerifyPage({ contactLink, sdkKey }: DocVerifyPageProps) {
     router.push('/login/id-proofing')
   }, [router])
 
-  const handleVerified = useCallback(() => {
+  // Pin the latest mutateAsync through a ref so handleVerified's identity is
+  // not affected by the mutation's internal status flips. Without this,
+  // VerificationPending's effect (which depends on onVerified) would re-run
+  // every time the refresh mutation's state changed, calling handleVerified
+  // again and creating an infinite update loop.
+  const refreshTokenAsyncRef = useRef(refreshToken.mutateAsync)
+  useEffect(() => {
+    refreshTokenAsyncRef.current = refreshToken.mutateAsync
+  }, [refreshToken.mutateAsync])
+
+  const handleVerified = useCallback(async () => {
     setPageData('docv_status', 'success')
     trackEvent(AnalyticsEvents.DOCV_RESULT)
     setPageData('idv_final_status', 'success')
     trackEvent(AnalyticsEvents.IDV_FINAL_RESULT)
     clearChallengeContext()
+
+    // DC-296: the webhook just bumped the user to IAL2 server-side. Await a
+    // token refresh so the rotated HttpOnly cookie is in place before we
+    // navigate. Otherwise the dashboard's first fetches race the refresh and
+    // hit the IAL guard with the stale IAL1 JWT. Swallow failures so we never
+    // trap the user on the "verified" screen; the dashboard will recover.
+    try {
+      await refreshTokenAsyncRef.current()
+    } catch {
+      // Intentionally silent. Fresh cookie did not arrive; proceed anyway.
+    }
+
     router.push('/dashboard')
   }, [router, setPageData, trackEvent])
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
@@ -126,10 +126,8 @@ export function DocVerifyPage({ contactLink, sdkKey }: DocVerifyPageProps) {
           setSubState('pending')
         },
         onError: () => {
-          sessionStorage.setItem('offboarding_reason', 'docVerificationFailed')
-          sessionStorage.setItem('offboarding_canApply', 'false')
           clearChallengeContext()
-          router.push('/login/id-proofing/off-boarding')
+          router.push('/login/id-proofing/off-boarding?reason=docVerificationFailed')
         }
       })
 
@@ -188,10 +186,16 @@ export function DocVerifyPage({ contactLink, sdkKey }: DocVerifyPageProps) {
       trackEvent(AnalyticsEvents.DOCV_RESULT)
       setPageData('idv_final_status', 'fail')
       trackEvent(AnalyticsEvents.IDV_FINAL_RESULT)
-      sessionStorage.setItem('offboarding_reason', offboardingReason ?? '')
-      sessionStorage.setItem('offboarding_canApply', 'false')
       clearChallengeContext()
-      router.push('/login/id-proofing/off-boarding')
+      // Pass the reason via URL so the off-boarding route can render distinct
+      // copy (docVerificationFailed, challengeNotFound, etc). Mirrors the
+      // pattern IdProofingForm uses for noIdProvided.
+      const params = new URLSearchParams()
+      if (offboardingReason) {
+        params.set('reason', offboardingReason)
+      }
+      const query = params.toString()
+      router.push(`/login/id-proofing/off-boarding${query ? `?${query}` : ''}`)
     },
     [router, setPageData, trackEvent]
   )

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
@@ -40,12 +40,42 @@ vi.mock('next/navigation', () => ({
 }))
 
 // Options used across tests. Labels/inputLabels match DC en translations.
-// Keys that are not yet in the locale JSON fall back to the key string itself.
+// The "none" option uses a cross-namespace lookup (common:noneOfTheAbove) because
+// the label key only lives in the common namespace.
+// Per-option `validation` mirrors DC_ID_OPTIONS in page.tsx so shape-enforcement
+// tests exercise the same path users hit in production.
 const TEST_ID_OPTIONS: IdOption[] = [
-  { value: 'ssn', labelKey: 'optionLabelSsn', inputLabelKey: 'labelSsn' },
-  { value: 'itin', labelKey: 'optionLabelItin', inputLabelKey: 'labelItin' },
-  // optionLabelNone is not yet in the locale JSON, so t() returns the key string
-  { value: 'none', labelKey: 'optionLabelNone' }
+  {
+    value: 'ssn',
+    labelKey: 'optionLabelSsn',
+    inputLabelKey: 'labelSsn',
+    validation: { digits: 9 }
+  },
+  {
+    value: 'itin',
+    labelKey: 'optionLabelItin',
+    inputLabelKey: 'labelItin',
+    validation: { digits: 9 }
+  },
+  {
+    value: 'medicaidId',
+    labelKey: 'optionLabelMedicaidId',
+    inputLabelKey: 'labelMedicaidId',
+    validation: { digits: [7, 8] }
+  },
+  {
+    value: 'snapAccountId',
+    labelKey: 'optionAccountId',
+    inputLabelKey: 'labelAccountId',
+    validation: { digits: [7, 8] }
+  },
+  {
+    value: 'snapPersonId',
+    labelKey: 'optionPersonId',
+    inputLabelKey: 'labelPersonId',
+    validation: { digits: [7, 8] }
+  },
+  { value: 'none', labelKey: 'common:noneOfTheAbove' }
 ]
 
 // Resolved translated strings / patterns for querying.
@@ -54,7 +84,7 @@ const TEST_ID_OPTIONS: IdOption[] = [
 // so regex patterns are used to match them.
 const LABEL_SSN = 'Social Security Number (SSN)'
 const LABEL_ITIN = 'Individual Taxpayer ID Number (ITIN)'
-const LABEL_NONE = 'optionLabelNone' // missing key → falls back to key
+const LABEL_NONE = 'None of the above'
 const INPUT_LABEL_SSN = /Enter your Social Security Number/i
 const INPUT_LABEL_ITIN = /Enter your Individual Taxpayer ID Number/i
 // Day/Year InputFields also append " *", so use partial-match patterns
@@ -99,6 +129,46 @@ describe('IdProofingForm', () => {
       expect(screen.getByRole('radio', { name: LABEL_SSN })).toBeInTheDocument()
       expect(screen.getByRole('radio', { name: LABEL_ITIN })).toBeInTheDocument()
       expect(screen.getByRole('radio', { name: LABEL_NONE })).toBeInTheDocument()
+    })
+
+    it('resolves cross-namespace labelKey (common:noneOfTheAbove) to the translated text', () => {
+      // Regression guard: the "none" option's label lives in the common namespace,
+      // while the form calls useTranslation('idProofing'). Without the "common:"
+      // prefix, i18next falls back to the raw key ("optionLabelNone" or similar).
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      const noneRadio = screen.getByRole('radio', { name: 'None of the above' })
+      expect(noneRadio).toBeInTheDocument()
+      // Should not leak the raw i18n key into the UI.
+      expect(screen.queryByText(/^optionLabelNone$/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^noneOfTheAbove$/)).not.toBeInTheDocument()
+    })
+
+    it('falls back to the raw key when a label key is missing from the active namespace (demonstrates the bug)', () => {
+      // Baseline demonstration: when labelKey is NOT prefixed with common: and
+      // the key does not exist in the idProofing namespace, i18next returns
+      // the key string itself. This is the behaviour that surfaced the
+      // literal "optionLabelNone" label in the UI before the fix.
+      const BROKEN_OPTIONS: IdOption[] = [
+        { value: 'ssn', labelKey: 'optionLabelSsn', inputLabelKey: 'labelSsn' },
+        { value: 'none', labelKey: 'optionLabelNone' }
+      ]
+
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={BROKEN_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      // With the broken key, the label text is literally the key string.
+      expect(screen.getByRole('radio', { name: 'optionLabelNone' })).toBeInTheDocument()
+      expect(screen.queryByRole('radio', { name: 'None of the above' })).not.toBeInTheDocument()
     })
 
     it('renders Continue button', () => {
@@ -449,6 +519,28 @@ describe('IdProofingForm', () => {
         expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding?canApply=false')
       })
     })
+
+    it('writes offboardingReason to sessionStorage before navigating so OffBoardingPage can branch', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /month/i }), '06')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '20')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), '1985')
+      await user.click(screen.getByRole('radio', { name: LABEL_NONE }))
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding')
+      })
+      expect(sessionStorage.getItem('offboarding_reason')).toBe('noIdProvided')
+      expect(sessionStorage.getItem('offboarding_canApply')).toBe('true')
+    })
   })
 
   describe('Shape validation (DC-296)', () => {
@@ -568,6 +660,175 @@ describe('IdProofingForm', () => {
       })
       expect(submitCalled).toBe(false)
       expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Per-option digit validation (DC-296)', () => {
+    // medicaidId: 7 or 8 digits accepted (per DC CSV).
+    const LABEL_MEDICAID = 'Medicaid ID'
+    const INPUT_LABEL_MEDICAID = /Enter your Medicaid ID/i
+
+    async function fillDobAndSelect(idLabel: string) {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+      await user.selectOptions(screen.getByRole('combobox', { name: /month/i }), '01')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '15')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), '1990')
+      await user.click(screen.getByRole('radio', { name: idLabel }))
+      return user
+    }
+
+    it('rejects a 6-digit Medicaid ID (below range)', async () => {
+      let submitCalled = false
+      server.use(
+        http.post('/api/id-proofing', () => {
+          submitCalled = true
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = await fillDobAndSelect(LABEL_MEDICAID)
+      const input = await screen.findByRole('textbox', { name: INPUT_LABEL_MEDICAID })
+      await user.type(input, '123456')
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        const errors = screen.getAllByRole('alert')
+        expect(errors.length).toBeGreaterThanOrEqual(1)
+      })
+      expect(submitCalled).toBe(false)
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('accepts a 7-digit Medicaid ID (lower bound)', async () => {
+      const user = await fillDobAndSelect(LABEL_MEDICAID)
+      const input = await screen.findByRole('textbox', { name: INPUT_LABEL_MEDICAID })
+      await user.type(input, '1234567')
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalled()
+      })
+    })
+
+    it('accepts an 8-digit Medicaid ID (upper bound)', async () => {
+      const user = await fillDobAndSelect(LABEL_MEDICAID)
+      const input = await screen.findByRole('textbox', { name: INPUT_LABEL_MEDICAID })
+      await user.type(input, '12345678')
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalled()
+      })
+    })
+
+    it('rejects a 9-digit Medicaid ID (no SSN bleed-through)', async () => {
+      // Guard against accidental reuse of the 9-digit SSN/ITIN rule for
+      // medicaidId. With maxLength=8 a user can't even type a 9th digit,
+      // so the realistic boundary check is: when 9 digits are programmatically
+      // pasted, the form either truncates (caps at 8) or rejects on submit.
+      // Either way, submit must not fire with a 9-digit medicaidId.
+      let submitCalled = false
+      server.use(
+        http.post('/api/id-proofing', () => {
+          submitCalled = true
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = await fillDobAndSelect(LABEL_MEDICAID)
+      const input = await screen.findByRole('textbox', { name: INPUT_LABEL_MEDICAID })
+      await user.type(input, '123456789')
+      // Expect the 9th digit to be clipped by maxLength=8.
+      expect(input).not.toHaveValue('123456789')
+
+      // Now double-check: if maxLength were raised, the form would still block
+      // submission. We can't easily simulate a paste past maxLength, but the
+      // prior expect already proves 9 chars never land in state via typing.
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      // 8-digit values submit successfully; the purpose of this test is to
+      // show a typed 9-digit entry can't land as-is. If the user actually
+      // ends up with 8 chars after typing 9, that's a valid submission.
+      if ((input as HTMLInputElement).value.length === 8) {
+        await waitFor(() => {
+          expect(mockPush).toHaveBeenCalled()
+        })
+      } else {
+        expect(submitCalled).toBe(false)
+      }
+    })
+
+    it('strips non-digit characters from Medicaid ID input', async () => {
+      const user = await fillDobAndSelect(LABEL_MEDICAID)
+      const input = await screen.findByRole('textbox', { name: INPUT_LABEL_MEDICAID })
+      await user.type(input, '12-34-567')
+      expect(input).toHaveValue('1234567')
+    })
+
+    it('sets inputMode="numeric" and maxLength=8 on the Medicaid ID input', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+      await user.click(screen.getByRole('radio', { name: LABEL_MEDICAID }))
+      const input = await screen.findByRole('textbox', { name: INPUT_LABEL_MEDICAID })
+      expect(input).toHaveAttribute('inputMode', 'numeric')
+      expect(input).toHaveAttribute('maxLength', '8')
+    })
+
+    it('rejects a 6-digit SNAP/TANF account ID (shared 7-8 rule, representative case)', async () => {
+      let submitCalled = false
+      server.use(
+        http.post('/api/id-proofing', () => {
+          submitCalled = true
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = await fillDobAndSelect('SNAP or TANF account ID')
+      const input = await screen.findByRole('textbox', {
+        name: /Enter your SNAP or TANF account ID/i
+      })
+      await user.type(input, '123456')
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        const errors = screen.getAllByRole('alert')
+        expect(errors.length).toBeGreaterThanOrEqual(1)
+      })
+      expect(submitCalled).toBe(false)
+    })
+
+    it('rejects a 6-digit SNAP/TANF person ID (shared 7-8 rule, representative case)', async () => {
+      let submitCalled = false
+      server.use(
+        http.post('/api/id-proofing', () => {
+          submitCalled = true
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = await fillDobAndSelect('SNAP or TANF person ID')
+      const input = await screen.findByRole('textbox', {
+        name: /Enter your SNAP or TANF person ID/i
+      })
+      await user.type(input, '123456')
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        const errors = screen.getAllByRole('alert')
+        expect(errors.length).toBeGreaterThanOrEqual(1)
+      })
+      expect(submitCalled).toBe(false)
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
@@ -484,12 +484,13 @@ describe('IdProofingForm', () => {
       await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '20')
       await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), '1985')
 
-      // "None of the above" triggers a 'failed' result in the mock
+      // "None of the above" triggers a 'failed' result in the mock,
+      // which also returns offboardingReason so the URL carries a reason param.
       await user.click(screen.getByRole('radio', { name: LABEL_NONE }))
       await user.click(screen.getByRole('button', { name: /continue/i }))
 
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding')
+        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding?reason=noIdProvided')
       })
     })
 
@@ -520,7 +521,7 @@ describe('IdProofingForm', () => {
       })
     })
 
-    it('writes offboardingReason to sessionStorage before navigating so OffBoardingPage can branch', async () => {
+    it('appends offboardingReason as a URL query param so the off-boarding route can branch copy', async () => {
       const user = userEvent.setup()
       renderWithProviders(
         <IdProofingForm
@@ -536,10 +537,8 @@ describe('IdProofingForm', () => {
       await user.click(screen.getByRole('button', { name: /continue/i }))
 
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding')
+        expect(mockPush).toHaveBeenCalledWith('/login/id-proofing/off-boarding?reason=noIdProvided')
       })
-      expect(sessionStorage.getItem('offboarding_reason')).toBe('noIdProvided')
-      expect(sessionStorage.getItem('offboarding_canApply')).toBe('true')
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
@@ -451,6 +451,126 @@ describe('IdProofingForm', () => {
     })
   })
 
+  describe('Shape validation (DC-296)', () => {
+    it('strips non-digit characters from SSN input as the user types', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      await user.click(screen.getByRole('radio', { name: LABEL_SSN }))
+      const ssnInput = await screen.findByRole('textbox', { name: INPUT_LABEL_SSN })
+      await user.type(ssnInput, '555-44-3333')
+
+      // User typed hyphens; state should only hold the 9 digits.
+      expect(ssnInput).toHaveValue('555443333')
+    })
+
+    it('sets inputMode="numeric" and maxLength=9 on the SSN input', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      await user.click(screen.getByRole('radio', { name: LABEL_SSN }))
+      const ssnInput = await screen.findByRole('textbox', { name: INPUT_LABEL_SSN })
+      expect(ssnInput).toHaveAttribute('inputMode', 'numeric')
+      expect(ssnInput).toHaveAttribute('maxLength', '9')
+    })
+
+    it('sets inputMode="numeric" and maxLength=9 on the ITIN input', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      await user.click(screen.getByRole('radio', { name: LABEL_ITIN }))
+      const itinInput = await screen.findByRole('textbox', { name: INPUT_LABEL_ITIN })
+      expect(itinInput).toHaveAttribute('inputMode', 'numeric')
+      expect(itinInput).toHaveAttribute('maxLength', '9')
+    })
+
+    it('blocks submit and shows a field-level error when SSN is too short', async () => {
+      // With the digit-stripping onChange + maxLength=9, users literally cannot
+      // type a 10-digit value. An 8-digit value is the realistic "wrong shape"
+      // case — verify the form blocks it and does not call the mutation.
+      let submitCalled = false
+      server.use(
+        http.post('/api/id-proofing', () => {
+          submitCalled = true
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /month/i }), '01')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '15')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), '1990')
+
+      await user.click(screen.getByRole('radio', { name: LABEL_SSN }))
+      const ssnInput = await screen.findByRole('textbox', { name: INPUT_LABEL_SSN })
+      await user.type(ssnInput, '12345678')
+
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        const errors = screen.getAllByRole('alert')
+        expect(errors.length).toBeGreaterThanOrEqual(1)
+      })
+      expect(submitCalled).toBe(false)
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('blocks submit and shows a DOB error when the DOB is in the future', async () => {
+      let submitCalled = false
+      server.use(
+        http.post('/api/id-proofing', () => {
+          submitCalled = true
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      const futureYear = String(new Date().getFullYear() + 5)
+      await user.selectOptions(screen.getByRole('combobox', { name: /month/i }), '06')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '15')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), futureYear)
+
+      await user.click(screen.getByRole('radio', { name: LABEL_NONE }))
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        const errors = screen.getAllByRole('alert')
+        expect(errors.length).toBeGreaterThanOrEqual(1)
+      })
+      expect(submitCalled).toBe(false)
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
   describe('API error handling', () => {
     it('shows a submit error alert when the API returns an error', async () => {
       const user = userEvent.setup()

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
@@ -19,11 +19,18 @@ const NONE_VALUE = 'none' as const
 
 type IdOptionValue = IdType | typeof NONE_VALUE
 
-// ID types whose value is exactly 9 digits. Used to enable numeric keypad,
-// digit-only input, and a 9-char hard cap at the input level.
-// medicaidId is intentionally excluded: DC CSV specifies "7 or 8 digits" while
-// Socure expects "4 or 9" — follow-up tracked outside DC-296.
-const NUMERIC_9_ID_TYPES: ReadonlySet<IdOptionValue> = new Set(['ssn', 'itin'])
+/**
+ * Per-option validation rule for the ID value input.
+ *
+ * `digits: 9` means exactly 9 digits (after non-digit stripping).
+ * `digits: [7, 8]` means inclusive range.
+ *
+ * Undefined/absent means no digit-count check. The input renders as a plain
+ * text field and only the base "required" rule applies.
+ */
+export interface IdOptionValidation {
+  digits: number | [number, number]
+}
 
 export interface IdOption {
   value: IdOptionValue
@@ -33,6 +40,24 @@ export interface IdOption {
   helperKey?: string
   /** i18next key for the text input label shown when this option is selected */
   inputLabelKey?: string
+  /**
+   * Digit-count rule for the associated ID value input. When present, the form
+   * strips non-digits on change, applies a numeric keypad, caps length at the
+   * rule's upper bound, and enforces the rule on submit. State-specific rules
+   * live on the option rather than in the shared Zod schema.
+   */
+  validation?: IdOptionValidation
+}
+
+// Returns [min, max] for either form of the digits rule.
+function digitBounds(rule: IdOptionValidation): [number, number] {
+  return Array.isArray(rule.digits) ? rule.digits : [rule.digits, rule.digits]
+}
+
+function matchesDigitRule(value: string, rule: IdOptionValidation): boolean {
+  const digits = value.replace(/\D/g, '')
+  const [min, max] = digitBounds(rule)
+  return digits.length >= min && digits.length <= max
 }
 
 interface IdProofingFormProps {
@@ -80,8 +105,21 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
   const REQUIRED_FIELD_ERROR = tValidation('required')
   // TODO: Use t('validation.ssnItinDigits') once key is available in dc.csv
   const SSN_ITIN_SHAPE_ERROR = 'Enter exactly 9 digits.'
+  // TODO: Use t('validation.sevenOrEightDigits') once key is available in dc.csv
+  const SEVEN_OR_EIGHT_DIGITS_ERROR = 'Enter 7 or 8 digits.'
   // TODO: Use t('validation.dobInvalid') once key is available in dc.csv
   const DOB_INVALID_ERROR = 'Enter a valid date of birth.'
+
+  // Pick the user-facing error message that matches the rule's shape. The SSN
+  // and ITIN messages stay verbatim so the existing wording carries through;
+  // [7, 8] rules use a shared message; other shapes fall back to a generic.
+  function digitRuleErrorMessage(rule: IdOptionValidation): string {
+    const [min, max] = digitBounds(rule)
+    if (min === max && min === 9) return SSN_ITIN_SHAPE_ERROR
+    if (min === 7 && max === 8) return SEVEN_OR_EIGHT_DIGITS_ERROR
+    if (min === max) return `Enter exactly ${min} digits.`
+    return `Enter ${min} or ${max} digits.`
+  }
 
   function validateFields(): boolean {
     const newDobErrors: { month?: string; day?: string; year?: string } = {}
@@ -125,6 +163,16 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
           } else if (path === 'idValue' && showIdValueInput) {
             idError = SSN_ITIN_SHAPE_ERROR
           }
+        }
+      }
+
+      // Per-option digit-shape enforcement. The shared Zod schema only covers
+      // SSN/ITIN (federal, state-agnostic); other ID types carry their own
+      // rule on the IdOption. Run this after schema parsing so schema-level
+      // errors win when both apply.
+      if (idError === null && showIdValueInput && selectedOption?.validation) {
+        if (!matchesDigitRule(idValue, selectedOption.validation)) {
+          idError = digitRuleErrorMessage(selectedOption.validation)
         }
       }
     }
@@ -172,6 +220,11 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
       } else if (response.result === 'failed') {
         setPageData('idv_primary_status', 'fail')
         trackEvent(AnalyticsEvents.IDV_PRIMARY_RESULT)
+        // Hand off offboarding context to OffBoardingPage so it can render
+        // reason-specific copy (e.g. noIdProvided gets a different heading).
+        // Mirrors the pattern DocVerifyPage uses on its reject path.
+        sessionStorage.setItem('offboarding_reason', response.offboardingReason ?? '')
+        sessionStorage.setItem('offboarding_canApply', String(response.canApply !== false))
         const params = new URLSearchParams()
         if (response.canApply === false) {
           params.set('canApply', 'false')
@@ -348,20 +401,21 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
             name="idValue"
             value={idValue}
             onChange={(e) => {
-              // For 9-digit ID types (SSN/ITIN), strip non-digit characters
-              // as the user types. maxLength on the input caps the length,
-              // so pastes like "555-44-3333" land in state as "555443333".
+              // When the option carries a digit-count rule, strip non-digits
+              // as the user types. maxLength on the input caps length at the
+              // rule's upper bound, so pasted input like "555-44-3333" lands
+              // in state as "555443333" (and is clipped to maxLength).
               const raw = e.target.value
-              const next =
-                selectedIdType && NUMERIC_9_ID_TYPES.has(selectedIdType)
-                  ? raw.replace(/\D/g, '')
-                  : raw
+              const next = selectedOption?.validation ? raw.replace(/\D/g, '') : raw
               setIdValue(next)
             }}
             autoComplete="off"
             isRequired
-            {...(selectedIdType && NUMERIC_9_ID_TYPES.has(selectedIdType)
-              ? { inputMode: 'numeric' as const, maxLength: 9 }
+            {...(selectedOption?.validation
+              ? {
+                  inputMode: 'numeric' as const,
+                  maxLength: digitBounds(selectedOption.validation)[1]
+                }
               : {})}
             {...(idValueError ? { error: idValueError } : {})}
           />

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
@@ -11,13 +11,19 @@ import {
   clearChallengeContext,
   SK_CHALLENGE_ID
 } from '@/features/auth/components/doc-verify/sessionKeys'
-import { useSubmitIdProofing, type IdType } from '../../api'
+import { SubmitIdProofingRequestSchema, useSubmitIdProofing, type IdType } from '../../api'
 
 // UI-only sentinel value for the "none" radio option.
 // The API receives idType: null when the user selects this.
 const NONE_VALUE = 'none' as const
 
 type IdOptionValue = IdType | typeof NONE_VALUE
+
+// ID types whose value is exactly 9 digits. Used to enable numeric keypad,
+// digit-only input, and a 9-char hard cap at the input level.
+// medicaidId is intentionally excluded: DC CSV specifies "7 or 8 digits" while
+// Socure expects "4 or 9" — follow-up tracked outside DC-296.
+const NUMERIC_9_ID_TYPES: ReadonlySet<IdOptionValue> = new Set(['ssn', 'itin'])
 
 export interface IdOption {
   value: IdOptionValue
@@ -72,6 +78,10 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
   const showIdValueInput = selectedIdType !== null && selectedIdType !== NONE_VALUE
 
   const REQUIRED_FIELD_ERROR = tValidation('required')
+  // TODO: Use t('validation.ssnItinDigits') once key is available in dc.csv
+  const SSN_ITIN_SHAPE_ERROR = 'Enter exactly 9 digits.'
+  // TODO: Use t('validation.dobInvalid') once key is available in dc.csv
+  const DOB_INVALID_ERROR = 'Enter a valid date of birth.'
 
   function validateFields(): boolean {
     const newDobErrors: { month?: string; day?: string; year?: string } = {}
@@ -80,18 +90,47 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
     if (!dobDay) newDobErrors.day = REQUIRED_FIELD_ERROR
     if (!dobYear) newDobErrors.year = REQUIRED_FIELD_ERROR
 
-    setDobErrors(newDobErrors)
-
     let idTypeErr: string | null = null
     if (selectedIdType === null) {
       idTypeErr = REQUIRED_FIELD_ERROR
     }
-    setIdTypeError(idTypeErr)
 
     let idError: string | null = null
     if (showIdValueInput && !idValue.trim()) {
       idError = REQUIRED_FIELD_ERROR
     }
+
+    // Run the shared schema only when the required-field checks above haven't
+    // already flagged the payload. The schema enforces SSN/ITIN digit count
+    // and DOB calendar/range rules; required-ness stays field-local so each
+    // field gets its own "This is required" message.
+    const allRequiredFilled =
+      Object.keys(newDobErrors).length === 0 && idTypeErr === null && idError === null
+
+    if (allRequiredFilled) {
+      const parsed = SubmitIdProofingRequestSchema.safeParse({
+        dateOfBirth: { month: dobMonth, day: dobDay, year: dobYear },
+        idType: selectedIdType === NONE_VALUE || selectedIdType === null ? null : selectedIdType,
+        idValue: showIdValueInput ? idValue : null
+      })
+
+      if (!parsed.success) {
+        for (const issue of parsed.error.issues) {
+          const path = issue.path.join('.')
+          if (path === 'dateOfBirth') {
+            // Surface the same message under the year field so the user has
+            // something to read. Month/day/year each render their own error
+            // slot; attaching to year avoids duplicate alerts for one issue.
+            newDobErrors.year = DOB_INVALID_ERROR
+          } else if (path === 'idValue' && showIdValueInput) {
+            idError = SSN_ITIN_SHAPE_ERROR
+          }
+        }
+      }
+    }
+
+    setDobErrors(newDobErrors)
+    setIdTypeError(idTypeErr)
     setIdValueError(idError)
 
     return Object.keys(newDobErrors).length === 0 && idTypeErr === null && idError === null
@@ -308,9 +347,22 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
             type="text"
             name="idValue"
             value={idValue}
-            onChange={(e) => setIdValue(e.target.value)}
+            onChange={(e) => {
+              // For 9-digit ID types (SSN/ITIN), strip non-digit characters
+              // as the user types. maxLength on the input caps the length,
+              // so pastes like "555-44-3333" land in state as "555443333".
+              const raw = e.target.value
+              const next =
+                selectedIdType && NUMERIC_9_ID_TYPES.has(selectedIdType)
+                  ? raw.replace(/\D/g, '')
+                  : raw
+              setIdValue(next)
+            }}
             autoComplete="off"
             isRequired
+            {...(selectedIdType && NUMERIC_9_ID_TYPES.has(selectedIdType)
+              ? { inputMode: 'numeric' as const, maxLength: 9 }
+              : {})}
             {...(idValueError ? { error: idValueError } : {})}
           />
         </div>

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
@@ -220,14 +220,14 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
       } else if (response.result === 'failed') {
         setPageData('idv_primary_status', 'fail')
         trackEvent(AnalyticsEvents.IDV_PRIMARY_RESULT)
-        // Hand off offboarding context to OffBoardingPage so it can render
-        // reason-specific copy (e.g. noIdProvided gets a different heading).
-        // Mirrors the pattern DocVerifyPage uses on its reject path.
-        sessionStorage.setItem('offboarding_reason', response.offboardingReason ?? '')
-        sessionStorage.setItem('offboarding_canApply', String(response.canApply !== false))
+        // Hand off offboarding context via URL query params so the server-rendered
+        // route page can branch copy (noIdProvided gets a distinct heading).
         const params = new URLSearchParams()
         if (response.canApply === false) {
           params.set('canApply', 'false')
+        }
+        if (response.offboardingReason) {
+          params.set('reason', response.offboardingReason)
         }
         const query = params.toString()
         router.push(`/login/id-proofing/off-boarding${query ? `?${query}` : ''}`)

--- a/src/SEBT.Portal.Web/src/features/auth/components/off-boarding/OffBoardingPage.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/off-boarding/OffBoardingPage.test.tsx
@@ -86,9 +86,67 @@ describe('OffBoardingPage', () => {
       />
     )
 
-    // The component renders — the reason is read but not currently displayed
-    // (future: copy can vary by reason per D7)
+    // The component renders. Generic copy is preserved for unknown reasons.
     expect(screen.getByRole('heading', { name: /we're sorry/i })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /apply now/i })).toBeInTheDocument()
+  })
+
+  describe('reason-specific copy', () => {
+    it('renders distinct heading and body when reason is noIdProvided', () => {
+      sessionStorage.setItem('offboarding_reason', 'noIdProvided')
+
+      render(<OffBoardingPage contactLink={TEST_CONTACT_LINK} />)
+
+      // Distinct heading for the noIdProvided case, not the generic "we're sorry".
+      expect(
+        screen.getByRole('heading', { name: /we need an ID to verify you/i })
+      ).toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /we're sorry/i })).not.toBeInTheDocument()
+
+      // Body references providing one of the listed IDs.
+      expect(screen.getByText(/one of the listed IDs/i)).toBeInTheDocument()
+    })
+
+    it('hides the Apply now block for noIdProvided even when canApply is true', () => {
+      sessionStorage.setItem('offboarding_reason', 'noIdProvided')
+      sessionStorage.setItem('offboarding_canApply', 'true')
+
+      render(
+        <OffBoardingPage
+          contactLink={TEST_CONTACT_LINK}
+          applyLink={TEST_APPLY_LINK}
+        />
+      )
+
+      // canApply is true, but for noIdProvided we intentionally don't surface
+      // "Apply now". The user hasn't failed; they just haven't provided an ID.
+      expect(screen.queryByRole('link', { name: /apply now/i })).not.toBeInTheDocument()
+    })
+
+    it('renders generic copy when reason is null', () => {
+      // No sessionStorage key set; lazy initializer returns null.
+      render(<OffBoardingPage contactLink={TEST_CONTACT_LINK} />)
+
+      expect(screen.getByRole('heading', { name: /we're sorry/i })).toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /we need an ID/i })).not.toBeInTheDocument()
+    })
+
+    it('renders generic copy when reason is idProofingFailed', () => {
+      sessionStorage.setItem('offboarding_reason', 'idProofingFailed')
+
+      render(<OffBoardingPage contactLink={TEST_CONTACT_LINK} />)
+
+      expect(screen.getByRole('heading', { name: /we're sorry/i })).toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /we need an ID/i })).not.toBeInTheDocument()
+    })
+
+    it('renders generic copy when reason is unknown', () => {
+      sessionStorage.setItem('offboarding_reason', 'someFutureReason')
+
+      render(<OffBoardingPage contactLink={TEST_CONTACT_LINK} />)
+
+      expect(screen.getByRole('heading', { name: /we're sorry/i })).toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /we need an ID/i })).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/SEBT.Portal.Web/src/features/auth/components/off-boarding/OffBoardingPage.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/off-boarding/OffBoardingPage.tsx
@@ -35,8 +35,16 @@ export function OffBoardingPage({ contactLink, applyLink }: OffBoardingPageProps
     return sessionStorage.getItem(SK_CAN_APPLY) === 'true'
   })
 
-  // reason is available for future copy differentiation by offboarding scenario
-  void reason
+  // Single reason branch so far: "noIdProvided" needs a tell-the-user-what-to-do
+  // tone rather than the generic failure copy. Other reasons (null, unknown,
+  // idProofingFailed, docVerificationFailed, ...) keep the existing generic path.
+  const isNoIdProvided = reason === 'noIdProvided'
+
+  // TODO: Use t('offboarding.noIdProvided.heading') once key is available in dc.csv
+  const noIdHeading = 'We need an ID to verify you'
+  // TODO: Use t('offboarding.noIdProvided.body') once key is available in dc.csv
+  const noIdBody =
+    "To confirm your identity, we need one of the listed IDs. If you don't have any of these IDs, contact us for help."
 
   // Clean up sessionStorage on unmount — the values have been read
   useEffect(() => {
@@ -54,17 +62,21 @@ export function OffBoardingPage({ contactLink, applyLink }: OffBoardingPageProps
             id="offboarding-title"
             className="font-sans-xl text-bold line-height-sans-1 margin-bottom-3"
           >
-            {t(
-              'offboardingHeading',
-              "We're sorry, we aren't able to show your DC SUN Bucks information"
-            )}
+            {isNoIdProvided
+              ? noIdHeading
+              : t(
+                  'offboardingHeading',
+                  "We're sorry, we aren't able to show your DC SUN Bucks information"
+                )}
           </h1>
 
           <p className="font-sans-sm">
-            {t(
-              'offboardingBody',
-              'You can go back to enter an ID number, or contact us if you need more help.'
-            )}
+            {isNoIdProvided
+              ? noIdBody
+              : t(
+                  'offboardingBody',
+                  'You can go back to enter an ID number, or contact us if you need more help.'
+                )}
           </p>
 
           <div className="margin-top-3">
@@ -88,8 +100,12 @@ export function OffBoardingPage({ contactLink, applyLink }: OffBoardingPageProps
             </a>
           </div>
 
-          {/* Conditional "Apply now" section (D7) — shown when canApply is true */}
-          {canApply && (
+          {/*
+            Conditional "Apply now" section. Shown when canApply is true,
+            but suppressed for the noIdProvided reason because the user hasn't
+            actually failed verification; they just didn't provide an ID yet.
+          */}
+          {canApply && !isNoIdProvided && (
             <div className="margin-top-4">
               <p className="font-sans-sm">
                 {t(

--- a/src/SEBT.Portal.Web/src/mocks/handlers.ts
+++ b/src/SEBT.Portal.Web/src/mocks/handlers.ts
@@ -283,9 +283,14 @@ export const handlers = [
       return HttpResponse.json({ error: 'Date of birth is required' }, { status: 400 })
     }
 
-    // Simulate failure when user selects "none of the above" for ID type
+    // Simulate failure when user selects "none of the above" for ID type.
+    // Backend returns offboardingReason so the frontend can land on distinct copy.
     if (body.idType === null) {
-      return HttpResponse.json({ result: 'failed', canApply: true })
+      return HttpResponse.json({
+        result: 'failed',
+        canApply: true,
+        offboardingReason: 'noIdProvided'
+      })
     }
 
     // Simulate step-up failure (canApply: false) with Medicaid ID for dev testing.

--- a/test/SEBT.Portal.Tests/Unit/Helpers/HouseholdFactoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Helpers/HouseholdFactoryTests.cs
@@ -253,8 +253,8 @@ public class HouseholdFactoryTests
         // Assert
         if (!string.IsNullOrEmpty(household.Phone))
         {
-            // Should match format ###-####
-            Assert.Matches(@"^\d{3}-\d{4}$", household.Phone);
+            // Should be a 10-digit US phone (NANP): area code 2-9, exchange 2-9.
+            Assert.Matches(@"^[2-9]\d{2}[2-9]\d{6}$", household.Phone);
         }
     }
 

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/HttpSocureClientTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/HttpSocureClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -223,10 +224,12 @@ public class HttpSocureClientTests
         Assert.NotNull(capturedBody);
         using var doc = JsonDocument.Parse(capturedBody);
         var root = doc.RootElement;
-        Assert.Equal(userId.ToString(), root.GetProperty("id").GetString());
+        // Top-level id must be a fresh Guid per call (OpenAPI: ConsumerOnboarding.id must be unique per evaluation).
+        Assert.True(Guid.TryParse(root.GetProperty("id").GetString(), out _));
         Assert.Equal("consumer_onboarding", root.GetProperty("workflow").GetString());
         Assert.True(root.TryGetProperty("timestamp", out _), "Request should include timestamp");
         var individual = root.GetProperty("data").GetProperty("individual");
+        // Individual id remains the customer-scoped user id (Socure transaction identifier).
         Assert.Equal(userId.ToString(), individual.GetProperty("id").GetString());
         Assert.Equal("US", individual.GetProperty("country").GetString());
         Assert.Equal("user@example.com", individual.GetProperty("email").GetString());
@@ -729,6 +732,298 @@ public class HttpSocureClientTests
         var config = docv.GetProperty("config");
         Assert.True(config.GetProperty("send_message").GetBoolean());
         Assert.Equal("en", config.GetProperty("language").GetString());
+    }
+
+    // --- Phone normalization to E.164 at the Socure client boundary ---
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_NormalizesPhoneToE164InOutboundPayload()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri(settings.BaseUrl) };
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient("Socure").Returns(httpClient);
+        var snapshot = Substitute.For<IOptionsSnapshot<SocureSettings>>();
+        snapshot.Value.Returns(settings);
+        var logger = Substitute.For<ILogger<HttpSocureClient>>();
+
+        var client = new HttpSocureClient(factory, snapshot, logger);
+
+        await client.RunIdProofingAssessmentAsync(
+            Guid.CreateVersion7(), "user@example.com", "1990-06-15", "ssn", "123-45-6789",
+            phoneNumber: "588-3245");
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        // Unparseable phone should be dropped, not sent as-is
+        Assert.False(individual.TryGetProperty("phone_number", out _));
+
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_FormatsValidUsPhoneAsE164()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        var client = CreateClient(handler);
+        await client.RunIdProofingAssessmentAsync(
+            Guid.CreateVersion7(), "user@example.com", "1990-06-15", "ssn", "123-45-6789",
+            phoneNumber: "(305) 302-1567");
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        Assert.Equal("+13053021567", individual.GetProperty("phone_number").GetString());
+    }
+
+    // --- Name truncation at Socure boundary (DC-296 Phase 3; OpenAPI maxLength: 240) ---
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_TruncatesGivenNameTo240Chars()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri(settings.BaseUrl) };
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient("Socure").Returns(httpClient);
+        var snapshot = Substitute.For<IOptionsSnapshot<SocureSettings>>();
+        snapshot.Value.Returns(settings);
+        var logger = Substitute.For<ILogger<HttpSocureClient>>();
+
+        var client = new HttpSocureClient(factory, snapshot, logger);
+
+        var overlongGivenName = new string('a', 241);
+
+        await client.RunIdProofingAssessmentAsync(
+            Guid.CreateVersion7(), "user@example.com", "1990-06-15", "ssn", "123-45-6789",
+            givenName: overlongGivenName);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        Assert.Equal(240, individual.GetProperty("given_name").GetString()!.Length);
+
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_TruncatesFamilyNameTo240Chars()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri(settings.BaseUrl) };
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient("Socure").Returns(httpClient);
+        var snapshot = Substitute.For<IOptionsSnapshot<SocureSettings>>();
+        snapshot.Value.Returns(settings);
+        var logger = Substitute.For<ILogger<HttpSocureClient>>();
+
+        var client = new HttpSocureClient(factory, snapshot, logger);
+
+        var overlongFamilyName = new string('b', 500);
+
+        await client.RunIdProofingAssessmentAsync(
+            Guid.CreateVersion7(), "user@example.com", "1990-06-15", "ssn", "123-45-6789",
+            familyName: overlongFamilyName);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        Assert.Equal(240, individual.GetProperty("family_name").GetString()!.Length);
+
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_LeavesNamesUnderLimitUntouched()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri(settings.BaseUrl) };
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient("Socure").Returns(httpClient);
+        var snapshot = Substitute.For<IOptionsSnapshot<SocureSettings>>();
+        snapshot.Value.Returns(settings);
+        var logger = Substitute.For<ILogger<HttpSocureClient>>();
+
+        var client = new HttpSocureClient(factory, snapshot, logger);
+
+        var givenName = new string('g', 100);
+        var familyName = new string('f', 100);
+
+        await client.RunIdProofingAssessmentAsync(
+            Guid.CreateVersion7(), "user@example.com", "1990-06-15", "ssn", "123-45-6789",
+            givenName: givenName, familyName: familyName);
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var individual = doc.RootElement.GetProperty("data").GetProperty("individual");
+        Assert.Equal(givenName, individual.GetProperty("given_name").GetString());
+        Assert.Equal(familyName, individual.GetProperty("family_name").GetString());
+
+        logger.DidNotReceive().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    // --- Unique top-level evaluation id per call (DC-296 Phase 3; OpenAPI ConsumerOnboarding.id) ---
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_TopLevelIdIsUniquePerCall()
+    {
+        var capturedBodies = new List<string>();
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBodies.Add(body);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        var client = CreateClient(handler);
+        var userId = Guid.CreateVersion7();
+
+        await client.RunIdProofingAssessmentAsync(
+            userId, "user@example.com", "1990-06-15", "ssn", "123-45-6789");
+        await client.RunIdProofingAssessmentAsync(
+            userId, "user@example.com", "1990-06-15", "ssn", "123-45-6789");
+
+        Assert.Equal(2, capturedBodies.Count);
+
+        using var doc1 = JsonDocument.Parse(capturedBodies[0]);
+        using var doc2 = JsonDocument.Parse(capturedBodies[1]);
+        var id1 = doc1.RootElement.GetProperty("id").GetString();
+        var id2 = doc2.RootElement.GetProperty("id").GetString();
+
+        Assert.NotNull(id1);
+        Assert.NotNull(id2);
+        Assert.NotEqual(id1, id2);
+
+        // Customer-scoped individual id must stay stable. That's the transaction identifier per Socure.
+        var individualId1 = doc1.RootElement.GetProperty("data").GetProperty("individual").GetProperty("id").GetString();
+        var individualId2 = doc2.RootElement.GetProperty("data").GetProperty("individual").GetProperty("id").GetString();
+        Assert.Equal(userId.ToString(), individualId1);
+        Assert.Equal(userId.ToString(), individualId2);
+    }
+
+    [Fact]
+    public async Task RunIdProofingAssessmentAsync_TopLevelIdIsAValidGuid()
+    {
+        string? capturedBody = null;
+        var handler = new CaptureRequestHandler(body =>
+        {
+            capturedBody = body;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new
+                {
+                    eval_id = "eval-123",
+                    decision = "ACCEPT",
+                    data_enrichments = Array.Empty<object>()
+                }), System.Text.Encoding.UTF8, "application/json")
+            };
+        });
+
+        var client = CreateClient(handler);
+        await client.RunIdProofingAssessmentAsync(
+            Guid.CreateVersion7(), "user@example.com", "1990-06-15", "ssn", "123-45-6789");
+
+        Assert.NotNull(capturedBody);
+        using var doc = JsonDocument.Parse(capturedBody);
+        var id = doc.RootElement.GetProperty("id").GetString();
+        Assert.True(Guid.TryParse(id, out _), $"Top-level id was not a Guid: {id}");
     }
 
     // --- StartDocvSessionAsync throws ---

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/PhoneNormalizerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/PhoneNormalizerTests.cs
@@ -1,0 +1,65 @@
+using SEBT.Portal.Infrastructure.Services;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Services;
+
+public class PhoneNormalizerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizePhone_returns_null_for_null_empty_or_whitespace(string? input)
+    {
+        Assert.Null(PhoneNormalizer.Normalize(input));
+    }
+
+    [Theory]
+    [InlineData("123")]
+    [InlineData("12345")]
+    [InlineData("555-1234")]
+    [InlineData("abcdefghij")]
+    public void NormalizePhone_returns_null_for_too_short_or_non_numeric(string input)
+    {
+        Assert.Null(PhoneNormalizer.Normalize(input));
+    }
+
+    [Theory]
+    [InlineData("8185551234", "8185551234")]           // bare 10 digits
+    [InlineData("(818) 555-1234", "8185551234")]       // US formatted
+    [InlineData("818-555-1234", "8185551234")]         // dashes
+    [InlineData("818.555.1234", "8185551234")]         // dots
+    [InlineData("  818 555 1234  ", "8185551234")]     // spaces with padding
+    public void NormalizePhone_extracts_10_digit_national_number(string input, string expected)
+    {
+        Assert.Equal(expected, PhoneNormalizer.Normalize(input));
+    }
+
+    [Theory]
+    [InlineData("18185551234", "8185551234")]          // leading 1 country code
+    [InlineData("+18185551234", "8185551234")]         // E.164
+    [InlineData("+1 (818) 555-1234", "8185551234")]   // E.164 with formatting
+    [InlineData("1-818-555-1234", "8185551234")]       // country code with dash
+    public void NormalizePhone_strips_US_country_code(string input, string expected)
+    {
+        Assert.Equal(expected, PhoneNormalizer.Normalize(input));
+    }
+
+    [Theory]
+    [InlineData("+447700900000")]   // UK mobile
+    [InlineData("+33612345678")]    // France mobile
+    [InlineData("0044770090000")]   // UK with international dialing prefix
+    public void NormalizePhone_rejects_non_US_numbers(string input)
+    {
+        Assert.Null(PhoneNormalizer.Normalize(input));
+    }
+
+    [Fact]
+    public void NormalizePhone_does_not_double_strip_leading_ones()
+    {
+        // Area codes can't start with 1 per NANP rules, but libphonenumber
+        // should handle the country code correctly without TrimStart bugs.
+        // "11234567890" = country code 1 + 1234567890, but 123 is not a valid
+        // NANP area code, so this should be rejected as invalid.
+        Assert.Null(PhoneNormalizer.Normalize("11234567890"));
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/SessionRefreshTokenServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/SessionRefreshTokenServiceTests.cs
@@ -6,8 +6,10 @@ namespace SEBT.Portal.Tests.Unit.Infrastructure.Services;
 
 public class SessionRefreshTokenServiceTests : JwtTokenServiceTestBase
 {
+    // Never downgrade: defense-in-depth. An admin-edited or stale DB row should not
+    // supersede a higher IAL already granted by the current session claim.
     [Fact]
-    public void CopiesIalFromExistingJwt()
+    public void DoesNotDowngradeIal_WhenDbIsLowerThanClaim_NoneVsIal1Plus()
     {
         var user = new User { IalLevel = UserIalLevel.None };
         var principal = MakePrincipal(
@@ -130,6 +132,126 @@ public class SessionRefreshTokenServiceTests : JwtTokenServiceTestBase
         Assert.Equal(
             ((int)IdProofingStatus.InProgress).ToString(),
             jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingStatus).Value);
+    }
+
+    // --- DocV elevation flow ---
+
+    // Critical scenario from the DocV webhook bug: DB has been updated to IAL2/Completed
+    // after a successful DocV webhook, but the current session JWT still carries the pre-
+    // DocV ial=1/NotStarted claims. Refresh must adopt the elevated DB state, not the stale
+    // claims, so the user can access the IAL1plus-gated dashboard.
+    [Fact]
+    public void ElevatesFromIal1NotStartedToIal2Completed_WhenDbHasPostDocVState()
+    {
+        var completedAt = new DateTime(2026, 4, 24, 17, 2, 31, DateTimeKind.Utc);
+        var user = new User
+        {
+            IalLevel = UserIalLevel.IAL2,
+            IdProofingStatus = IdProofingStatus.Completed,
+            IdProofingCompletedAt = completedAt,
+            Email = "user@example.com"
+        };
+        var principal = MakePrincipal(
+            (JwtClaimTypes.Ial, "1"),
+            (JwtClaimTypes.IdProofingStatus, ((int)IdProofingStatus.NotStarted).ToString()),
+            ("email", "user@example.com"));
+
+        var token = Service.GenerateForSessionRefresh(user, principal);
+
+        var jwt = ReadJwt(token);
+        Assert.Equal("2", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+        Assert.Equal(
+            ((int)IdProofingStatus.Completed).ToString(),
+            jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingStatus).Value);
+
+        var expectedCompletedAtUnix =
+            new DateTimeOffset(completedAt, TimeSpan.Zero).ToUnixTimeSeconds().ToString();
+        Assert.Equal(
+            expectedCompletedAtUnix,
+            jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingCompletedAt).Value);
+    }
+
+    [Fact]
+    public void ElevatesIalFromClaim1ToDbIal1Plus()
+    {
+        var user = new User { IalLevel = UserIalLevel.IAL1plus, Email = "user@example.com" };
+        var principal = MakePrincipal(
+            (JwtClaimTypes.Ial, "1"),
+            (JwtClaimTypes.IdProofingStatus, ((int)IdProofingStatus.NotStarted).ToString()),
+            ("email", "user@example.com"));
+
+        var token = Service.GenerateForSessionRefresh(user, principal);
+
+        var jwt = ReadJwt(token);
+        Assert.Equal("1plus", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+    }
+
+    // Defense-in-depth: a stale or admin-edited DB IAL below the active claim
+    // must not demote the session. IAL1plus in claim wins over IAL1plus vs
+    // IAL2 in claim wins over IAL1plus in DB.
+    [Fact]
+    public void DoesNotDowngradeIal_WhenDbIal1PlusAndClaimIal2()
+    {
+        var user = new User
+        {
+            IalLevel = UserIalLevel.IAL1plus,
+            IdProofingStatus = IdProofingStatus.Completed,
+            IdProofingCompletedAt = new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            Email = "user@example.com"
+        };
+        var principal = MakePrincipal(
+            (JwtClaimTypes.Ial, "2"),
+            (JwtClaimTypes.IdProofingStatus, ((int)IdProofingStatus.Completed).ToString()),
+            (JwtClaimTypes.IdProofingCompletedAt, "1700000000"),
+            (JwtClaimTypes.IdProofingExpiresAt, "1857676800"),
+            ("email", "user@example.com"));
+
+        var token = Service.GenerateForSessionRefresh(user, principal);
+
+        var jwt = ReadJwt(token);
+        Assert.Equal("2", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+    }
+
+    [Fact]
+    public void FallsBackToDbIal_WhenPrincipalLacksIalClaim_Ial2()
+    {
+        var user = new User { IalLevel = UserIalLevel.IAL2, Email = "user@example.com" };
+        var principal = MakePrincipal(("email", "user@example.com"));
+
+        var token = Service.GenerateForSessionRefresh(user, principal);
+
+        var jwt = ReadJwt(token);
+        Assert.Equal("2", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+    }
+
+    [Fact]
+    public void ElevatesIdProofingStatusToCompleted_WithCompletedAtTimestamp()
+    {
+        var completedAt = new DateTime(2026, 4, 24, 10, 30, 0, DateTimeKind.Utc);
+        var user = new User
+        {
+            IalLevel = UserIalLevel.IAL2,
+            IdProofingStatus = IdProofingStatus.Completed,
+            IdProofingCompletedAt = completedAt,
+            Email = "user@example.com"
+        };
+        var principal = MakePrincipal(
+            (JwtClaimTypes.Ial, "1"),
+            (JwtClaimTypes.IdProofingStatus, ((int)IdProofingStatus.NotStarted).ToString()),
+            ("email", "user@example.com"));
+
+        var token = Service.GenerateForSessionRefresh(user, principal);
+
+        var jwt = ReadJwt(token);
+        Assert.Equal(
+            ((int)IdProofingStatus.Completed).ToString(),
+            jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingStatus).Value);
+
+        var expectedCompletedAtUnix =
+            new DateTimeOffset(completedAt, TimeSpan.Zero).ToUnixTimeSeconds().ToString();
+        Assert.Equal(
+            expectedCompletedAtUnix,
+            jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingCompletedAt).Value);
     }
 
     // --- Email fallback chain ---

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/Socure/SocureExcludedIdentifierTypesTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/Socure/SocureExcludedIdentifierTypesTests.cs
@@ -1,0 +1,50 @@
+using SEBT.Portal.Infrastructure.Services.Socure;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Services.Socure;
+
+public class SocureExcludedIdentifierTypesTests
+{
+    [Theory]
+    [InlineData("snapAccountId")]
+    [InlineData("snapPersonId")]
+    [InlineData("tanfAccountId")]
+    [InlineData("tanfPersonId")]
+    public void IsExcludedFromSocurePayload_ReturnsTrue_ForSnapOrTanfPortalSelections(string idType)
+    {
+        Assert.True(SocureExcludedIdentifierTypes.IsExcludedFromSocurePayload(idType));
+    }
+
+    [Fact]
+    public void IsExcludedFromSocurePayload_ReturnsTrue_ForMedicaidId()
+    {
+        // Medicaid IDs (7 or 8 digits per DC content) cannot satisfy Socure's
+        // national_id schema requirement of exactly 4 or 9 digits, so they are
+        // excluded from the outbound evaluation payload.
+        Assert.True(SocureExcludedIdentifierTypes.IsExcludedFromSocurePayload("medicaidId"));
+    }
+
+    [Theory]
+    [InlineData("ssn")]
+    [InlineData("itin")]
+    public void IsExcludedFromSocurePayload_ReturnsFalse_ForNonBenefitIdentifierTypes(string idType)
+    {
+        Assert.False(SocureExcludedIdentifierTypes.IsExcludedFromSocurePayload(idType));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsExcludedFromSocurePayload_ReturnsFalse_ForNullOrEmpty(string? idType)
+    {
+        Assert.False(SocureExcludedIdentifierTypes.IsExcludedFromSocurePayload(idType));
+    }
+
+    [Fact]
+    public void IsExcludedFromSocurePayload_IsCaseSensitive()
+    {
+        // Comparison uses StringComparer.Ordinal to match the existing HashSet
+        // convention in IdProofingBenefitIdentifierTypes. A differently-cased
+        // value (e.g., "MedicaidId") is not recognized as the portal idType.
+        Assert.False(SocureExcludedIdentifierTypes.IsExcludedFromSocurePayload("MedicaidId"));
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ProcessWebhookCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ProcessWebhookCommandHandlerTests.cs
@@ -30,12 +30,16 @@ public class ProcessWebhookCommandHandlerTests
     private static ProcessWebhookCommand CreateValidCommand(
         string eventId = "evt-123",
         string? referenceId = "ref-456",
-        string? decision = "accept") =>
+        string? workflowDecision = "ACCEPT",
+        string? documentDecision = "accept",
+        string? eventType = "evaluation_completed") =>
         new()
         {
             EventId = eventId,
             ReferenceId = referenceId,
-            DocumentDecision = decision
+            WorkflowDecision = workflowDecision,
+            DocumentDecision = documentDecision,
+            EventType = eventType
         };
 
     // --- Webhook signature rejection (Codex test 2) ---
@@ -51,7 +55,9 @@ public class ProcessWebhookCommandHandlerTests
         {
             EventId = "evt-123",
             ReferenceId = "ref-456",
+            WorkflowDecision = "ACCEPT",
             DocumentDecision = "accept",
+            EventType = "evaluation_completed",
             WebhookSignature = null // Missing signature
         };
 
@@ -83,7 +89,9 @@ public class ProcessWebhookCommandHandlerTests
         {
             EventId = "evt-123",
             ReferenceId = "ref-456",
+            WorkflowDecision = "ACCEPT",
             DocumentDecision = "accept",
+            EventType = "evaluation_completed",
             WebhookSignature = "my-webhook-secret" // Matches the configured secret
         };
 
@@ -103,7 +111,9 @@ public class ProcessWebhookCommandHandlerTests
         {
             EventId = "evt-123",
             ReferenceId = "ref-456",
+            WorkflowDecision = "ACCEPT",
             DocumentDecision = "accept",
+            EventType = "evaluation_completed",
             WebhookSignature = "wrong-secret" // Does NOT match
         };
 
@@ -154,7 +164,8 @@ public class ProcessWebhookCommandHandlerTests
         var command = CreateValidCommand(
             eventId: "evt-late-reject",
             referenceId: "ref-456",
-            decision: "reject");
+            workflowDecision: "REJECT",
+            documentDecision: "reject");
 
         var result = await handler.Handle(command, CancellationToken.None);
 
@@ -184,7 +195,7 @@ public class ProcessWebhookCommandHandlerTests
         userRepository.GetUserByIdAsync(challenge.UserId, Arg.Any<CancellationToken>())
             .Returns(user);
 
-        var command = CreateValidCommand(decision: "accept");
+        var command = CreateValidCommand(workflowDecision: "ACCEPT", documentDecision: "accept");
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
@@ -215,7 +226,7 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
             .Returns(challenge);
 
-        var command = CreateValidCommand(decision: "reject");
+        var command = CreateValidCommand(workflowDecision: "REJECT", documentDecision: "reject");
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
@@ -253,7 +264,9 @@ public class ProcessWebhookCommandHandlerTests
             EventId = "evt-123",
             ReferenceId = "ref-unknown",
             EvalId = "eval-789",
-            DocumentDecision = "accept"
+            WorkflowDecision = "ACCEPT",
+            DocumentDecision = "accept",
+            EventType = "evaluation_completed"
         };
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -277,7 +290,9 @@ public class ProcessWebhookCommandHandlerTests
         {
             EventId = "evt-123",
             ReferenceId = "ref-unknown",
-            DocumentDecision = "accept"
+            WorkflowDecision = "ACCEPT",
+            DocumentDecision = "accept",
+            EventType = "evaluation_completed"
         };
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -304,7 +319,7 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.UpdateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new ConcurrencyConflictException("Row was updated by another thread"));
 
-        var command = CreateValidCommand(decision: "accept");
+        var command = CreateValidCommand(workflowDecision: "ACCEPT", documentDecision: "accept");
         var result = await handler.Handle(command, CancellationToken.None);
 
         // Should return success — the other thread handled it
@@ -333,7 +348,9 @@ public class ProcessWebhookCommandHandlerTests
         {
             EventId = "evt-123",
             ReferenceId = "ref-456",
+            WorkflowDecision = "ACCEPT",
             DocumentDecision = "accept",
+            EventType = "evaluation_completed",
             WebhookSignature = null // No signature, but stub mode
         };
 
@@ -357,7 +374,7 @@ public class ProcessWebhookCommandHandlerTests
         var command = CreateValidCommand(
             eventId: "evt-late-accept",
             referenceId: "ref-456",
-            decision: "accept");
+            workflowDecision: "ACCEPT", documentDecision: "accept");
 
         var result = await handler.Handle(command, CancellationToken.None);
 
@@ -382,7 +399,7 @@ public class ProcessWebhookCommandHandlerTests
         var command = CreateValidCommand(
             eventId: "evt-late-accept",
             referenceId: "ref-456",
-            decision: "accept");
+            workflowDecision: "ACCEPT", documentDecision: "accept");
 
         var result = await handler.Handle(command, CancellationToken.None);
 
@@ -391,10 +408,10 @@ public class ProcessWebhookCommandHandlerTests
             .UpdateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
     }
 
-    // --- Intermediate decisions stay Pending ---
+    // --- Workflow REVIEW transitions to Rejected (DC-296: DC does not use human review queues) ---
 
     [Fact]
-    public async Task Handle_ShouldReturnSuccess_WhenDecisionIsReview()
+    public async Task HandleAsync_EvaluationCompleted_WorkflowReview_TransitionsToRejected()
     {
         var handler = CreateHandler();
         var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
@@ -402,17 +419,167 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
             .Returns(challenge);
 
-        var command = CreateValidCommand(decision: "review");
+        var command = CreateValidCommand(workflowDecision: "REVIEW", documentDecision: null);
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await challengeRepository.Received(1)
+            .UpdateAsync(Arg.Is<DocVerificationChallenge>(c =>
+                c.Status == DocVerificationStatus.Rejected
+                && c.OffboardingReason == "docVerificationFailed"),
+                Arg.Any<CancellationToken>());
+        await userRepository.DidNotReceive()
+            .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Workflow RESUBMIT transitions to Rejected (DC-296: covers DocV decline case) ---
+
+    [Fact]
+    public async Task HandleAsync_EvaluationCompleted_WorkflowResubmit_TransitionsToRejected()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+
+        challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
+            .Returns(challenge);
+
+        // Decline case: user declined on the Capture App, no DocV enrichment present
+        var command = CreateValidCommand(workflowDecision: "RESUBMIT", documentDecision: null);
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await challengeRepository.Received(1)
+            .UpdateAsync(Arg.Is<DocVerificationChallenge>(c =>
+                c.Status == DocVerificationStatus.Rejected
+                && c.OffboardingReason == "docVerificationFailed"),
+                Arg.Any<CancellationToken>());
+        await userRepository.DidNotReceive()
+            .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Workflow REJECT transitions to Rejected ---
+
+    [Fact]
+    public async Task HandleAsync_EvaluationCompleted_WorkflowReject_TransitionsToRejected()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+
+        challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
+            .Returns(challenge);
+
+        var command = CreateValidCommand(workflowDecision: "REJECT", documentDecision: "reject");
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await challengeRepository.Received(1)
+            .UpdateAsync(Arg.Is<DocVerificationChallenge>(c =>
+                c.Status == DocVerificationStatus.Rejected
+                && c.OffboardingReason == "docVerificationFailed"),
+                Arg.Any<CancellationToken>());
+        await userRepository.DidNotReceive()
+            .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Happy path: workflow ACCEPT on evaluation_completed ---
+
+    [Fact]
+    public async Task HandleAsync_EvaluationCompleted_WorkflowAccept_TransitionsToVerified()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+        var user = new User
+        {
+            Id = challenge.UserId,
+            Email = "test@example.com",
+            IdProofingStatus = IdProofingStatus.InProgress
+        };
+
+        challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(challenge.UserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        var command = CreateValidCommand(workflowDecision: "ACCEPT", documentDecision: "accept");
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await challengeRepository.Received(1)
+            .UpdateAsync(Arg.Is<DocVerificationChallenge>(c =>
+                c.Status == DocVerificationStatus.Verified),
+                Arg.Any<CancellationToken>());
+        await userRepository.Received(1)
+            .UpdateUserAsync(Arg.Is<User>(u =>
+                u.IdProofingStatus == IdProofingStatus.Completed
+                && u.IalLevel == UserIalLevel.IAL2),
+                Arg.Any<CancellationToken>());
+    }
+
+    // --- evaluation_paused keeps challenge Pending (no terminal decision yet) ---
+
+    [Fact]
+    public async Task HandleAsync_EvaluationPaused_KeepsChallengePending()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+
+        challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
+            .Returns(challenge);
+
+        var command = CreateValidCommand(
+            workflowDecision: null,
+            documentDecision: null,
+            eventType: "evaluation_paused");
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         Assert.Equal(DocVerificationStatus.Pending, challenge.Status);
         await challengeRepository.DidNotReceive()
             .UpdateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
+        await userRepository.DidNotReceive()
+            .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
+    // --- Latent-bug fix: DI-rejected workflow with DocV "accept" must NOT grant IAL2 ---
+
     [Fact]
-    public async Task Handle_ShouldReturnSuccess_WhenDecisionIsResubmit()
+    public async Task HandleAsync_EvaluationCompleted_WorkflowRejectButDocvAccept_TransitionsToRejected()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+        var user = new User
+        {
+            Id = challenge.UserId,
+            Email = "test@example.com",
+            IdProofingStatus = IdProofingStatus.InProgress
+        };
+
+        challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(challenge.UserId, Arg.Any<CancellationToken>())
+            .Returns(user);
+
+        // Workflow rejected by Digital Intelligence signals (VPN, timezone mismatch, etc.)
+        // even though the DocV enrichment internally said "accept".
+        var command = CreateValidCommand(workflowDecision: "REJECT", documentDecision: "accept");
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await challengeRepository.Received(1)
+            .UpdateAsync(Arg.Is<DocVerificationChallenge>(c =>
+                c.Status == DocVerificationStatus.Rejected
+                && c.OffboardingReason == "docVerificationFailed"),
+                Arg.Any<CancellationToken>());
+
+        // Critical: user must NOT be updated to IAL2
+        await userRepository.DidNotReceive()
+            .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Unrecognized / missing workflow decision on evaluation_completed ---
+
+    [Fact]
+    public async Task HandleAsync_EvaluationCompleted_WorkflowDecisionMissing_LogsUnrecognizedAndStaysSuccess()
     {
         var handler = CreateHandler();
         var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
@@ -420,19 +587,19 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
             .Returns(challenge);
 
-        var command = CreateValidCommand(decision: "resubmit");
+        var command = CreateValidCommand(workflowDecision: null, documentDecision: null);
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         Assert.Equal(DocVerificationStatus.Pending, challenge.Status);
         await challengeRepository.DidNotReceive()
             .UpdateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
+        await userRepository.DidNotReceive()
+            .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
-    // --- Unrecognized decision ---
-
     [Fact]
-    public async Task Handle_ShouldReturnSuccess_WhenDecisionIsUnrecognized()
+    public async Task HandleAsync_EvaluationCompleted_WorkflowDecisionUnrecognized_StaysSuccess()
     {
         var handler = CreateHandler();
         var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
@@ -440,7 +607,7 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
             .Returns(challenge);
 
-        var command = CreateValidCommand(decision: "unknown");
+        var command = CreateValidCommand(workflowDecision: "unknown", documentDecision: null);
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
@@ -460,7 +627,7 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
             .Returns(challenge);
 
-        var command = CreateValidCommand(decision: "accept");
+        var command = CreateValidCommand(workflowDecision: "ACCEPT", documentDecision: "accept");
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
@@ -482,7 +649,7 @@ public class ProcessWebhookCommandHandlerTests
         userRepository.GetUserByIdAsync(challenge.UserId, Arg.Any<CancellationToken>())
             .Returns((User?)null);
 
-        var command = CreateValidCommand(decision: "accept");
+        var command = CreateValidCommand(workflowDecision: "ACCEPT", documentDecision: "accept");
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
@@ -510,7 +677,9 @@ public class ProcessWebhookCommandHandlerTests
             EventId = "evt-123",
             ReferenceId = null,
             EvalId = null,
-            DocumentDecision = "accept"
+            WorkflowDecision = "ACCEPT",
+            DocumentDecision = "accept",
+            EventType = "evaluation_completed"
         };
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -539,7 +708,9 @@ public class ProcessWebhookCommandHandlerTests
         {
             EventId = eventId,
             ReferenceId = "ref-456",
-            DocumentDecision = "accept"
+            WorkflowDecision = "ACCEPT",
+            DocumentDecision = "accept",
+            EventType = "evaluation_completed"
         };
 
         var result = await handler.Handle(command, CancellationToken.None);
@@ -561,7 +732,9 @@ public class ProcessWebhookCommandHandlerTests
             EventId = "evt-valid",
             ReferenceId = injected,
             EvalId = injected,
-            DocumentDecision = injected
+            WorkflowDecision = injected,
+            DocumentDecision = injected,
+            EventType = injected
         };
 
         var result = await handler.Handle(command, CancellationToken.None);

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -400,6 +400,138 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<CancellationToken>());
     }
 
+    // --- SSN/ITIN must be exactly 9 digits after stripping non-digits (DC-296 Phase 3 backend guard) ---
+    // OpenAPI Individual.national_id permits 4-digit partials; product decision is full 9 only.
+
+    [Fact]
+    public async Task HandleAsync_SsnWithFewerThan9Digits_ReturnsValidationFailedAndDoesNotCallSocure()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "ssn", idValue: "12345678");
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com" });
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var failed = Assert.IsType<ValidationFailedResult<SubmitIdProofingResponse>>(result);
+        Assert.Contains(
+            failed.Errors,
+            e => e.Key == nameof(SubmitIdProofingCommand.IdValue));
+
+        await socureClient.DidNotReceiveWithAnyArgs()
+            .RunIdProofingAssessmentAsync(
+                default, default!, default!,
+                default, default, default, default,
+                default, default, default, default,
+                default);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SsnWithMoreThan9Digits_ReturnsValidationFailedAndDoesNotCallSocure()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "ssn", idValue: "1234567890");
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com" });
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var failed = Assert.IsType<ValidationFailedResult<SubmitIdProofingResponse>>(result);
+        Assert.Contains(
+            failed.Errors,
+            e => e.Key == nameof(SubmitIdProofingCommand.IdValue));
+
+        await socureClient.DidNotReceiveWithAnyArgs()
+            .RunIdProofingAssessmentAsync(
+                default, default!, default!,
+                default, default, default, default,
+                default, default, default, default,
+                default);
+    }
+
+    [Fact]
+    public async Task HandleAsync_SsnWithNonDigits_ReturnsValidationFailedAndDoesNotCallSocure()
+    {
+        var handler = CreateHandler();
+        // 6 digits after stripping letters; should fail the 9-digit check
+        var command = CreateValidCommand(idType: "ssn", idValue: "abc123456");
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com" });
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var failed = Assert.IsType<ValidationFailedResult<SubmitIdProofingResponse>>(result);
+        Assert.Contains(
+            failed.Errors,
+            e => e.Key == nameof(SubmitIdProofingCommand.IdValue));
+
+        await socureClient.DidNotReceiveWithAnyArgs()
+            .RunIdProofingAssessmentAsync(
+                default, default!, default!,
+                default, default, default, default,
+                default, default, default, default,
+                default);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ItinWithInvalidLength_ReturnsValidationFailedAndDoesNotCallSocure()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: "itin", idValue: "12345");
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com" });
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var failed = Assert.IsType<ValidationFailedResult<SubmitIdProofingResponse>>(result);
+        Assert.Contains(
+            failed.Errors,
+            e => e.Key == nameof(SubmitIdProofingCommand.IdValue));
+
+        await socureClient.DidNotReceiveWithAnyArgs()
+            .RunIdProofingAssessmentAsync(
+                default, default!, default!,
+                default, default, default, default,
+                default, default, default, default,
+                default);
+    }
+
+    [Fact]
+    public async Task HandleAsync_Ssn9DigitsWithHyphens_NormalizesAndProceeds()
+    {
+        var handler = CreateHandler();
+        // Hyphens are optional per OpenAPI; after stripping we have 9 digits and the guard lets us through.
+        var command = CreateValidCommand(idType: "ssn", idValue: "123-45-6789");
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com" });
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        socureClient.RunIdProofingAssessmentAsync(
+                command.UserId, "test@example.com", command.DateOfBirth,
+                command.IdType, command.IdValue, Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.Success(
+                new IdProofingAssessmentResult(IdProofingOutcome.Matched, AllowIdRetry: false)));
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await socureClient.Received(1)
+            .RunIdProofingAssessmentAsync(
+                command.UserId, "test@example.com", command.DateOfBirth,
+                command.IdType, command.IdValue, Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task Handle_ShouldCallSocure_WhenNotCoLoadedAndSnapIdWithValue()
     {


### PR DESCRIPTION
# PR Review Priority Guide — DC-296

- **Branch:** `bugfix/DC-296-socure-data-validation` -> `main`
- **State:** pre-PR (no #)
- **Risk Level:** Medium-High
- **Files:** 30 | **Lines:** +2,207 / -127
- **Generated:** 2026-04-24

Catches Socure outbound payload shape errors (10-digit SSN/ITIN, non-E.164 phone, oversized names, reused evaluation ids) before they 400 the workflow, plus routes DocV webhook outcomes off the top-level workflow decision and refreshes JWT claims from DB post-DocV. Reviewer attention belongs on the claim-refresh logic, the webhook decision-routing shift, and the boundary validation guards.

---

## PR template (draft, for copy-paste when opening)

#### 🔗 Jira ticket
- [DC-296](https://codeforamerica.atlassian.net/browse/DC-296)

#### ✍️ Description
Hardens the data validation on the outbound path to Socure so shape errors never reach the workflow. Frontend Zod schema enforces 9-digit SSN/ITIN and calendar-valid DOB. Backend adds the same SSN/ITIN guard in `SubmitIdProofingCommandHandler`, normalizes phones to E.164 and truncates names to 240 chars at the `HttpSocureClient` boundary, and sends a unique `id` per evaluation. DocV webhook processing routes on the top-level workflow decision (ACCEPT/REJECT/RESUBMIT/REVIEW) rather than the document-enrichment decision. Session JWT refresh re-pulls `ial` and `id_proofing_status` from the DB when the DB reflects a post-DocV elevation, using a rank comparison to block any accidental downgrade. Also cleans up offboarding copy for decline-consent and normalizes `SocureExcludedIdentifierTypes`.

#### 🔗 Links to related PRs
- Connector changes: none (portal-only)
- Follow-ups tracked: DC-138 resubmit handling (deferred), offboarding copy distinctness (tracked separately), Medicaid ID shape (open product question)

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

No config changes in this branch. One NuGet dep added: `libphonenumber-csharp` (matches CO connector version).

---

## Priority Review Table

| Priority | File | Change | Lines | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|:---:|---|
| 🔴 | `src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs` | `GenerateForSessionRefresh` IAL/status elevation via `RankIal` | 205-279 | High | Med | Med | Claim downgrade defense |
| 🔴 | `src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs` | Switch to workflow decision; RESUBMIT/REVIEW -> Rejected | 80-220 | High | Med | High | Routing behavior change |
| 🔴 | `src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs` | SSN/ITIN 9-digit guard before Socure call | 58-72, 388-416 | High | Low | Low | Data boundary check |
| 🔴 | `src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs` | E.164 phone + name truncate + unique evaluation id | 45-68, 193-225 | High | Med | Med | Per-eval id is a semantic shift |
| 🔴 | `src/SEBT.Portal.Web/src/features/auth/api/submit-id-proofing/schema.ts` (new) | DOB calendar/age/future + SSN/ITIN digit validation | 1-90 | High | Med | Med | PII-adjacent input contract |
| 🟡 | `src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx` | Per-option `validation`, digit-stripping, shape errors | 11-180 | High | Med | Med | Untranslated copy (TODOs) |
| 🟡 | `src/SEBT.Portal.Infrastructure/Services/PhoneNormalizer.cs` (new) | libphonenumber US parse/validate wrapper | 1-36 | Low | Low | Med | Mirrors CO connector API |
| 🟡 | `src/SEBT.Portal.Infrastructure/Socure/SocureExcludedIdentifierTypes.cs` | Excluded-type filter adjustments | full | Med | Low | Low | Affects which ids reach Socure |
| 🟡 | `src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx` | Post-verify state handling | full | Med | Med | Low | Pairs with JWT refresh |
| 🟡 | `src/SEBT.Portal.Web/src/features/auth/components/off-boarding/OffBoardingPage.tsx` | Decline-consent reason/copy plumbing | full | Low | Low | Med | Copy gap still open |
| 🟢 | `*.test.*` (8 files, ~1,300 lines) | Coverage for all above | — | Low | — | — | Skim for gap coverage |
| 🟢 | `WebhookController.cs`, `ProcessWebhookCommand.cs` | Pass-through plumbing for `workflowDecision` | — | Low | Low | Low | Wire-up |
| 🟢 | `mocks/handlers.ts`, `HouseholdFactory.cs`, `useSubmitIdProofing.test.tsx` | Fixture tweaks | — | Low | Low | Low | Trivial |
| 🟢 | `SEBT.Portal.Infrastructure.csproj` | `libphonenumber-csharp` dep | +1 | Low | — | Low | Matches CO version |

---

## Review Recommendation

Start with the four red items in this order:

1. **`JwtTokenService.cs`** — verify `RankIal` ordering (`2 > 1plus > 1 > null`) is correct, and that `IdProofingCompletedAt` / `IdProofingExpiresAt` claims are always repopulated whenever `IdProofingStatus` is set to `Completed` (`BuildAndSignToken` invariant depends on it). Confirm the non-Completed branch can never silently drop an existing higher-value status claim.
2. **`ProcessWebhookCommandHandler.cs`** — the switch from `documentDecision` to `workflowDecision` changes observable behavior: RESUBMIT and REVIEW now terminate as Rejected rather than staying Pending. Verify every code path that previously relied on "review" / "resubmit" being intermediate is either gone or intentionally re-routed; confirm `evaluation_paused` still the only intermediate path.
3. **`SubmitIdProofingCommandHandler.cs`** (guard) + **`HttpSocureClient.cs`** (boundary) — read as a pair. The 9-digit check is the gating fence, the E.164 / truncate / unique-id transforms are what ships when the fence passes. Confirm `Guid.NewGuid()` on the top-level `id` doesn't break any downstream correlation we rely on.
4. **`schema.ts`** — the DOB `isRealCalendarDate` trick (JS Date rollover) is correct but non-obvious; cross-check against `schema.test.ts` leap-year and month-boundary cases.

Yellow items: `IdProofingForm.tsx` has three user-facing strings hardcoded with `// TODO: Use t(...)` — confirm DC CSV gap is tracked. `SocureExcludedIdentifierTypes` change is small but affects which id types reach the API; verify it matches the intended include/exclude set.

Tests (~1,300 lines) can be skimmed for coverage rather than read line-by-line. The ones worth opening: `HttpSocureClientTests.cs` (+297 — name truncation + phone edge cases), `ProcessWebhookCommandHandlerTests.cs` (+221 — RESUBMIT/REVIEW now-terminal), `SessionRefreshTokenServiceTests.cs` (+124 — IAL rank rules), `schema.test.ts` (+197, new — DOB edge cases).


[DC-296]: https://codeforamerica.atlassian.net/browse/DC-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ