### PR TITLE
DC-196: Remove email PII from OTP service and rate-limit logs

### DIFF
--- a/src/SEBT.Portal.Api/Middleware/OtpRateLimitMiddleware.cs
+++ b/src/SEBT.Portal.Api/Middleware/OtpRateLimitMiddleware.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using SEBT.Portal.Core.Utilities;
 
 namespace SEBT.Portal.Api.Middleware;
 
@@ -152,7 +153,7 @@ public class OtpRateLimitMiddleware
                 {
                     // Store email in HttpContext.Items for rate limiting partition key resolver
                     context.Items[EmailKey] = email.ToLowerInvariant();
-                    _logger.LogDebug("Extracted email {Email} for rate limiting", email);
+                    _logger.LogDebug("Extracted email {MaskedEmail} for rate limiting", PiiMasker.MaskEmail(email));
                     return true;
                 }
             }

--- a/src/SEBT.Portal.Infrastructure/Services/EmailOtpSenderService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/EmailOtpSenderService.cs
@@ -42,13 +42,11 @@ public class EmailOtpSenderService(
                 _settings.Subject,
                 htmlBody,
                 linkedResources);
-
-            logger.LogInformation("OTP email sent to {To}", to);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send OTP to: {To}", to);
-            return new PreconditionFailedResult(PreconditionFailedReason.Conflict, $"Failed to send OTP to: {to}");
+            logger.LogError(ex, "Failed to send OTP.");
+            return new PreconditionFailedResult(PreconditionFailedReason.Conflict, "Failed to send OTP email.");
         }
 
         return new SuccessResult();


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-196](https://codeforamerica.atlassian.net/browse/DC-196)

#### ✍️ Description
Reviewed open PII-related alerts in code scanning. Dismissed false positives and dev/test-only flags; fixed the remaining real exposures here.

**Code changes (2 files):**
- `EmailOtpSenderService` — removed raw `{To}` email from the error log and from the failure `Result.Message`; deleted the success log entirely (it was redundant with `RequestOtpCommandHandler.cs:80` which already logs success with a masked email). The error log keeps the exception, which carries the diagnostic payload. Closes alerts #37, #38, #109, #110.
- `OtpRateLimitMiddleware` — masked email in the rate-limit Debug log via `PiiMasker.MaskEmail`. The middleware sees every OTP request before the rate limiter decides, so masking preserves observability for both accepted and rate-limited paths. Closes alert #7.

**Investigated but no change required:**
- `OtpController`, `RequestOtpCommandHandler`, `ValidateOtpCommandHandler` — already use `MaskEmail`; flagged because the masker preserves the domain. Tracked as a separate decision (whether to switch to a hashed identifier).
- Validator error messages — confirmed clean (DataAnnotations literals only; no value interpolation).
- All `result.Message` log sites traced; only PII leak was the `EmailOtpSenderService` message string fixed here.
- Final sweep across Household, IdProofing, Webhook, Address, and OIDC handlers found no additional leaks.

**Post-merge expectation:** alerts #7, #37, #38, #109, #110 should auto-close on the next CodeQL scan of `main`.

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks
- [ ] Added relevant tests — N/A (changes are log-message substitutions; existing OTP tests still pass)
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes — none required

[DC-196]: https://codeforamerica.atlassian.net/browse/DC-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ