### PR TITLE
DC-296 - Allow non-co-loaded users without ID # to reach Socure DocV

### DIFF
--- a/src/SEBT.Portal.Core/Models/Auth/IdProofingBenefitIdentifierTypes.cs
+++ b/src/SEBT.Portal.Core/Models/Auth/IdProofingBenefitIdentifierTypes.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace SEBT.Portal.Core.Models.Auth;
 
 /// <summary>
@@ -19,6 +21,6 @@ public static class IdProofingBenefitIdentifierTypes
     /// True when <paramref name="idType"/> is a SNAP or TANF selection from the portal onboarding UI
     /// (aligned with the web <c>IdType</c> enum and any future TANF variants).
     /// </summary>
-    public static bool IsSnapOrTanfPortalSelection(string? idType) =>
+    public static bool IsSnapOrTanfPortalSelection([NotNullWhen(true)] string? idType) =>
         idType != null && SnapOrTanfPortalTypes.Contains(idType);
 }

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -104,12 +104,24 @@ public class SubmitIdProofingCommandHandler(
                     OffboardingReason: "maxAttemptsReached"));
         }
 
-        // No ID provided → off-board immediately (Codex test 5)
+        // Co-loaded users still need a SNAP/TANF identifier so we can household them; off-board
+        // when no ID is provided. Non-co-loaded users fall through to Socure DocV — Socure's
+        // consumer_onboarding workflow short-circuits to document verification when KYC can't
+        // resolve the consumer, so national_id is optional for that path.
         if (string.IsNullOrWhiteSpace(command.IdType))
         {
-            logger.LogInformation("User {UserId} submitted ID proofing without an ID type", command.UserId);
-            return Result<SubmitIdProofingResponse>.Success(
-                new SubmitIdProofingResponse("failed", OffboardingReason: "noIdProvided"));
+            if (user.IsCoLoaded)
+            {
+                logger.LogInformation(
+                    "Co-loaded user {UserId} submitted ID proofing without an ID type; off-boarding (householding requires a benefit ID)",
+                    command.UserId);
+                return Result<SubmitIdProofingResponse>.Success(
+                    new SubmitIdProofingResponse("failed", OffboardingReason: "noIdProvided"));
+            }
+
+            logger.LogInformation(
+                "Non-co-loaded user {UserId} submitted ID proofing without an ID type; proceeding to Socure DocV with no national_id",
+                command.UserId);
         }
 
         // Check for an existing active challenge → reuse instead of creating a duplicate

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -60,16 +60,16 @@ public class SubmitIdProofingCommandHandlerTests
         Assert.IsType<ValidationFailedResult<SubmitIdProofingResponse>>(result);
     }
 
-    // --- Null idType → noIdProvided (Codex test 5) ---
+    // --- Null idType: co-loaded users still need a benefit ID (householding); non-co-loaded fall through to Socure DocV ---
 
     [Fact]
-    public async Task Handle_ShouldReturnFailed_WhenIdTypeIsNull()
+    public async Task Handle_ShouldReturnFailed_WhenIdTypeIsNullAndUserIsCoLoaded()
     {
         var handler = CreateHandler();
         var command = CreateValidCommand(idType: null, idValue: null);
 
         userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
-            .Returns(new User { Id = command.UserId, Email = "test@example.com" });
+            .Returns(new User { Id = command.UserId, Email = "test@example.com", IsCoLoaded = true });
 
         var result = await handler.Handle(command, CancellationToken.None);
 
@@ -78,6 +78,49 @@ public class SubmitIdProofingCommandHandlerTests
         Assert.Equal("failed", response.Result);
         Assert.Equal("noIdProvided", response.OffboardingReason);
         Assert.Null(response.ChallengeId);
+
+        await socureClient.DidNotReceive()
+            .RunIdProofingAssessmentAsync(
+                Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldCallSocureWithNullIdentifier_WhenIdTypeIsNullAndUserIsNotCoLoaded()
+    {
+        // Socure's consumer_onboarding workflow short-circuits to DocV when KYC can't resolve
+        // the consumer; national_id is not required. Non-co-loaded users who pick "none of the
+        // above" should reach Socure, not the noIdProvided off-board.
+        var handler = CreateHandler();
+        var command = CreateValidCommand(idType: null, idValue: null);
+
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "test@example.com", IsCoLoaded = false });
+        challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+        socureClient.RunIdProofingAssessmentAsync(
+                command.UserId, "test@example.com", command.DateOfBirth,
+                null, null, Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.Success(
+                new IdProofingAssessmentResult(IdProofingOutcome.DocumentVerificationRequired, AllowIdRetry: true)));
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var response = result.Value;
+        Assert.Equal("documentVerificationRequired", response.Result);
+        Assert.NotNull(response.ChallengeId);
+
+        await socureClient.Received(1)
+            .RunIdProofingAssessmentAsync(
+                command.UserId, "test@example.com", command.DateOfBirth,
+                null, null, Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>());
     }
 
     // --- User not found ---


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-296](https://codeforamerica.atlassian.net/browse/DC-296)

#### ✍️ Description
Removes the upstream off-board that rejected ID-proofing submissions without an identifier when the user is non-co-loaded. Those users now flow into Socure DocV with no `national_id` in the request body — Socure's `consumer_onboarding` workflow short-circuits to document capture when KYC can't resolve, so an SSN/ITIN is optional. Co-loaded users still need a SNAP/TANF identifier (we use it for householding) and continue to see the existing off-board.

#### 🔗 Links to related PRs
- {none — backend-only change in this repo}

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

- **Branch:** `bugfix/DC-296-allow-empty-socure-payload` -> `main`
- **Risk Level:** Low

Single-conditional change in the ID-proofing handler with TDD coverage on both surviving branches. Reviewer attention should land on the loosened gate to confirm co-loaded users still off-board and that downstream Socure payload construction tolerates null `IdType`/`IdValue` — both existing behaviors we're now exercising in a new combination.

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs` | `Handle()` no-IdType branch | Med | Low | Low | gate loosened in auth path |
| 🟢 | `src/SEBT.Portal.Core/Models/Auth/IdProofingBenefitIdentifierTypes.cs` | `IsSnapOrTanfPortalSelection()` | Low | Low | Low | adds `[NotNullWhen(true)]` |
| 🟢 | `test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs` | renamed + new tests | Low | Low | Low | mirrors existing patterns |

### High-priority focus

1. Co-loaded users with null `IdType` still off-board with `noIdProvided` — covered by `Handle_ShouldReturnFailed_WhenIdTypeIsNullAndUserIsCoLoaded`, but worth eyeballing the conditional.
2. `HttpSocureClient.BuildEvaluationRequest` (unchanged, lines ~149-184) now gets exercised with `idType: null` / `idValue: null`. Confirm `national_id` is correctly omitted from the JSON body.
3. The `[NotNullWhen(true)]` annotation on `IsSnapOrTanfPortalSelection` preserves the compiler's null-flow inference inside the co-loaded SNAP/TANF block — verify there's no resurfacing of CS8604 elsewhere.

### Review Recommendation

Start at the handler diff, jump to `HttpSocureClient` to confirm the null-payload path, then skim the tests.


[DC-296]: https://codeforamerica.atlassian.net/browse/DC-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ