### PR TITLE
DC-301 - Socure resubmits

### DIFF
--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -18,6 +18,7 @@ export const IDV_PRIMARY_RESULT = 'idv_primary_result'
 export const DOCV_START = 'docv_start'
 export const DOCV_UPLOAD = 'docv_upload'
 export const DOCV_RESULT = 'docv_result'
+export const DOCV_RESUBMIT = 'docv_resubmit'
 export const IDV_FINAL_RESULT = 'idv_final_result'
 
 // Benefits Dashboard

--- a/src/SEBT.Portal.Api/Controllers/IdProofing/ChallengesController.cs
+++ b/src/SEBT.Portal.Api/Controllers/IdProofing/ChallengesController.cs
@@ -48,4 +48,41 @@ public class ChallengesController : ControllerBase
         var result = await handler.Handle(command, cancellationToken);
         return result.ToActionResult();
     }
+
+    /// <summary>
+    /// Retries document verification after a Socure RESUBMIT decision (DC-301).
+    /// Opens a fresh <c>docv_stepup</c> evaluation as a new challenge; the prior Resubmit
+    /// challenge stays terminal. Returns the new challenge ID + DocV URL for the user to
+    /// re-capture their documents.
+    /// </summary>
+    /// <param name="id">The prior challenge's public GUID (must be in Resubmit state).</param>
+    /// <param name="handler">The command handler.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <response code="200">Fresh challenge created. Returns new challenge ID, token, and URL.</response>
+    /// <response code="401">User is not authenticated.</response>
+    /// <response code="404">Prior challenge not found or belongs to a different user.</response>
+    /// <response code="409">Prior challenge is not in Resubmit state, or step-up returned an unexpected outcome.</response>
+    /// <response code="502">Socure step-up call failed.</response>
+    [HttpPost("{id:guid}/resubmit")]
+    [ProducesResponseType(typeof(ResubmitChallengeResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status502BadGateway)]
+    public async Task<IActionResult> Resubmit(
+        Guid id,
+        [FromServices] ICommandHandler<ResubmitChallengeCommand, ResubmitChallengeResponse> handler,
+        CancellationToken cancellationToken)
+    {
+        var userId = (Guid)HttpContext.Items[ResolveUserFilter.UserIdKey]!;
+
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = id,
+            UserId = userId
+        };
+
+        var result = await handler.Handle(command, cancellationToken);
+        return result.ToActionResult();
+    }
 }

--- a/src/SEBT.Portal.Api/appsettings.dc.example.json
+++ b/src/SEBT.Portal.Api/appsettings.dc.example.json
@@ -63,6 +63,7 @@
     "DocvTransactionTokenTtlMinutes": 20,
     "ApiVersion": "2025-01-01.orion",
     "Workflow": "consumer_onboarding",
+    "DocvStepupWorkflow": "docv_stepup",
     "DocvEnrichmentName": "SocureDocRequest",
     "DiSessionToken": "sandbox-placeholder",
     "SandboxPhoneOverride": "+1YOUR_PHONE_NUMBER"

--- a/src/SEBT.Portal.Core/AppSettings/SocureSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/SocureSettings.cs
@@ -67,6 +67,13 @@ public class SocureSettings
     public string Workflow { get; set; } = "consumer_onboarding";
 
     /// <summary>
+    /// Socure workflow name for DocV step-up retries (DC-301). Used when a user clicks
+    /// "try again" from a Resubmit prompt. The step-up workflow only emits ACCEPT/REJECT,
+    /// so retries are structurally capped at one attempt.
+    /// </summary>
+    public string DocvStepupWorkflow { get; set; } = "docv_stepup";
+
+    /// <summary>
     /// Identifier used to locate the DocV enrichment in the evaluation response.
     /// Matched against the <c>enrichment_provider</c> field — not <c>enrichment_name</c>,
     /// which varies by workflow (e.g. "Socure Document Request - Default Flow" in sandbox).

--- a/src/SEBT.Portal.Core/Models/DocVerification/DocVerificationChallenge.cs
+++ b/src/SEBT.Portal.Core/Models/DocVerification/DocVerificationChallenge.cs
@@ -97,16 +97,18 @@ public class DocVerificationChallenge
     public DateTime? DocvTokenIssuedAt { get; set; }
 
     /// <summary>
-    /// Whether this challenge is in a terminal state (Verified, Rejected, or Expired).
-    /// Terminal challenges cannot be modified.
+    /// Whether this challenge is in a terminal state (Verified, Rejected, Expired, or Resubmit).
+    /// Terminal challenges cannot be modified. A Resubmit challenge is terminal at this challenge's
+    /// scope; the user opens a fresh challenge to retry.
     /// </summary>
     public bool IsTerminal => Status is DocVerificationStatus.Verified
         or DocVerificationStatus.Rejected
-        or DocVerificationStatus.Expired;
+        or DocVerificationStatus.Expired
+        or DocVerificationStatus.Resubmit;
 
     /// <summary>
     /// Transitions the challenge to a new status, enforcing valid state transitions.
-    /// Allowed: Created → Pending → Verified | Rejected | Expired.
+    /// Allowed: Created → Pending → Verified | Rejected | Expired | Resubmit.
     /// Terminal states cannot be overwritten.
     /// </summary>
     /// <param name="newStatus">The target status.</param>
@@ -126,9 +128,10 @@ public class DocVerificationChallenge
 
         // Scrub id-proofing PII once the challenge reaches a terminal state. These fields
         // exist only to re-issue a Socure DocV token while the challenge is still active;
-        // once Verified/Rejected/Expired they serve no further purpose and should not sit
-        // at rest. Keep DocvTokenIssuedAt — it is a timestamp, not PII, and is useful for
-        // auditing how long the last-issued token lived before the terminal transition.
+        // once terminal they serve no further purpose and should not sit at rest. Resubmit
+        // is included: any retry opens a brand-new challenge with freshly minted tokens.
+        // Keep DocvTokenIssuedAt — it is a timestamp, not PII, and is useful for auditing
+        // how long the last-issued token lived before the terminal transition.
         if (IsTerminal)
         {
             ProofingDateOfBirth = null;
@@ -144,6 +147,7 @@ public class DocVerificationChallenge
             (DocVerificationStatus.Pending, DocVerificationStatus.Verified) => true,
             (DocVerificationStatus.Pending, DocVerificationStatus.Rejected) => true,
             (DocVerificationStatus.Pending, DocVerificationStatus.Expired) => true,
+            (DocVerificationStatus.Pending, DocVerificationStatus.Resubmit) => true,
             // Created can also expire directly if the user never starts
             (DocVerificationStatus.Created, DocVerificationStatus.Expired) => true,
             _ => false

--- a/src/SEBT.Portal.Core/Models/DocVerification/DocVerificationStatus.cs
+++ b/src/SEBT.Portal.Core/Models/DocVerification/DocVerificationStatus.cs
@@ -2,8 +2,10 @@ namespace SEBT.Portal.Core.Models.DocVerification;
 
 /// <summary>
 /// Lifecycle states for a document verification challenge.
-/// Transitions: Created → Pending → Verified | Rejected | Expired.
-/// Terminal states (Verified, Rejected, Expired) cannot be overwritten.
+/// Transitions: Created → Pending → Verified | Rejected | Expired | Resubmit.
+/// All four post-Pending states are terminal and cannot be overwritten. Resubmit is terminal at
+/// the Socure level (the workflow ended) but retry-eligible at the portal level: a user who
+/// lands on Resubmit can open a fresh challenge against Socure's `docv_stepup` workflow.
 /// </summary>
 public enum DocVerificationStatus
 {
@@ -30,5 +32,13 @@ public enum DocVerificationStatus
     /// <summary>
     /// The challenge expired before the user completed the flow. Terminal state.
     /// </summary>
-    Expired = 4
+    Expired = 4,
+
+    /// <summary>
+    /// Socure returned a RESUBMIT decision (recoverable failure such as image quality).
+    /// Terminal at Socure: the workflow ended and a retry must start a brand-new evaluation.
+    /// Retry-eligible at the portal: a fresh `DocVerificationChallenge` can be opened against
+    /// Socure's `docv_stepup` workflow when the user clicks "try again".
+    /// </summary>
+    Resubmit = 5
 }

--- a/src/SEBT.Portal.Core/Services/ISocureClient.cs
+++ b/src/SEBT.Portal.Core/Services/ISocureClient.cs
@@ -54,6 +54,31 @@ public interface ISocureClient
         Guid userId,
         string email,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Starts a fresh DocV step-up evaluation for a user who landed on Resubmit (DC-301).
+    /// Backed by the <c>docv_stepup</c> workflow, which only emits ACCEPT/REJECT — caps retries
+    /// at one by construction. Returns a brand-new transaction token + DocV URL; the caller
+    /// persists these on a new <see cref="DocVerificationChallenge"/> row.
+    /// </summary>
+    /// <param name="userId">Internal user ID for correlation.</param>
+    /// <param name="email">User's email address.</param>
+    /// <param name="phoneNumber">User's phone number (drives Socure's SMS link), or null.</param>
+    /// <param name="givenName">The user's first name, or null.</param>
+    /// <param name="familyName">The user's last name, or null.</param>
+    /// <param name="address">The user's mailing address from household data, or null.</param>
+    /// <param name="diSessionToken">Device Intelligence session token from the frontend SDK, or null to use config fallback.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An assessment result whose Outcome should be DocumentVerificationRequired with a non-null DocvSession.</returns>
+    Task<Result<IdProofingAssessmentResult>> RunDocvStepupAssessmentAsync(
+        Guid userId,
+        string email,
+        string? phoneNumber = null,
+        string? givenName = null,
+        string? familyName = null,
+        Address? address = null,
+        string? diSessionToken = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/SEBT.Portal.Infrastructure/Services/DisabledSocureClient.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/DisabledSocureClient.cs
@@ -42,4 +42,19 @@ public class DisabledSocureClient : ISocureClient
             Result<SocureDocvSession>.DependencyFailed(
                 DependencyFailedReason.NotConfigured, DisabledMessage));
     }
+
+    public Task<Result<IdProofingAssessmentResult>> RunDocvStepupAssessmentAsync(
+        Guid userId,
+        string email,
+        string? phoneNumber = null,
+        string? givenName = null,
+        string? familyName = null,
+        Address? address = null,
+        string? diSessionToken = null,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(
+            Result<IdProofingAssessmentResult>.DependencyFailed(
+                DependencyFailedReason.NotConfigured, DisabledMessage));
+    }
 }

--- a/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
@@ -43,7 +43,56 @@ public class HttpSocureClient(
         string? diSessionToken = null,
         CancellationToken cancellationToken = default)
     {
+        return await RunEvaluationAsync(
+            userId, email, dateOfBirth, idType, idValue,
+            workflow: null,
+            ipAddress, phoneNumber, givenName, familyName, address, diSessionToken,
+            cancellationToken);
+    }
+
+    public async Task<Result<IdProofingAssessmentResult>> RunDocvStepupAssessmentAsync(
+        Guid userId,
+        string email,
+        string? phoneNumber = null,
+        string? givenName = null,
+        string? familyName = null,
+        Address? address = null,
+        string? diSessionToken = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stepupWorkflow = socureSettingsSnapshot.Value.DocvStepupWorkflow;
+
+        // docv_stepup tolerates an empty DOB and no national_id; the workflow only re-runs the
+        // Document Request enrichment to mint a fresh capture URL. Sandbox-confirmed via
+        // docs/.local/socure-context/docv_stepup-experiments/FINDINGS.md (2026-04-18).
+        return await RunEvaluationAsync(
+            userId, email,
+            dateOfBirth: string.Empty,
+            idType: null,
+            idValue: null,
+            workflow: stepupWorkflow,
+            ipAddress: null,
+            phoneNumber, givenName, familyName, address, diSessionToken,
+            cancellationToken);
+    }
+
+    private async Task<Result<IdProofingAssessmentResult>> RunEvaluationAsync(
+        Guid userId,
+        string email,
+        string dateOfBirth,
+        string? idType,
+        string? idValue,
+        string? workflow,
+        string? ipAddress,
+        string? phoneNumber,
+        string? givenName,
+        string? familyName,
+        Address? address,
+        string? diSessionToken,
+        CancellationToken cancellationToken)
+    {
         var settings = socureSettingsSnapshot.Value;
+        var effectiveWorkflow = !string.IsNullOrWhiteSpace(workflow) ? workflow : settings.Workflow;
 
         // Normalize phone to E.164 at the Socure boundary. Defense-in-depth:
         // malformed upstream values (e.g. seed-data artifacts) must not reach the API.
@@ -60,7 +109,7 @@ public class HttpSocureClient(
         var truncatedGivenName = TruncateNameOrWarn(givenName, nameof(givenName));
         var truncatedFamilyName = TruncateNameOrWarn(familyName, nameof(familyName));
 
-        var request = BuildEvaluationRequest(userId, email, dateOfBirth, idType, idValue, settings, ipAddress, e164Phone, truncatedGivenName, truncatedFamilyName, address, diSessionToken);
+        var request = BuildEvaluationRequest(userId, email, dateOfBirth, idType, idValue, settings, ipAddress, e164Phone, truncatedGivenName, truncatedFamilyName, address, diSessionToken, effectiveWorkflow);
         var jsonContent = JsonSerializer.Serialize(request, JsonOptions);
 
         var httpClient = httpClientFactory.CreateClient("Socure");
@@ -137,7 +186,8 @@ public class HttpSocureClient(
         string? givenName = null,
         string? familyName = null,
         Address? address = null,
-        string? diSessionToken = null)
+        string? diSessionToken = null,
+        string? workflow = null)
     {
         // Frontend-provided DI token takes precedence over config fallback
         var effectiveDiToken = !string.IsNullOrWhiteSpace(diSessionToken)
@@ -197,7 +247,7 @@ public class HttpSocureClient(
             // causes RiskOS to treat the request as a re-run and can impact downstream workflows.
             // The customer/transaction identifier stays on individual.id (userId).
             Id = Guid.NewGuid().ToString(),
-            Workflow = settings.Workflow,
+            Workflow = !string.IsNullOrWhiteSpace(workflow) ? workflow : settings.Workflow,
             Timestamp = DateTime.UtcNow.ToString("o"),
             Data = new SocureEvaluationRequestData { Individual = individual }
         };

--- a/src/SEBT.Portal.Infrastructure/Services/StubSocureClient.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/StubSocureClient.cs
@@ -64,4 +64,30 @@ public class StubSocureClient(ILogger<StubSocureClient> logger) : ISocureClient
 
         return Task.FromResult(Result<SocureDocvSession>.Success(session));
     }
+
+    public Task<Result<IdProofingAssessmentResult>> RunDocvStepupAssessmentAsync(
+        Guid userId,
+        string email,
+        string? phoneNumber = null,
+        string? givenName = null,
+        string? familyName = null,
+        Address? address = null,
+        string? diSessionToken = null,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Stub: Starting DocV step-up evaluation for user {UserId}", userId);
+
+        var token = Guid.NewGuid().ToString();
+        var session = new SocureDocvSession(
+            DocvTransactionToken: token,
+            DocvUrl: $"https://verify.socure.com/#/dv/{token}",
+            ReferenceId: Guid.NewGuid().ToString(),
+            EvalId: Guid.NewGuid().ToString());
+
+        return Task.FromResult(Result<IdProofingAssessmentResult>.Success(
+            new IdProofingAssessmentResult(
+                Outcome: IdProofingOutcome.DocumentVerificationRequired,
+                AllowIdRetry: true,
+                DocvSession: session)));
+    }
 }

--- a/src/SEBT.Portal.TestUtilities/Helpers/DocVerificationChallengeFactory.cs
+++ b/src/SEBT.Portal.TestUtilities/Helpers/DocVerificationChallengeFactory.cs
@@ -113,6 +113,21 @@ public static class DocVerificationChallengeFactory
     }
 
     /// <summary>
+    /// Creates a challenge that has been marked Resubmit (Socure RESUBMIT decision).
+    /// Terminal at Socure level; the user can open a fresh challenge via the resubmit endpoint.
+    /// </summary>
+    /// <param name="customize">Optional action to further customize the challenge.</param>
+    /// <returns>A challenge in Resubmit status.</returns>
+    public static DocVerificationChallenge CreateResubmitChallenge(Action<DocVerificationChallenge>? customize = null)
+    {
+        var challenge = ChallengeFaker.Generate();
+        challenge.TransitionTo(DocVerificationStatus.Pending);
+        challenge.TransitionTo(DocVerificationStatus.Resubmit);
+        customize?.Invoke(challenge);
+        return challenge;
+    }
+
+    /// <summary>
     /// Sets a seed for the random number generator to ensure deterministic test data.
     /// </summary>
     /// <param name="seed">The seed value to use.</param>

--- a/src/SEBT.Portal.UseCases/Dependencies.cs
+++ b/src/SEBT.Portal.UseCases/Dependencies.cs
@@ -19,6 +19,7 @@ public static class Dependencies
         services.RegisterQueryHandler<GetHouseholdDataQuery, HouseholdData, GetHouseholdDataQueryHandler>();
         services.RegisterCommandHandler<SubmitIdProofingCommand, SubmitIdProofingResponse, SubmitIdProofingCommandHandler>();
         services.RegisterCommandHandler<StartChallengeCommand, StartChallengeResponse, StartChallengeCommandHandler>();
+        services.RegisterCommandHandler<ResubmitChallengeCommand, ResubmitChallengeResponse, ResubmitChallengeCommandHandler>();
         services.RegisterQueryHandler<GetVerificationStatusQuery, VerificationStatusResponse, GetVerificationStatusQueryHandler>();
         services.RegisterCommandHandler<ProcessWebhookCommand, ProcessWebhookCommandHandler>();
         services.RegisterCommandHandler<CheckEnrollmentCommand, EnrollmentCheckResult, CheckEnrollmentCommandHandler>();

--- a/src/SEBT.Portal.UseCases/IdProofing/GetVerificationStatus/GetVerificationStatusQueryHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/GetVerificationStatus/GetVerificationStatusQueryHandler.cs
@@ -53,6 +53,7 @@ public class GetVerificationStatusQueryHandler(
             DocVerificationStatus.Verified => "verified",
             DocVerificationStatus.Rejected => "rejected",
             DocVerificationStatus.Expired => "rejected",
+            DocVerificationStatus.Resubmit => "resubmit",
             _ => "pending"
         };
 

--- a/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
@@ -195,12 +195,11 @@ public class ProcessWebhookCommandHandler(
     }
 
     /// <summary>
-    /// Maps the top-level Socure workflow decision to our DocV challenge status (DC-296).
+    /// Maps the top-level Socure workflow decision to our DocV challenge status.
     /// ACCEPT -> Verified.
     /// REJECT -> Rejected.
-    /// RESUBMIT -> Rejected. The workflow terminated (e.g. user declined on the Capture App
-    /// before uploading). Treated as terminal rejection here; DC-138 resubmit scaffold will
-    /// refine this once in-session retries are supported.
+    /// RESUBMIT -> Resubmit (DC-301). Terminal at Socure but retry-eligible at the portal —
+    /// the user opens a fresh challenge against `docv_stepup` from the resubmit prompt.
     /// REVIEW -> Rejected. DC does not use human review queues, so we treat review as a safe
     /// default reject.
     /// </summary>
@@ -210,7 +209,7 @@ public class ProcessWebhookCommandHandler(
         {
             "ACCEPT" => DocVerificationStatus.Verified,
             "REJECT" => DocVerificationStatus.Rejected,
-            "RESUBMIT" => DocVerificationStatus.Rejected,
+            "RESUBMIT" => DocVerificationStatus.Resubmit,
             "REVIEW" => DocVerificationStatus.Rejected,
             _ => null
         };

--- a/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommand.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommand.cs
@@ -1,0 +1,22 @@
+using SEBT.Portal.Kernel;
+
+namespace SEBT.Portal.UseCases.IdProofing;
+
+/// <summary>
+/// Command to retry document verification after a Socure RESUBMIT decision (DC-301).
+/// Opens a brand-new <c>docv_stepup</c> evaluation; the existing Resubmit challenge is left
+/// untouched and a fresh <c>DocVerificationChallenge</c> row is persisted in Pending.
+/// </summary>
+public class ResubmitChallengeCommand : ICommand<ResubmitChallengeResponse>
+{
+    /// <summary>
+    /// The public GUID of the prior challenge (must be in Resubmit state).
+    /// </summary>
+    public Guid ChallengeId { get; init; }
+
+    /// <summary>
+    /// The authenticated user's internal ID. Used to enforce ownership.
+    /// Guaranteed non-empty by ResolveUserFilter before the command is built.
+    /// </summary>
+    public Guid UserId { get; init; }
+}

--- a/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs
@@ -1,0 +1,184 @@
+using Microsoft.Extensions.Logging;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Models;
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Models.DocVerification;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Core.Repositories;
+using SEBT.Portal.Core.Services;
+using SEBT.Portal.Kernel;
+using SEBT.Portal.Kernel.Results;
+
+namespace SEBT.Portal.UseCases.IdProofing;
+
+/// <summary>
+/// Handles a user-initiated retry after a Socure RESUBMIT decision (DC-301).
+///
+/// RESUBMIT is terminal at Socure — the original workflow ended and cannot be resumed.
+/// This handler starts a brand-new evaluation against the <c>docv_stepup</c> workflow
+/// (which only emits ACCEPT/REJECT, structurally capping retries at one) and persists a
+/// fresh <c>DocVerificationChallenge</c> row in Pending. The prior Resubmit challenge is
+/// left untouched as a terminal record.
+/// </summary>
+public class ResubmitChallengeCommandHandler(
+    IDocVerificationChallengeRepository challengeRepository,
+    IUserRepository userRepository,
+    IHouseholdRepository householdRepository,
+    ISocureClient socureClient,
+    SocureSettings socureSettings,
+    IValidator<ResubmitChallengeCommand> validator,
+    ILogger<ResubmitChallengeCommandHandler> logger)
+    : ICommandHandler<ResubmitChallengeCommand, ResubmitChallengeResponse>
+{
+    public async Task<Result<ResubmitChallengeResponse>> Handle(
+        ResubmitChallengeCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var validationResult = await validator.Validate(command, cancellationToken);
+        if (validationResult is ValidationFailedResult validationFailed)
+        {
+            logger.LogWarning("ResubmitChallenge validation failed for user {UserId}", command.UserId);
+            return Result<ResubmitChallengeResponse>.ValidationFailed(validationFailed.Errors);
+        }
+
+        // IDOR-safe load: returns null when (publicId, userId) doesn't match
+        var priorChallenge = await challengeRepository.GetByPublicIdAsync(
+            command.ChallengeId, command.UserId, cancellationToken);
+        if (priorChallenge == null)
+        {
+            logger.LogWarning(
+                "ResubmitChallenge: challenge {ChallengeId} not found for user {UserId}",
+                command.ChallengeId, command.UserId);
+            return Result<ResubmitChallengeResponse>.PreconditionFailed(
+                PreconditionFailedReason.NotFound, "Challenge not found.");
+        }
+
+        if (priorChallenge.Status != DocVerificationStatus.Resubmit)
+        {
+            logger.LogWarning(
+                "ResubmitChallenge: challenge {ChallengeId} is in {Status} state, expected Resubmit",
+                command.ChallengeId, priorChallenge.Status);
+            return Result<ResubmitChallengeResponse>.PreconditionFailed(
+                PreconditionFailedReason.Conflict,
+                $"Challenge is in {priorChallenge.Status} state and cannot be resubmitted.");
+        }
+
+        var user = await userRepository.GetUserByIdAsync(command.UserId, cancellationToken);
+        if (user == null)
+        {
+            logger.LogWarning("ResubmitChallenge: user {UserId} not found", command.UserId);
+            return Result<ResubmitChallengeResponse>.PreconditionFailed(
+                PreconditionFailedReason.NotFound, "User not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            logger.LogWarning(
+                "ResubmitChallenge: user {UserId} has no email, cannot retry document verification",
+                command.UserId);
+            return Result<ResubmitChallengeResponse>.PreconditionFailed(
+                PreconditionFailedReason.Conflict,
+                "Email is required for document verification.");
+        }
+
+        // Best-effort household lookup, mirroring StartChallenge's refresh path. Socure's docv_stepup
+        // accepts an empty payload (sandbox-confirmed), but we pass name/address/phone when we have
+        // them so DI signals stay consistent with the original consumer_onboarding evaluation.
+        string? givenName = null;
+        string? familyName = null;
+        Address? address = null;
+        string? householdPhone = null;
+        try
+        {
+            var household = await householdRepository.GetHouseholdByEmailAsync(
+                user.Email,
+                new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true),
+                user.IalLevel,
+                cancellationToken);
+            if (household?.UserProfile != null)
+            {
+                givenName = household.UserProfile.FirstName;
+                familyName = household.UserProfile.LastName;
+            }
+            if (household?.AddressOnFile != null)
+            {
+                address = household.AddressOnFile;
+            }
+            householdPhone = household?.Phone;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                "ResubmitChallenge: household lookup failed ({ExceptionType}) for user {UserId}, proceeding without name/address/phone from CMS",
+                ex.GetType().FullName, command.UserId);
+        }
+
+        var phoneNumber = !string.IsNullOrWhiteSpace(socureSettings.SandboxPhoneOverride)
+            ? socureSettings.SandboxPhoneOverride
+            : !string.IsNullOrWhiteSpace(householdPhone)
+                ? householdPhone
+                : user.Phone;
+
+        var assessmentResult = await socureClient.RunDocvStepupAssessmentAsync(
+            command.UserId,
+            user.Email!,
+            phoneNumber: phoneNumber,
+            givenName: givenName,
+            familyName: familyName,
+            address: address,
+            diSessionToken: null,
+            cancellationToken: cancellationToken);
+
+        if (!assessmentResult.IsSuccess)
+        {
+            logger.LogWarning(
+                "ResubmitChallenge: docv_stepup assessment failed for user {UserId}",
+                command.UserId);
+            if (assessmentResult is DependencyFailedResult<IdProofingAssessmentResult> depFailed)
+            {
+                return Result<ResubmitChallengeResponse>.DependencyFailed(depFailed.Reason, depFailed.Message);
+            }
+            return Result<ResubmitChallengeResponse>.DependencyFailed(
+                DependencyFailedReason.ConnectionFailed,
+                "Failed to start document verification retry.");
+        }
+
+        var assessment = assessmentResult.Value;
+        if (assessment.Outcome != IdProofingOutcome.DocumentVerificationRequired
+            || assessment.DocvSession == null)
+        {
+            logger.LogWarning(
+                "ResubmitChallenge: docv_stepup returned unexpected outcome {Outcome} (DocvSession={HasSession}) for user {UserId}",
+                assessment.Outcome, assessment.DocvSession != null, command.UserId);
+            return Result<ResubmitChallengeResponse>.PreconditionFailed(
+                PreconditionFailedReason.Conflict,
+                "Unable to start document verification retry. Please try again later.");
+        }
+
+        var session = assessment.DocvSession;
+        var newChallenge = new DocVerificationChallenge
+        {
+            UserId = command.UserId,
+            SocureReferenceId = session.ReferenceId,
+            EvalId = session.EvalId,
+            DocvTransactionToken = session.DocvTransactionToken,
+            DocvUrl = session.DocvUrl,
+            DocvTokenIssuedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(socureSettings.ChallengeExpirationMinutes),
+            AllowIdRetry = true
+        };
+        newChallenge.TransitionTo(DocVerificationStatus.Pending);
+
+        await challengeRepository.CreateAsync(newChallenge, cancellationToken);
+
+        logger.LogInformation(
+            "ResubmitChallenge: opened fresh challenge {NewChallengeId} for user {UserId} (prior {PriorChallengeId} stays Resubmit)",
+            newChallenge.PublicId, command.UserId, priorChallenge.PublicId);
+
+        return Result<ResubmitChallengeResponse>.Success(
+            new ResubmitChallengeResponse(
+                ChallengeId: newChallenge.PublicId,
+                DocvTransactionToken: session.DocvTransactionToken,
+                DocvUrl: session.DocvUrl));
+    }
+}

--- a/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeResponse.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeResponse.cs
@@ -1,0 +1,14 @@
+namespace SEBT.Portal.UseCases.IdProofing;
+
+/// <summary>
+/// Response from a successful resubmit retry. Returns the new challenge's public ID so the
+/// frontend can poll its status, plus the fresh DocV transaction token + URL for the SDK
+/// or new-tab handoff.
+/// </summary>
+/// <param name="ChallengeId">Public ID of the freshly created <c>DocVerificationChallenge</c>.</param>
+/// <param name="DocvTransactionToken">The transaction token for the Socure DocV SDK.</param>
+/// <param name="DocvUrl">The Socure verification URL for document capture.</param>
+public record ResubmitChallengeResponse(
+    Guid ChallengeId,
+    string DocvTransactionToken,
+    string DocvUrl);

--- a/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/index.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/index.ts
@@ -1,8 +1,11 @@
 export {
+  ResubmitChallengeResponseSchema,
   StartChallengeResponseSchema,
   VerificationStatusResponseSchema,
+  type ResubmitChallengeResponse,
   type StartChallengeResponse,
   type VerificationStatusResponse
 } from './schema'
+export { useResubmitChallenge } from './useResubmitChallenge'
 export { useStartChallenge } from './useStartChallenge'
 export { useVerificationStatus } from './useVerificationStatus'

--- a/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/schema.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/schema.ts
@@ -11,10 +11,22 @@ export type StartChallengeResponse = z.infer<typeof StartChallengeResponseSchema
 
 // GET /api/id-proofing/status — polling endpoint for async verification (D3).
 // Backend receives Socure webhook results and exposes them here.
+// 'resubmit' is terminal at Socure but retry-eligible at the portal — the user can
+// open a fresh docv_stepup challenge via POST /api/challenges/:id/resubmit.
 export const VerificationStatusResponseSchema = z.object({
-  status: z.enum(['pending', 'verified', 'rejected']),
+  status: z.enum(['pending', 'verified', 'rejected', 'resubmit']),
   offboardingReason: z.string().nullish(),
   allowIdRetry: z.boolean().optional()
 })
 
 export type VerificationStatusResponse = z.infer<typeof VerificationStatusResponseSchema>
+
+// POST /api/challenges/:id/resubmit — opens a brand-new docv_stepup challenge after a
+// Socure RESUBMIT verdict. Returns the new challenge ID + DocV URL for re-capture.
+export const ResubmitChallengeResponseSchema = z.object({
+  challengeId: z.string().uuid(),
+  docvTransactionToken: z.string(),
+  docvUrl: z.string().url()
+})
+
+export type ResubmitChallengeResponse = z.infer<typeof ResubmitChallengeResponseSchema>

--- a/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/useResubmitChallenge.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/useResubmitChallenge.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { server } from '@/mocks/server'
+
+import { AuthProvider } from '../../context'
+import { useResubmitChallenge } from './useResubmitChallenge'
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
+}
+
+function createWrapper() {
+  const queryClient = createTestQueryClient()
+  function TestWrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>{children}</AuthProvider>
+      </QueryClientProvider>
+    )
+  }
+  return TestWrapper
+}
+
+describe('useResubmitChallenge', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('returns the new challengeId, docvUrl, and token on success', async () => {
+    const newId = '11111111-1111-4111-8111-111111111111'
+    server.use(
+      http.post('/api/challenges/:id/resubmit', () => {
+        return HttpResponse.json({
+          challengeId: newId,
+          docvTransactionToken: 'fresh-token',
+          docvUrl: 'https://verify.socure.com/#/dv/fresh-token'
+        })
+      })
+    )
+
+    const { result } = renderHook(() => useResubmitChallenge(), {
+      wrapper: createWrapper()
+    })
+
+    result.current.mutate('22222222-2222-4222-8222-222222222222')
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(result.current.data).toEqual({
+      challengeId: newId,
+      docvTransactionToken: 'fresh-token',
+      docvUrl: 'https://verify.socure.com/#/dv/fresh-token'
+    })
+  })
+
+  it('reports error on 409 (prior challenge not in Resubmit state)', async () => {
+    server.use(
+      http.post('/api/challenges/:id/resubmit', () => {
+        return HttpResponse.json(
+          { error: 'Challenge is in Pending state and cannot be resubmitted.' },
+          { status: 409 }
+        )
+      })
+    )
+
+    const { result } = renderHook(() => useResubmitChallenge(), {
+      wrapper: createWrapper()
+    })
+
+    result.current.mutate('any-id')
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+    })
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/useResubmitChallenge.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/doc-verify/useResubmitChallenge.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { ApiError, apiFetch } from '@/api'
+
+import { ResubmitChallengeResponseSchema, type ResubmitChallengeResponse } from './schema'
+
+const CHALLENGE_RESUBMIT_ENDPOINT = '/challenges'
+
+async function resubmitChallenge(challengeId: string): Promise<ResubmitChallengeResponse> {
+  return apiFetch<ResubmitChallengeResponse>(
+    `${CHALLENGE_RESUBMIT_ENDPOINT}/${challengeId}/resubmit`,
+    {
+      method: 'POST',
+      schema: ResubmitChallengeResponseSchema
+    }
+  )
+}
+
+/**
+ * Mutation that opens a fresh docv_stepup challenge after a Socure RESUBMIT verdict (DC-301).
+ * The prior challenge stays terminal (Resubmit); the response gives a brand-new challenge ID
+ * the caller should swap into the URL and start polling.
+ */
+export function useResubmitChallenge() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: resubmitChallenge,
+    onSuccess: async (_data, priorChallengeId) => {
+      // Stale verification status from the prior Resubmit challenge would otherwise flash
+      // the retry prompt again before the new challenge ID swaps in.
+      await queryClient.invalidateQueries({ queryKey: ['verificationStatus', priorChallengeId] })
+    },
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+        return false
+      }
+      return failureCount < 2
+    },
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000)
+  })
+}

--- a/src/SEBT.Portal.Web/src/features/auth/api/index.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/index.ts
@@ -1,10 +1,13 @@
 export { AuthorizationStatusResponseSchema, type AuthorizationStatusResponse } from './auth-status'
 
 export {
+  ResubmitChallengeResponseSchema,
   StartChallengeResponseSchema,
   VerificationStatusResponseSchema,
+  useResubmitChallenge,
   useStartChallenge,
   useVerificationStatus,
+  type ResubmitChallengeResponse,
   type StartChallengeResponse,
   type VerificationStatusResponse
 } from './doc-verify'

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
@@ -462,6 +462,70 @@ describe('DocVerifyPage', () => {
     })
   })
 
+  describe('Pending → resubmit branch (DC-301)', () => {
+    function mockWindowOpen() {
+      const popup = {
+        closed: false,
+        location: { href: '' },
+        close: vi.fn()
+      }
+      const spy = vi.spyOn(window, 'open').mockImplementation(() => popup as unknown as Window)
+      return { popup, spy }
+    }
+
+    it('renders the retry prompt when status returns resubmit', async () => {
+      setChallengeContext('challenge-abc', 'pending')
+
+      server.use(
+        http.get('/api/id-proofing/status', () => {
+          return HttpResponse.json({ status: 'resubmit' })
+        })
+      )
+
+      renderWithProviders(<DocVerifyPage contactLink={TEST_CONTACT_LINK} />)
+
+      expect(
+        await screen.findByRole('heading', { name: /let's try that again/i })
+      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /try again/i })).toBeEnabled()
+    })
+
+    it('opens a new tab and swaps to the new challenge ID when Try again is clicked', async () => {
+      setChallengeContext('challenge-abc', 'pending')
+
+      server.use(
+        http.get('/api/id-proofing/status', () => {
+          return HttpResponse.json({ status: 'resubmit' })
+        })
+      )
+
+      const { popup, spy } = mockWindowOpen()
+      const user = userEvent.setup()
+
+      renderWithProviders(<DocVerifyPage contactLink={TEST_CONTACT_LINK} />)
+
+      await user.click(await screen.findByRole('button', { name: /try again/i }))
+
+      expect(spy).toHaveBeenCalledWith('about:blank', '_blank')
+
+      await waitFor(() => {
+        expect(popup.location.href).toBe('https://verify.socure.com/#/dv/mock-resubmit-token')
+      })
+
+      // sessionStorage and URL both swap to the new challenge ID returned by the mutation
+      await waitFor(() => {
+        expect(sessionStorage.getItem('docVerify_challengeId')).toBe(
+          '99999999-9999-4999-8999-999999999999'
+        )
+      })
+      expect(mockReplace).toHaveBeenCalledWith(
+        '/login/id-proofing/doc-verify?challengeId=99999999-9999-4999-8999-999999999999'
+      )
+
+      spy.mockRestore()
+    })
+  })
+
   describe('Error handling', () => {
     it('shows error alert when challenge start fails', async () => {
       setChallengeContext('challenge-abc')

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
@@ -10,11 +10,18 @@ import { Alert } from '@sebt/design-system'
 import {
   clearChallengeContext,
   SK_CHALLENGE_ID,
+  SK_STILL_CHECKING,
   SK_SUB_STATE,
   SubState
 } from '@/features/auth/components/doc-verify/sessionKeys'
-import { useRefreshToken, useStartChallenge, useVerificationStatus } from '../../api'
+import {
+  useRefreshToken,
+  useResubmitChallenge,
+  useStartChallenge,
+  useVerificationStatus
+} from '../../api'
 import { DocVerifyInterstitial } from './DocVerifyInterstitial'
+import { DocVerifyResubmit } from './DocVerifyResubmit'
 import { VerificationPending } from './VerificationPending'
 
 interface DocVerifyPageProps {
@@ -46,6 +53,7 @@ export function DocVerifyPage({ contactLink }: DocVerifyPageProps) {
   const searchParams = useSearchParams()
   const { t } = useTranslation('idProofing')
   const startChallenge = useStartChallenge()
+  const resubmitChallenge = useResubmitChallenge()
   const refreshToken = useRefreshToken()
 
   const [subState, setSubState] = useState<SubState>('interstitial')
@@ -184,6 +192,48 @@ export function DocVerifyPage({ contactLink }: DocVerifyPageProps) {
     [router, setPageData, trackEvent]
   )
 
+  const handleEnterResubmit = useCallback(() => {
+    setSubState('resubmit')
+    setError(null)
+  }, [])
+
+  // "Try again" → open Socure's hosted retry URL in a new tab. Same user-gesture
+  // discipline as handleContinue: synchronous window.open so popup blockers honor
+  // the click. The mutation creates a brand-new docv_stepup challenge server-side
+  // and returns the new challenge's public ID; we swap that into URL, state, and
+  // sessionStorage so polling and reloads target the fresh challenge — not the
+  // old terminal Resubmit one (which would otherwise loop us right back here).
+  const handleResubmit = () => {
+    if (!challengeId) return
+    setError(null)
+    trackEvent(AnalyticsEvents.DOCV_RESUBMIT)
+
+    const captureTab = window.open('about:blank', '_blank')
+
+    resubmitChallenge
+      .mutateAsync(challengeId)
+      .then(({ challengeId: newChallengeId, docvUrl }) => {
+        if (captureTab && !captureTab.closed) {
+          captureTab.location.href = docvUrl
+        } else {
+          window.location.href = docvUrl
+        }
+        // Clear "still checking" so the new challenge's pending state starts fresh
+        sessionStorage.removeItem(SK_STILL_CHECKING)
+        sessionStorage.setItem(SK_CHALLENGE_ID, newChallengeId)
+        sessionStorage.setItem(SK_SUB_STATE, 'pending')
+        setChallengeId(newChallengeId)
+        setSubState('pending')
+        router.replace(`/login/id-proofing/doc-verify?challengeId=${newChallengeId}`)
+      })
+      .catch(() => {
+        if (captureTab && !captureTab.closed) captureTab.close()
+        setError(
+          t('docVerifyResubmitError', "We couldn't start a retry. Please try again in a moment.")
+        )
+      })
+  }
+
   return (
     <div className="usa-section">
       <div className="grid-container maxw-tablet">
@@ -212,6 +262,14 @@ export function DocVerifyPage({ contactLink }: DocVerifyPageProps) {
             challengeId={challengeId}
             onVerified={handleVerified}
             onRejected={handleRejected}
+            onResubmit={handleEnterResubmit}
+          />
+        )}
+
+        {subState === 'resubmit' && challengeId && (
+          <DocVerifyResubmit
+            onResubmit={handleResubmit}
+            isResubmitting={resubmitChallenge.isPending}
           />
         )}
       </div>

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyResubmit.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyResubmit.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DocVerifyResubmit } from './DocVerifyResubmit'
+
+describe('DocVerifyResubmit', () => {
+  it('renders a retry prompt heading and Try again CTA', () => {
+    render(
+      <DocVerifyResubmit
+        onResubmit={vi.fn()}
+        isResubmitting={false}
+      />
+    )
+
+    expect(screen.getByRole('heading')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /try again/i })).toBeEnabled()
+  })
+
+  it('calls onResubmit when the user clicks Try again', async () => {
+    const user = userEvent.setup()
+    const onResubmit = vi.fn()
+
+    render(
+      <DocVerifyResubmit
+        onResubmit={onResubmit}
+        isResubmitting={false}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /try again/i }))
+
+    expect(onResubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the Try again button while resubmitting', () => {
+    render(
+      <DocVerifyResubmit
+        onResubmit={vi.fn()}
+        isResubmitting
+      />
+    )
+
+    // When loading, the button label changes to the loadingText prop.
+    const button = screen.getByRole('button', { name: /starting retry/i })
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('shows an error alert when error prop is set', () => {
+    render(
+      <DocVerifyResubmit
+        onResubmit={vi.fn()}
+        isResubmitting={false}
+        error="Could not start a retry. Please try again."
+      />
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not start a retry/i)
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyResubmit.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyResubmit.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useTranslation } from 'react-i18next'
+
+import { Alert, Button } from '@sebt/design-system'
+
+interface DocVerifyResubmitProps {
+  onResubmit: () => void
+  isResubmitting: boolean
+  error?: string | null
+}
+
+// TODO: Use t('resubmit*') keys once they are available in dc.csv. The retry copy is a content
+// gap until Laura's reason-code mapping doc lands; ship with generic copy first and surface
+// reason-specific branches (blur, glare, unsupported ID) when the mapping is in.
+export function DocVerifyResubmit({ onResubmit, isResubmitting, error }: DocVerifyResubmitProps) {
+  const { t } = useTranslation('idProofing')
+
+  return (
+    <section aria-labelledby="doc-verify-resubmit-title">
+      {error && (
+        <Alert
+          variant="error"
+          slim
+          className="margin-bottom-2"
+        >
+          {error}
+        </Alert>
+      )}
+
+      <h1
+        id="doc-verify-resubmit-title"
+        className="font-sans-xl text-bold line-height-sans-1 margin-bottom-3"
+      >
+        {t('resubmitHeading', "Let's try that again")}
+      </h1>
+
+      <p className="font-sans-sm">
+        {t(
+          'resubmitBody',
+          "We weren't able to verify your identity from the document you uploaded. " +
+            'Make sure the image is clear, well-lit, and shows the full ID, then try again.'
+        )}
+      </p>
+
+      <div className="margin-top-3">
+        <Button
+          type="button"
+          onClick={onResubmit}
+          isLoading={isResubmitting}
+          loadingText={t('resubmitLoading', 'Starting retry...')}
+          disabled={isResubmitting}
+        >
+          {t('resubmitActionTryAgain', 'Try again')}
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyResubmit.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyResubmit.tsx
@@ -13,6 +13,11 @@ interface DocVerifyResubmitProps {
 // TODO: Use t('resubmit*') keys once they are available in dc.csv. The retry copy is a content
 // gap until Laura's reason-code mapping doc lands; ship with generic copy first and surface
 // reason-specific branches (blur, glare, unsupported ID) when the mapping is in.
+// TODO: Sandbox observation 2026-04-28 — Socure coerces a consent decline into the same
+// RESUBMIT verdict as a poor-quality capture, so this screen also greets users who actively
+// declined the DocV terms. The "we weren't able to verify your identity from the document
+// you uploaded" line is misleading in that case (they didn't upload anything). Confirm prod
+// behavior with Laura, then split copy by reason if consent-decline lands here in prod too.
 export function DocVerifyResubmit({ onResubmit, isResubmitting, error }: DocVerifyResubmitProps) {
   const { t } = useTranslation('idProofing')
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/VerificationPending.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/VerificationPending.tsx
@@ -16,12 +16,14 @@ interface VerificationPendingProps {
   challengeId: string
   onVerified: () => void
   onRejected: (offboardingReason?: string) => void
+  onResubmit: () => void
 }
 
 export function VerificationPending({
   challengeId,
   onVerified,
-  onRejected
+  onRejected,
+  onResubmit
 }: VerificationPendingProps) {
   const { t } = useTranslation('idProofing')
   // Persist "still checking" state across remounts so the UI doesn't oscillate
@@ -51,8 +53,10 @@ export function VerificationPending({
       onVerified()
     } else if (data?.status === 'rejected') {
       onRejected(data.offboardingReason ?? undefined)
+    } else if (data?.status === 'resubmit') {
+      onResubmit()
     }
-  }, [data?.status, data?.offboardingReason, onVerified, onRejected])
+  }, [data?.status, data?.offboardingReason, onVerified, onRejected, onResubmit])
 
   // Treat 404 as terminal — challenge doesn't exist for this user
   useEffect(() => {

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/sessionKeys.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/sessionKeys.ts
@@ -2,7 +2,7 @@ export const SK_CHALLENGE_ID = 'docVerify_challengeId'
 export const SK_SUB_STATE = 'docVerify_subState'
 export const SK_STILL_CHECKING = 'docv_still_checking'
 
-export type SubState = 'interstitial' | 'capture' | 'pending'
+export type SubState = 'interstitial' | 'capture' | 'pending' | 'resubmit'
 
 /** Remove all DocV session keys. Call before starting a new challenge flow. */
 export function clearChallengeContext(): void {

--- a/src/SEBT.Portal.Web/src/mocks/handlers.ts
+++ b/src/SEBT.Portal.Web/src/mocks/handlers.ts
@@ -313,6 +313,18 @@ export const handlers = [
     })
   }),
 
+  // Resubmit endpoint — opens a fresh docv_stepup challenge (DC-301).
+  // Returns a stable mock UUID so tests can assert on it.
+  http.post('/api/challenges/:id/resubmit', async () => {
+    await delay(50)
+
+    return HttpResponse.json({
+      challengeId: '99999999-9999-4999-8999-999999999999',
+      docvTransactionToken: 'mock-resubmit-token',
+      docvUrl: 'https://verify.socure.com/#/dv/mock-resubmit-token'
+    })
+  }),
+
   // Verification status endpoint — first call returns pending, subsequent returns verified.
   // Uses a closure counter to simulate async verification (D3).
   // allowIdRetry is included so the interstitial can show/hide the "Enter an ID number" button (D9).

--- a/test/SEBT.Portal.Tests/Unit/Models/DocVerificationChallengeTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Models/DocVerificationChallengeTests.cs
@@ -67,6 +67,20 @@ public class DocVerificationChallengeTests
         Assert.True(challenge.UpdatedAt >= beforeTransition);
     }
 
+    // Socure RESUBMIT terminates the workflow; the portal treats Resubmit as a terminal
+    // status from which a fresh challenge can be opened. See branch-context/DC-301/socure-validation.md.
+    [Fact]
+    public void TransitionTo_ShouldSucceed_WhenPendingToResubmit()
+    {
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+        var beforeTransition = DateTime.UtcNow;
+
+        challenge.TransitionTo(DocVerificationStatus.Resubmit);
+
+        Assert.Equal(DocVerificationStatus.Resubmit, challenge.Status);
+        Assert.True(challenge.UpdatedAt >= beforeTransition);
+    }
+
     // --- Invalid transitions from terminal states ---
 
     [Theory]
@@ -74,6 +88,7 @@ public class DocVerificationChallengeTests
     [InlineData(DocVerificationStatus.Pending)]
     [InlineData(DocVerificationStatus.Rejected)]
     [InlineData(DocVerificationStatus.Expired)]
+    [InlineData(DocVerificationStatus.Resubmit)]
     public void TransitionTo_ShouldThrow_WhenFromVerified(DocVerificationStatus target)
     {
         var challenge = DocVerificationChallengeFactory.CreateVerifiedChallenge();
@@ -88,6 +103,7 @@ public class DocVerificationChallengeTests
     [InlineData(DocVerificationStatus.Pending)]
     [InlineData(DocVerificationStatus.Verified)]
     [InlineData(DocVerificationStatus.Expired)]
+    [InlineData(DocVerificationStatus.Resubmit)]
     public void TransitionTo_ShouldThrow_WhenFromRejected(DocVerificationStatus target)
     {
         var challenge = DocVerificationChallengeFactory.CreateRejectedChallenge();
@@ -102,6 +118,7 @@ public class DocVerificationChallengeTests
     [InlineData(DocVerificationStatus.Pending)]
     [InlineData(DocVerificationStatus.Verified)]
     [InlineData(DocVerificationStatus.Rejected)]
+    [InlineData(DocVerificationStatus.Resubmit)]
     public void TransitionTo_ShouldThrow_WhenFromExpired(DocVerificationStatus target)
     {
         var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
@@ -110,6 +127,21 @@ public class DocVerificationChallengeTests
         var ex = Assert.Throws<InvalidOperationException>(
             () => challenge.TransitionTo(target));
         Assert.Contains("Cannot transition from Expired", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(DocVerificationStatus.Created)]
+    [InlineData(DocVerificationStatus.Pending)]
+    [InlineData(DocVerificationStatus.Verified)]
+    [InlineData(DocVerificationStatus.Rejected)]
+    [InlineData(DocVerificationStatus.Expired)]
+    public void TransitionTo_ShouldThrow_WhenFromResubmit(DocVerificationStatus target)
+    {
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => challenge.TransitionTo(target));
+        Assert.Contains("Cannot transition from Resubmit", ex.Message);
     }
 
     // --- Invalid transitions that skip Pending ---
@@ -134,6 +166,16 @@ public class DocVerificationChallengeTests
         Assert.Contains("Cannot transition from Created to Rejected", ex.Message);
     }
 
+    [Fact]
+    public void TransitionTo_ShouldThrow_WhenCreatedToResubmit()
+    {
+        var challenge = DocVerificationChallengeFactory.CreateChallenge();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => challenge.TransitionTo(DocVerificationStatus.Resubmit));
+        Assert.Contains("Cannot transition from Created to Resubmit", ex.Message);
+    }
+
     // --- IsTerminal property ---
 
     [Theory]
@@ -142,6 +184,7 @@ public class DocVerificationChallengeTests
     [InlineData(DocVerificationStatus.Verified, true)]
     [InlineData(DocVerificationStatus.Rejected, true)]
     [InlineData(DocVerificationStatus.Expired, true)]
+    [InlineData(DocVerificationStatus.Resubmit, true)]
     public void IsTerminal_ShouldReturnExpectedValue_ForEachStatus(
         DocVerificationStatus status, bool expected)
     {
@@ -221,6 +264,7 @@ public class DocVerificationChallengeTests
     [InlineData(DocVerificationStatus.Verified)]
     [InlineData(DocVerificationStatus.Rejected)]
     [InlineData(DocVerificationStatus.Expired)]
+    [InlineData(DocVerificationStatus.Resubmit)]
     public void TransitionTo_ShouldScrubProofingPii_WhenTransitioningToTerminalState(
         DocVerificationStatus terminalStatus)
     {

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/GetVerificationStatusQueryHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/GetVerificationStatusQueryHandlerTests.cs
@@ -110,6 +110,29 @@ public class GetVerificationStatusQueryHandlerTests
         Assert.Equal("docVerificationFailed", result.Value.OffboardingReason);
     }
 
+    // --- Resubmit status (DC-301: Socure RESUBMIT decision, retry-eligible at portal) ---
+
+    [Fact]
+    public async Task Handle_ShouldReturnResubmit_WhenChallengeIsResubmit()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var query = new GetVerificationStatusQuery
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(query.ChallengeId, query.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("resubmit", result.Value.Status);
+        Assert.Null(result.Value.OffboardingReason);
+    }
+
     // --- Check-on-read expiration (Codex test 7) ---
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ProcessWebhookCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ProcessWebhookCommandHandlerTests.cs
@@ -432,10 +432,10 @@ public class ProcessWebhookCommandHandlerTests
             .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
-    // --- Workflow RESUBMIT transitions to Rejected (DC-296: covers DocV decline case) ---
+    // --- Workflow RESUBMIT transitions to Resubmit (DC-301: terminal at Socure, retry-eligible at portal) ---
 
     [Fact]
-    public async Task HandleAsync_EvaluationCompleted_WorkflowResubmit_TransitionsToRejected()
+    public async Task HandleAsync_EvaluationCompleted_WorkflowResubmit_TransitionsToResubmit()
     {
         var handler = CreateHandler();
         var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
@@ -443,15 +443,14 @@ public class ProcessWebhookCommandHandlerTests
         challengeRepository.GetBySocureReferenceIdAsync("ref-456", Arg.Any<CancellationToken>())
             .Returns(challenge);
 
-        // Decline case: user declined on the Capture App, no DocV enrichment present
         var command = CreateValidCommand(workflowDecision: "RESUBMIT", documentDecision: null);
         var result = await handler.Handle(command, CancellationToken.None);
 
         Assert.True(result.IsSuccess);
         await challengeRepository.Received(1)
             .UpdateAsync(Arg.Is<DocVerificationChallenge>(c =>
-                c.Status == DocVerificationStatus.Rejected
-                && c.OffboardingReason == "docVerificationFailed"),
+                c.Status == DocVerificationStatus.Resubmit
+                && c.OffboardingReason == null),
                 Arg.Any<CancellationToken>());
         await userRepository.DidNotReceive()
             .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandlerTests.cs
@@ -1,0 +1,342 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Models.DocVerification;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Core.Repositories;
+using SEBT.Portal.Core.Services;
+using SEBT.Portal.Kernel;
+using SEBT.Portal.Kernel.Results;
+using SEBT.Portal.TestUtilities.Helpers;
+using SEBT.Portal.UseCases.IdProofing;
+
+namespace SEBT.Portal.Tests.Unit.UseCases.IdProofing.ResubmitChallenge;
+
+public class ResubmitChallengeCommandHandlerTests
+{
+    private readonly IDocVerificationChallengeRepository challengeRepository =
+        Substitute.For<IDocVerificationChallengeRepository>();
+    private readonly IUserRepository userRepository = Substitute.For<IUserRepository>();
+    private readonly IHouseholdRepository householdRepository = Substitute.For<IHouseholdRepository>();
+    private readonly ISocureClient socureClient = Substitute.For<ISocureClient>();
+    private readonly SocureSettings socureSettings = new()
+    {
+        DocvStepupWorkflow = "docv_stepup",
+        ChallengeExpirationMinutes = 30
+    };
+    private readonly IValidator<ResubmitChallengeCommand> validator =
+        new DataAnnotationsValidator<ResubmitChallengeCommand>(null!);
+    private readonly NullLogger<ResubmitChallengeCommandHandler> logger =
+        NullLogger<ResubmitChallengeCommandHandler>.Instance;
+
+    private ResubmitChallengeCommandHandler CreateHandler() => new(
+        challengeRepository, userRepository, householdRepository,
+        socureClient, socureSettings, validator, logger);
+
+    private static SocureDocvSession FreshSession() => new(
+        DocvTransactionToken: "new-token-" + Guid.NewGuid(),
+        DocvUrl: $"https://verify.socure.com/#/dv/new-token-{Guid.NewGuid()}",
+        ReferenceId: "new-ref-" + Guid.NewGuid(),
+        EvalId: "new-eval-" + Guid.NewGuid());
+
+    private void StubStepupSuccess(SocureDocvSession session)
+    {
+        socureClient.RunDocvStepupAssessmentAsync(
+                Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<Address?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.Success(
+                new IdProofingAssessmentResult(
+                    Outcome: IdProofingOutcome.DocumentVerificationRequired,
+                    AllowIdRetry: true,
+                    DocvSession: session)));
+    }
+
+    // --- IDOR prevention ---
+
+    [Fact]
+    public async Task Handle_ShouldReturnNotFound_WhenChallengeNotFoundForUser()
+    {
+        var handler = CreateHandler();
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = Guid.CreateVersion7(),
+            UserId = Guid.CreateVersion7()
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns((DocVerificationChallenge?)null);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var precondFailed = Assert.IsType<PreconditionFailedResult<ResubmitChallengeResponse>>(result);
+        Assert.Equal(PreconditionFailedReason.NotFound, precondFailed.Reason);
+
+        await socureClient.DidNotReceive().RunDocvStepupAssessmentAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<Address?>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // --- Wrong state guard: only Resubmit may resubmit ---
+
+    [Theory]
+    [InlineData(DocVerificationStatus.Created)]
+    [InlineData(DocVerificationStatus.Pending)]
+    [InlineData(DocVerificationStatus.Verified)]
+    [InlineData(DocVerificationStatus.Rejected)]
+    [InlineData(DocVerificationStatus.Expired)]
+    public async Task Handle_ShouldReturnConflict_WhenChallengeIsNotInResubmitState(
+        DocVerificationStatus status)
+    {
+        var handler = CreateHandler();
+        var challenge = status switch
+        {
+            DocVerificationStatus.Created => DocVerificationChallengeFactory.CreateChallenge(),
+            DocVerificationStatus.Pending => DocVerificationChallengeFactory.CreatePendingChallenge(),
+            DocVerificationStatus.Verified => DocVerificationChallengeFactory.CreateVerifiedChallenge(),
+            DocVerificationStatus.Rejected => DocVerificationChallengeFactory.CreateRejectedChallenge(),
+            DocVerificationStatus.Expired => CreateExpiredChallenge(),
+            _ => throw new ArgumentOutOfRangeException(nameof(status))
+        };
+
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var precondFailed = Assert.IsType<PreconditionFailedResult<ResubmitChallengeResponse>>(result);
+        Assert.Equal(PreconditionFailedReason.Conflict, precondFailed.Reason);
+
+        await socureClient.DidNotReceive().RunDocvStepupAssessmentAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<Address?>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+        await challengeRepository.DidNotReceive()
+            .CreateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- User must exist and have an email ---
+
+    [Fact]
+    public async Task Handle_ShouldReturnNotFound_WhenUserMissing()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var precondFailed = Assert.IsType<PreconditionFailedResult<ResubmitChallengeResponse>>(result);
+        Assert.Equal(PreconditionFailedReason.NotFound, precondFailed.Reason);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnConflict_WhenUserHasNoEmail()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = null });
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var precondFailed = Assert.IsType<PreconditionFailedResult<ResubmitChallengeResponse>>(result);
+        Assert.Equal(PreconditionFailedReason.Conflict, precondFailed.Reason);
+    }
+
+    // --- Socure dependency failures propagate ---
+
+    [Fact]
+    public async Task Handle_ShouldReturnDependencyFailed_WhenSocureCallFails()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "user@example.com" });
+        socureClient.RunDocvStepupAssessmentAsync(
+                Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<Address?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.DependencyFailed(
+                DependencyFailedReason.ConnectionFailed, "Socure unreachable"));
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.IsType<DependencyFailedResult<ResubmitChallengeResponse>>(result);
+        await challengeRepository.DidNotReceive()
+            .CreateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnConflict_WhenSocureReturnsUnexpectedOutcome()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "user@example.com" });
+        // Socure says Matched (no DocV needed) — unexpected for a step-up call
+        socureClient.RunDocvStepupAssessmentAsync(
+                Arg.Any<Guid>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                Arg.Any<Address?>(), Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Result<IdProofingAssessmentResult>.Success(
+                new IdProofingAssessmentResult(
+                    Outcome: IdProofingOutcome.Matched,
+                    AllowIdRetry: true,
+                    DocvSession: null)));
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        var precondFailed = Assert.IsType<PreconditionFailedResult<ResubmitChallengeResponse>>(result);
+        Assert.Equal(PreconditionFailedReason.Conflict, precondFailed.Reason);
+        await challengeRepository.DidNotReceive()
+            .CreateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Happy path: a fresh challenge is created in Pending and the prior one stays Resubmit ---
+
+    [Fact]
+    public async Task Handle_ShouldCreateFreshChallenge_AndLeaveResubmitChallengeUntouched()
+    {
+        var handler = CreateHandler();
+        var priorChallenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var priorReferenceId = priorChallenge.SocureReferenceId;
+        var priorEvalId = priorChallenge.EvalId;
+        var priorPublicId = priorChallenge.PublicId;
+        var session = FreshSession();
+
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = priorChallenge.PublicId,
+            UserId = priorChallenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(priorChallenge);
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "user@example.com" });
+        StubStepupSuccess(session);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var response = result.Value;
+        Assert.NotEqual(priorPublicId, response.ChallengeId);
+        Assert.Equal(session.DocvUrl, response.DocvUrl);
+        Assert.Equal(session.DocvTransactionToken, response.DocvTransactionToken);
+
+        // A new challenge row was persisted in Pending state with the fresh session
+        await challengeRepository.Received(1).CreateAsync(
+            Arg.Is<DocVerificationChallenge>(c =>
+                c.UserId == command.UserId
+                && c.Status == DocVerificationStatus.Pending
+                && c.SocureReferenceId == session.ReferenceId
+                && c.EvalId == session.EvalId
+                && c.DocvTransactionToken == session.DocvTransactionToken
+                && c.DocvUrl == session.DocvUrl
+                && c.DocvTokenIssuedAt != null
+                && c.ExpiresAt != null),
+            Arg.Any<CancellationToken>());
+
+        // Prior Resubmit challenge is untouched — terminal stays terminal
+        Assert.Equal(DocVerificationStatus.Resubmit, priorChallenge.Status);
+        Assert.Equal(priorReferenceId, priorChallenge.SocureReferenceId);
+        Assert.Equal(priorEvalId, priorChallenge.EvalId);
+        await challengeRepository.DidNotReceive()
+            .UpdateAsync(Arg.Any<DocVerificationChallenge>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ShouldDelegateToSocureWithDocvStepupWorkflow()
+    {
+        var handler = CreateHandler();
+        var challenge = DocVerificationChallengeFactory.CreateResubmitChallenge();
+        var session = FreshSession();
+        var command = new ResubmitChallengeCommand
+        {
+            ChallengeId = challenge.PublicId,
+            UserId = challenge.UserId
+        };
+
+        challengeRepository.GetByPublicIdAsync(command.ChallengeId, command.UserId, Arg.Any<CancellationToken>())
+            .Returns(challenge);
+        userRepository.GetUserByIdAsync(command.UserId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = command.UserId, Email = "user@example.com" });
+        StubStepupSuccess(session);
+
+        await handler.Handle(command, CancellationToken.None);
+
+        // Resubmit must go through the dedicated step-up entry point — never through the
+        // regular consumer_onboarding path, which can itself produce another RESUBMIT.
+        await socureClient.Received(1).RunDocvStepupAssessmentAsync(
+            command.UserId,
+            "user@example.com",
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<Address?>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+        await socureClient.DidNotReceive().RunIdProofingAssessmentAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<Address?>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static DocVerificationChallenge CreateExpiredChallenge()
+    {
+        var challenge = DocVerificationChallengeFactory.CreatePendingChallenge();
+        challenge.TransitionTo(DocVerificationStatus.Expired);
+        return challenge;
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-301](https://codeforamerica.atlassian.net/browse/DC-301)

#### ✍️ Description
When Socure returns a `RESUBMIT` decision on DocV, the user now lands on a "Let's try that again" prompt instead of being offboarded. Clicking "Try again" calls a new `POST /api/challenges/{id}/resubmit` endpoint that opens a fresh `docv_stepup` Socure evaluation, swaps the URL to the new challenge ID, and resumes polling. Supersedes the DC-296 stopgap that mapped `RESUBMIT` to `Rejected`.

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

> Adds one appsetting: `Socure:DocvStepupWorkflow` (defaults to `"docv_stepup"`, documented in `appsettings.dc.example.json`). AppConfig update still pending.

---

## Triage analysis

- **Branch:** `feat/DC-301-socure-docv-resubmit` -> `main` (5 commits)
- **Risk Level:** Medium

The two units that warrant the closest read are `ResubmitChallengeCommandHandler` (new use case that issues a Socure evaluation and persists a new challenge — IDOR + state-machine surface) and the `DocVerifyPage` resubmit substate (synchronous popup + URL/sessionStorage swap to retarget polling). Everything else is straightforward additive change behind tests.

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs` | `Handle` | High | Med | Med | IDOR check, new Socure round-trip |
| 🟡 | `src/SEBT.Portal.Web/.../doc-verify/DocVerifyPage.tsx` | `handleResubmit`, `handleEnterResubmit` | Med | Med | Med | popup + URL/sessionStorage swap |
| 🟡 | `src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs` | `RunDocvStepupAssessmentAsync`, `RunEvaluationAsync` | Med | Med | Low | extracted shared path, new workflow override |
| 🟡 | `src/SEBT.Portal.Core/Models/DocVerification/DocVerificationChallenge.cs` | `IsValidTransition`, `IsTerminal` | Med | Low | Low | new terminal state w/ PII scrub |
| 🟡 | `src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs` | `MapWorkflowDecisionToStatus` | Med | Low | Low | RESUBMIT remapped from Rejected |
| 🟡 | `src/SEBT.Portal.Api/Controllers/IdProofing/ChallengesController.cs` | `Resubmit` | Med | Low | Low | new authenticated POST endpoint |
| 🟢 | `src/SEBT.Portal.Core/Models/DocVerification/DocVerificationStatus.cs` | `Resubmit = 5` | Low | Low | Low | enum addition |
| 🟢 | `src/SEBT.Portal.Core/AppSettings/SocureSettings.cs` | `DocvStepupWorkflow` | Low | Low | Low | new appsetting w/ default |
| 🟢 | `src/SEBT.Portal.Api/appsettings.dc.example.json` | `DocvStepupWorkflow` | Low | Low | Low | example doc only |
| 🟢 | `src/SEBT.Portal.Core/Services/ISocureClient.cs` | `RunDocvStepupAssessmentAsync` | Low | Low | Low | interface addition |
| 🟢 | `src/SEBT.Portal.Infrastructure/Services/StubSocureClient.cs`, `DisabledSocureClient.cs` | impl | Low | Low | Low | mirror impls |
| 🟢 | `src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommand.cs`, `ResubmitChallengeResponse.cs` | DTOs | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.UseCases/IdProofing/GetVerificationStatus/GetVerificationStatusQueryHandler.cs` | mapping | Low | Low | Low | adds `'resubmit'` string |
| 🟢 | `src/SEBT.Portal.UseCases/Dependencies.cs` | DI | Low | Low | Low | handler registration |
| 🟢 | `src/SEBT.Portal.Web/.../doc-verify/DocVerifyResubmit.tsx` | component | Low | Low | Low | presentational + 2 inline TODOs (i18n keys, consent-decline copy nuance) |
| 🟢 | `src/SEBT.Portal.Web/.../doc-verify/VerificationPending.tsx` | `onResubmit` prop | Low | Low | Low | new optional prop |
| 🟢 | `src/SEBT.Portal.Web/.../doc-verify/sessionKeys.ts` | `SubState` union | Low | Low | Low | adds `'resubmit'` |
| 🟢 | `src/SEBT.Portal.Web/.../auth/api/doc-verify/{schema,index,useResubmitChallenge}.ts` | hook + zod | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.Web/src/mocks/handlers.ts` | mock | Low | Low | Low | MSW handler |
| 🟢 | `packages/analytics/src/events.ts` | `DOCV_RESUBMIT` | Low | Low | Low | new event constant |
| 🟢 | `src/SEBT.Portal.TestUtilities/Helpers/DocVerificationChallengeFactory.cs` | `CreateResubmitChallenge` | Low | Low | Low | factory helper |
| 🟢 | `test/SEBT.Portal.Tests/.../*.cs`, `**/*.test.tsx` | tests | Low | Low | Low | unit + component coverage |

### High-priority focus

1. **`ResubmitChallengeCommandHandler.Handle`** — confirm: prior challenge is loaded scoped to `userId` (IDOR-safe); it asserts state is exactly `Resubmit` before proceeding; the new challenge is persisted in `Pending` only after the Socure call returns; the prior challenge is left untouched (still `Resubmit`, terminal).
2. **`DocVerifyPage` resubmit substate** — popup opens synchronously inside the click handler (preserves user-gesture so it isn't blocked); on success, URL `challengeId` query param, sessionStorage key, and component state all swap to the new challenge before polling resumes; old challenge ID does not leak into the new polling loop.
3. **PII scrub on `Resubmit` transition** — `DocVerificationChallenge.IsTerminal` includes `Resubmit`, so `TransitionTo` clears `ProofingDateOfBirth` and `ProofingIdValue` (verified at runtime). Confirm no other PII column was forgotten.
4. **`HttpSocureClient.RunEvaluationAsync` extraction** — both id-proofing and docv-stepup paths share the same private method; verify the extraction did not change the wire payload for the original `RunIdProofingAssessmentAsync` call.
5. **Webhook re-mapping** — `MapWorkflowDecisionToStatus(RESUBMIT)` now returns `Resubmit`. Confirm the existing offboarding-reason write only fires on `Rejected`, so no stray offboarding row is written for resubmit transitions.

### Review Recommendation

Start with `ResubmitChallengeCommandHandler` and its tests (`ResubmitChallengeCommandHandlerTests` covers IDOR / wrong-state / Socure-failure / happy-path). Then the FE `DocVerifyPage` substate diff. Skim everything else — most green rows are interface/DI/DTO additions with mirrored stub/disabled implementations.


[DC-301]: https://codeforamerica.atlassian.net/browse/DC-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ