### PR TITLE
Add verbose logging around IdProofingRequirements configuration

### DIFF
--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -70,6 +70,7 @@ builder.Services.AddHttpClient();
 var state = Environment.GetEnvironmentVariable("STATE");
 if (!string.IsNullOrEmpty(state))
 {
+    Log.Logger.Information("Loading state-specific config: {State}", state);
     var stateConfigFile = $"appsettings.{state.ToLowerInvariant()}.json";
     builder.Configuration.AddJsonFile(stateConfigFile, optional: true, reloadOnChange: true);
 }

--- a/src/SEBT.Portal.Core/AppSettings/IalRequirement.cs
+++ b/src/SEBT.Portal.Core/AppSettings/IalRequirement.cs
@@ -61,6 +61,19 @@ public class IalRequirement
         return _perCaseType?.Values ?? Enumerable.Empty<IalLevel>();
     }
 
+    public override string ToString()
+    {
+        if (_uniform.HasValue)
+        {
+            return _uniform.Value.ToString();
+        }
+        else if (_perCaseType is not null)
+        {
+            return $"[{string.Join(',', _perCaseType.Select(kvp => $"{kvp.Key}:{kvp.Value}"))}]";
+        }
+        return "unknown";
+    }
+
     // Case-type key lookup is case-insensitive when the dictionary is created with
     // StringComparer.OrdinalIgnoreCase (see ConfigureIdProofingRequirements).
     // If a case type is not in the dictionary, fail-closed to IAL1plus.

--- a/src/SEBT.Portal.Core/AppSettings/IdProofingRequirementsSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/IdProofingRequirementsSettings.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using SEBT.Portal.Core.Models.Auth;
 
 namespace SEBT.Portal.Core.AppSettings;
@@ -32,5 +33,20 @@ public class IdProofingRequirementsSettings
     public IalRequirement Get(ProtectedResource resource, ProtectedAction action)
     {
         return Get(IdProofingKeys.ToConfigKey(resource, action));
+    }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("[");
+
+        foreach (var kvp in Requirements)
+        {
+            sb.AppendLine($"    {kvp.Key}: {kvp.Value},");
+        }
+
+        sb.AppendLine("]");
+
+        return sb.ToString();
     }
 }

--- a/src/SEBT.Portal.Infrastructure/Configuration/ConfigureIdProofingRequirements.cs
+++ b/src/SEBT.Portal.Infrastructure/Configuration/ConfigureIdProofingRequirements.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,8 +34,10 @@ public class ConfigureIdProofingRequirements(
                 continue;
             }
 
-            if (child.Value is not null)
+            if (child.Value is not null && !child.GetChildren().Any())
             {
+                logger.LogInformation("IdProofingRequirements Child - {Key}: {Value}", child.Key, child.Value);
+
                 // Simple form: "address+view": "IAL1plus"
                 if (!Enum.TryParse<IalLevel>(child.Value, ignoreCase: true, out var level))
                 {
@@ -74,7 +77,11 @@ public class ConfigureIdProofingRequirements(
                 {
                     options.Requirements[child.Key] = IalRequirement.PerCaseType(perCase);
                 }
+
+                logger.LogInformation("IdProofingRequirements Child - {Key}: {Values}", child.Key, perCase);
             }
         }
+
+        logger.LogInformation("IdProofingRequirements: {IdProofingRequirements}", options.ToString());
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
N/A

#### ✍️ Description
Adds verbose logging around IdProofingRequirements config load to diagnose issue in CO test environment and [fixes a subtle bug](https://github.com/codeforamerica/sebt-self-service-portal/pull/228/changes#diff-53e1121a03f90893cff05476495f433d148fb1d10a3bf2dd78db6cd7ab89b9bcR37) that affects complex object config (for DC).

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
