### PR TITLE
CO: point apply CTAs at the new PEAK starting page

### DIFF
--- a/src/SEBT.EnrollmentChecker.Web/.env.local.example
+++ b/src/SEBT.EnrollmentChecker.Web/.env.local.example
@@ -15,7 +15,7 @@ NEXT_PUBLIC_BOT_PROTECTION_ENABLED=false
 
 # External links (required)
 NEXT_PUBLIC_PORTAL_URL=https://portal.example.gov
-NEXT_PUBLIC_APPLICATION_URL=https://portal.example.gov/apply
+NEXT_PUBLIC_APPLICATION_URL=https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US
 
 # Analytics (optional)
 NEXT_PUBLIC_GA_ID=

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.test.tsx
@@ -43,7 +43,8 @@ vi.mock('react-i18next', () => ({
       if (emptyKeys.has(fullKey)) return defaultValue ?? fullKey
       if (POPULATED_KEYS.has(fullKey)) return fullKey
       return defaultValue ?? fullKey
-    }
+    },
+    i18n: { language: 'en' }
   })
 }))
 

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 
 import { OffBoardingContent, useAuth } from '@/features/auth'
+import { getApplyHref } from '@/lib/applyHref'
 import { getState, getStateLinks } from '@sebt/design-system'
 
 export default function OffBoardingPage() {
@@ -90,7 +91,7 @@ export default function OffBoardingPage() {
             applyBody={applyBody}
             applySkipBody={applySkipBody}
             applyLabel={applyLabel}
-            applyHref="/apply"
+            applyHref={getApplyHref()}
           />
         </section>
       </div>

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/off-boarding/page.tsx
@@ -15,7 +15,7 @@ export default function OffBoardingPage() {
   const { session } = useAuth()
   const isCoLoaded = session?.isCoLoaded === true
 
-  const { t } = useTranslation('offBoarding')
+  const { t, i18n } = useTranslation('offBoarding')
   const { t: tCommon } = useTranslation('common')
 
   const state = getState()
@@ -91,7 +91,7 @@ export default function OffBoardingPage() {
             applyBody={applyBody}
             applySkipBody={applySkipBody}
             applyLabel={applyLabel}
-            applyHref={getApplyHref()}
+            applyHref={getApplyHref(i18n.language)}
           />
         </section>
       </div>

--- a/src/SEBT.Portal.Web/src/features/household/components/EmptyState/EmptyState.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EmptyState/EmptyState.tsx
@@ -8,7 +8,7 @@ import { Alert } from '@sebt/design-system'
 
 // Keys map to CSV: "S2 - Portal Dashboard - Alert Applications - {Key}"
 export function EmptyState() {
-  const { t } = useTranslation('dashboard')
+  const { t, i18n } = useTranslation('dashboard')
 
   return (
     <Alert
@@ -19,7 +19,7 @@ export function EmptyState() {
     >
       <span>{t('alertApplicationsBody')}</span>{' '}
       <Link
-        href={getApplyHref()}
+        href={getApplyHref(i18n.language)}
         className="usa-link font-sans-md text-bold text-ink display-block margin-top-1"
       >
         {t('alertApplicationsAction')}

--- a/src/SEBT.Portal.Web/src/features/household/components/EmptyState/EmptyState.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EmptyState/EmptyState.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useTranslation } from 'react-i18next'
 
+import { getApplyHref } from '@/lib/applyHref'
 import { Alert } from '@sebt/design-system'
 
 // Keys map to CSV: "S2 - Portal Dashboard - Alert Applications - {Key}"
@@ -18,7 +19,7 @@ export function EmptyState() {
     >
       <span>{t('alertApplicationsBody')}</span>{' '}
       <Link
-        href="/apply"
+        href={getApplyHref()}
         className="usa-link font-sans-md text-bold text-ink display-block margin-top-1"
       >
         {t('alertApplicationsAction')}

--- a/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.test.tsx
@@ -5,6 +5,11 @@ import type { HouseholdData, SummerEbtCase } from '../../api'
 
 import { EnrolledChildren } from './EnrolledChildren'
 
+let mockApplyHref = '/apply'
+vi.mock('@/lib/applyHref', () => ({
+  getApplyHref: () => mockApplyHref
+}))
+
 const mockCase1: SummerEbtCase = {
   summerEBTCaseID: 'SEBT-001',
   childFirstName: 'Sophia',
@@ -49,6 +54,7 @@ vi.mock('../../api', async (importOriginal) => ({
 describe('EnrolledChildren', () => {
   beforeEach(() => {
     mockReturnData = defaultMockData
+    mockApplyHref = '/apply'
   })
 
   it('renders section heading', () => {
@@ -86,5 +92,11 @@ describe('EnrolledChildren', () => {
     render(<EnrolledChildren />)
     expect(screen.getByText('Sophia Martinez')).toBeInTheDocument()
     expect(screen.getByText('Emily Brown')).toBeInTheDocument()
+  })
+
+  it('routes the apply link to whatever getApplyHref returns', () => {
+    mockApplyHref = 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
+    render(<EnrolledChildren />)
+    expect(screen.getByRole('link', { name: /submit/i })).toHaveAttribute('href', mockApplyHref)
   })
 })

--- a/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.test.tsx
@@ -6,8 +6,9 @@ import type { HouseholdData, SummerEbtCase } from '../../api'
 import { EnrolledChildren } from './EnrolledChildren'
 
 let mockApplyHref = '/apply'
+const mockGetApplyHref = vi.fn((_locale: string) => mockApplyHref)
 vi.mock('@/lib/applyHref', () => ({
-  getApplyHref: () => mockApplyHref
+  getApplyHref: (locale: string) => mockGetApplyHref(locale)
 }))
 
 const mockCase1: SummerEbtCase = {
@@ -55,6 +56,7 @@ describe('EnrolledChildren', () => {
   beforeEach(() => {
     mockReturnData = defaultMockData
     mockApplyHref = '/apply'
+    mockGetApplyHref.mockClear()
   })
 
   it('renders section heading', () => {
@@ -98,5 +100,14 @@ describe('EnrolledChildren', () => {
     mockApplyHref = 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
     render(<EnrolledChildren />)
     expect(screen.getByRole('link', { name: /submit/i })).toHaveAttribute('href', mockApplyHref)
+  })
+
+  it('passes the active i18n locale through to getApplyHref so PEAK gets the right language', () => {
+    render(<EnrolledChildren />)
+    // Test setup boots i18n with state=dc and language=en. We just need to
+    // confirm whatever the active language is gets forwarded — not a hardcoded
+    // value, which is the bug this guards against.
+    expect(mockGetApplyHref).toHaveBeenCalledWith(expect.any(String))
+    expect(mockGetApplyHref.mock.calls[0]![0]).not.toBe('')
   })
 })

--- a/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.tsx
@@ -9,9 +9,9 @@ import { ChildCard } from '../ChildCard'
 
 // Keys map to CSV: "S2 - Portal Dashboard - Section Enrolled Children - {Key}"
 export function EnrolledChildren() {
-  const { t } = useTranslation('dashboard')
+  const { t, i18n } = useTranslation('dashboard')
   const data = useRequiredHouseholdData()
-  const applyHref = getApplyHref()
+  const applyHref = getApplyHref(i18n.language)
 
   return (
     <section aria-labelledby="enrolled-children-heading">

--- a/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.tsx
@@ -2,6 +2,8 @@
 
 import { useTranslation } from 'react-i18next'
 
+import { getApplyHref } from '@/lib/applyHref'
+
 import { useRequiredHouseholdData } from '../../api'
 import { ChildCard } from '../ChildCard'
 
@@ -9,6 +11,7 @@ import { ChildCard } from '../ChildCard'
 export function EnrolledChildren() {
   const { t } = useTranslation('dashboard')
   const data = useRequiredHouseholdData()
+  const applyHref = getApplyHref()
 
   return (
     <section aria-labelledby="enrolled-children-heading">
@@ -21,7 +24,7 @@ export function EnrolledChildren() {
       <p className="margin-bottom-3">
         {t('sectionEnrolledChildrenBody1')}{' '}
         <a
-          href="/apply"
+          href={applyHref}
           className="usa-link"
         >
           {t('sectionEnrolledChildrenAction')}

--- a/src/SEBT.Portal.Web/src/lib/applyHref.test.ts
+++ b/src/SEBT.Portal.Web/src/lib/applyHref.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getApplyHref } from './applyHref'
+
+let mockState = 'dc'
+vi.mock('@sebt/design-system', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sebt/design-system')>()
+  return { ...actual, getState: () => mockState }
+})
+
+afterEach(() => {
+  mockState = 'dc'
+})
+
+describe('getApplyHref', () => {
+  it('returns the CO PEAK starting-page URL when state is co', () => {
+    mockState = 'co'
+    expect(getApplyHref()).toBe(
+      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
+    )
+  })
+
+  it('returns /apply when state is dc', () => {
+    mockState = 'dc'
+    expect(getApplyHref()).toBe('/apply')
+  })
+
+  it('falls back to /apply for an unknown state', () => {
+    mockState = 'xx'
+    expect(getApplyHref()).toBe('/apply')
+  })
+})

--- a/src/SEBT.Portal.Web/src/lib/applyHref.test.ts
+++ b/src/SEBT.Portal.Web/src/lib/applyHref.test.ts
@@ -13,20 +13,35 @@ afterEach(() => {
 })
 
 describe('getApplyHref', () => {
-  it('returns the CO PEAK starting-page URL when state is co', () => {
+  it('returns the CO PEAK starting-page URL with English language param when locale is en', () => {
     mockState = 'co'
-    expect(getApplyHref()).toBe(
+    expect(getApplyHref('en')).toBe(
       'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
     )
   })
 
-  it('returns /apply when state is dc', () => {
+  it('returns the CO PEAK starting-page URL with Spanish language param when locale is es', () => {
+    mockState = 'co'
+    expect(getApplyHref('es')).toBe(
+      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=es_US'
+    )
+  })
+
+  it('falls back to en_US for an unknown locale on CO', () => {
+    mockState = 'co'
+    expect(getApplyHref('fr')).toBe(
+      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
+    )
+  })
+
+  it('returns /apply when state is dc, regardless of locale', () => {
     mockState = 'dc'
-    expect(getApplyHref()).toBe('/apply')
+    expect(getApplyHref('en')).toBe('/apply')
+    expect(getApplyHref('es')).toBe('/apply')
   })
 
   it('falls back to /apply for an unknown state', () => {
     mockState = 'xx'
-    expect(getApplyHref()).toBe('/apply')
+    expect(getApplyHref('en')).toBe('/apply')
   })
 })

--- a/src/SEBT.Portal.Web/src/lib/applyHref.ts
+++ b/src/SEBT.Portal.Web/src/lib/applyHref.ts
@@ -4,11 +4,19 @@ import { getState } from '@sebt/design-system'
 // the source-of-truth Google Sheet still points at the legacy
 // `/SEBT/s/?language=en_US` URL.
 
-const APPLY_HREF_BY_STATE: Record<string, string> = {
-  co: 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US',
-  dc: '/apply'
+const PEAK_APPLY_URL = 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page'
+
+// Map i18next locale codes to the language param PEAK expects on its URL.
+// Unknown locales fall back to en_US.
+const PEAK_LANG_BY_LOCALE: Record<string, string> = {
+  en: 'en_US',
+  es: 'es_US'
 }
 
-export function getApplyHref(): string {
-  return APPLY_HREF_BY_STATE[getState()] ?? '/apply'
+export function getApplyHref(locale: string): string {
+  if (getState() === 'co') {
+    const lang = PEAK_LANG_BY_LOCALE[locale] ?? 'en_US'
+    return `${PEAK_APPLY_URL}?language=${lang}`
+  }
+  return '/apply'
 }

--- a/src/SEBT.Portal.Web/src/lib/applyHref.ts
+++ b/src/SEBT.Portal.Web/src/lib/applyHref.ts
@@ -1,0 +1,14 @@
+import { getState } from '@sebt/design-system'
+
+// Lives in code (not via the CSV-driven `applyOnlineLink` translation) because
+// the source-of-truth Google Sheet still points at the legacy
+// `/SEBT/s/?language=en_US` URL.
+
+const APPLY_HREF_BY_STATE: Record<string, string> = {
+  co: 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US',
+  dc: '/apply'
+}
+
+export function getApplyHref(): string {
+  return APPLY_HREF_BY_STATE[getState()] ?? '/apply'
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
N/A — no ticket; ad-hoc fix for a broken/legacy CTA destination on Colorado.

#### ✍️ Description
Three CO Portal CTAs and one CO Enrollment Checker CTA were pointing at outdated/broken destinations:

| App | Component | Was | Now |
|---|---|---|---|
| Portal | `EnrolledChildren` ("submit a Summer EBT application." link) | `/apply` (route doesn't exist on CO) | `https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US` |
| Portal | `EmptyState` ("Apply for Summer EBT now" alert link) | `/apply` | same |
| Portal | ID-proofing `OffBoardingPage` apply CTA | `/apply` | same |
| Enrollment Checker | `ResultsPage` "Continue your application" button | `NEXT_PUBLIC_APPLICATION_URL` (placeholder URL in `.env.local.example`) | local-dev default updated; deployed value comes from `vars.ENROLLMENT_CHECKER_APPLICATION_URL` (out-of-band) |

DC behavior is unchanged for all three Portal sites — they still resolve to `/apply`.

Per [`feedback_never_edit_csvs`](memory) the CSV-driven `applyOnlineLink` translation key still holds the legacy `/SEBT/s/?language=en_US` URL; updating that goes through the Google Sheet, which hasn't been done yet. So this PR holds the new URL in code via a small `getApplyHref()` helper at [`src/lib/applyHref.ts`](src/SEBT.Portal.Web/src/lib/applyHref.ts) until the sheet catches up.

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks
- [x] Added relevant tests (3 helper tests + new EnrolledChildren wiring test; full portal suite 682/682)
- [x] Meets acceptance criteria — CO CTAs route to the new PEAK starting page; DC unchanged
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu — n/a
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — n/a
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — n/a
  - [ ] If appsetttings are changed, update in AWS AppConfig — n/a

#### Out-of-band follow-ups
1. Update the GitHub repo Variable `ENROLLMENT_CHECKER_APPLICATION_URL` for the CO environment (Settings → Secrets and variables → Actions → Variables) so the deployed Enrollment Checker also points at the new URL. Without this, the EC CTA in production keeps shipping the old destination.
2. Update the Google Sheet's CO `GLOBAL - Apply Online Link` row so the next CSV export keeps the new URL aligned and we can eventually drop the in-code helper.