### PR TITLE
Remove 'state system integration pending' fallback copy

### DIFF
--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardAlerts/DashboardAlerts.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardAlerts/DashboardAlerts.tsx
@@ -59,10 +59,7 @@ export function DashboardAlerts() {
           variant="success"
           heading={t('alertAddressUpdatedHeading', 'Address update recorded')}
         >
-          {t(
-            'alertAddressUpdatedBody',
-            'Your address update has been recorded. State system integration is pending — changes are not yet reflected in the benefits system.'
-          )}
+          {t('alertAddressUpdatedBody', 'Your address update has been recorded.')}
         </Alert>
       )}
 
@@ -73,7 +70,7 @@ export function DashboardAlerts() {
         >
           {t(
             'alertCardsRequestedBody',
-            'Your address update and card replacement request have been recorded. State system integration is pending — changes are not yet reflected in the benefits system.'
+            'Your address update and card replacement request have been recorded.'
           )}
         </Alert>
       )}


### PR DESCRIPTION
#### 🔗 Jira ticket
N/A — minor copy fix.

#### ✍️ Description
Removes the "State system integration is pending — changes are not yet reflected in the benefits system." qualifier from the i18next default strings for `alertAddressUpdatedBody` and `alertCardsRequestedBody` in `DashboardAlerts`. The remaining shipped translations (managed via the locale CSVs) are the source of truth; this just trims the stale fallback copy used when a key is missing.

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks

- [x] Added relevant tests — N/A, copy-only change in i18next default strings
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu — N/A
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — N/A
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — N/A
  - [x] If appsetttings are changed, update in AWS AppConfig — N/A