### PR TITLE
DC-340: re-wire DcSource now that seed task works

### DIFF
--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -108,6 +108,7 @@ module "app" {
 
   seeding_enabled       = "true"
   seeding_email_pattern = "sebt.dc+{0}@codeforamerica.org"
+  dc_source_db_name     = "DcSource"
 
   state_api_environment_variables = {
     "IdProofingRequirements__household+view__application"        = "IAL1"


### PR DESCRIPTION
#### 🔗 Jira ticket
DC-340

#### ✍️ Description
Re-adds `dc_source_db_name = "DcSource"` to the dev-dc app module, restoring the wiring that was temporarily removed in #259 while the seeding workflow was in a broken state. 

The seed task is now working (after the dc-connector go-sqlcmd switch + bzip2 hotfix), and DcSource is populated with 92 households on RDS. With this line restored, the API task gets `DC_SOURCE_DB_NAME` back, and `Program.cs` builds `DCConnector:ConnectionString` again to connect to the new DC Source DB in AWS.

#### 🔗 Links to related PRs
Reverses the temporary rollback in codeforamerica/sebt-self-service-portal#259. Depends on (already merged) seed task fixes in codeforamerica/sebt-self-service-portal-dc-connector#26 and the bzip2 hotfix.

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests - N/A (single line tofu change)
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu — `DC_SOURCE_DB_NAME` (already plumbed through`sebt_application` module) 
