### PR TITLE
DC-371: Activity-gated session refresh + absolute timeout cap

### DIFF
--- a/docs/adr/0014-session-idle-and-absolute-timeout.md
+++ b/docs/adr/0014-session-idle-and-absolute-timeout.md
@@ -1,0 +1,33 @@
+# ADR 0014: Session Idle and Absolute Timeout
+
+## Status
+
+Accepted
+
+## Context
+
+The portal session is an HttpOnly cookie carrying a JWT, renewed by `POST /api/auth/refresh`. A `TokenRefresher` component was calling refresh on a fixed 10-minute interval whenever an authenticated tab was open. The interval had no notion of user activity, so a tab left open kept the session alive indefinitely — bypassing idle timeout. Reported as a security issue (#267).
+
+The server JWT also had no absolute lifetime — refresh requests were always honored.
+
+## Decision
+
+Implement two complementary timeouts, aligned with [OWASP Session Management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) and [NIST SP 800-63B §7.1](https://pages.nist.gov/800-63-3/sp800-63b.html) (IAL2: ≤30 min idle, ≤12 hr absolute).
+
+**Idle (sliding) timeout — `JwtSettings.ExpirationMinutes`, default 15 min.**
+The session cookie expires this long after the most recent renewal. Renewal is now activity-gated: `TokenRefresher` schedules a single `setTimeout` keyed off the server-returned `expiresAt`, and at fire time only refreshes if `now − lastActivityAt < idleThreshold`. DOM events (`mousedown`, `keydown`, `touchstart`, `scroll`, `visibilitychange`) update `lastActivityAt` via a 1-second-throttled listener. Idle users stop refreshing; the cookie lapses and the next API call's 401 redirects to `/login`.
+
+**Absolute timeout — `JwtSettings.AbsoluteExpirationMinutes`, default 60 min.**
+Stamped once at first login as the standard OIDC `auth_time` claim. Refresh forwards the same `auth_time` forward — never re-stamps. `RefreshTokenCommandHandler` rejects with `Result<string>.Unauthorized` when `now − auth_time ≥ AbsoluteExpirationMinutes`. The controller maps this to 401 + `AuthCookies.ClearAuthCookie`. A configuration validator enforces `AbsoluteExpirationMinutes ≥ ExpirationMinutes`.
+
+`/api/auth/status` exposes both `expiresAt` and `absoluteExpiresAt` so the SPA can schedule and halt refreshes without round-tripping for the JWT contents.
+
+The activity-tracking and refresh-scheduling logic is hand-rolled (~3 small modules, ~80 LOC total). A library (`react-idle-timer`) was evaluated and rejected: 3-year release gap, 40 untriaged issues, no React 19 verification, and we would use <10% of its surface (no prompt, no leader election, no cross-tab sync — per-tab independence is intentional).
+
+## Consequences
+
+- Idle sessions expire after 15 min of no activity. Active users renew silently.
+- All sessions terminate at 60 min regardless of activity. Returning users re-authenticate.
+- Tokens minted before this change lack `auth_time` and are rejected on refresh — a one-time forced re-login window when this deploys (acceptable; ≤15 min cleared by the new idle window).
+- Per-tab activity tracking: each tab schedules its own refresh, so activity in one tab does not silently extend another idle tab's session.
+- Defaults are tighter than NIST IAL2 ceilings; can be relaxed via configuration without code changes.

--- a/docs/adr/0014-session-idle-and-absolute-timeout.md
+++ b/docs/adr/0014-session-idle-and-absolute-timeout.md
@@ -18,7 +18,7 @@ Implement two complementary timeouts, aligned with [OWASP Session Management](ht
 The session cookie expires this long after the most recent renewal. Renewal is now activity-gated: `TokenRefresher` schedules a single `setTimeout` keyed off the server-returned `expiresAt`, and at fire time only refreshes if `now − lastActivityAt < idleThreshold`. DOM events (`mousedown`, `keydown`, `touchstart`, `scroll`, `visibilitychange`) update `lastActivityAt` via a 1-second-throttled listener. Idle users stop refreshing; the cookie lapses and the next API call's 401 redirects to `/login`.
 
 **Absolute timeout — `JwtSettings.AbsoluteExpirationMinutes`, default 60 min.**
-Stamped once at first login as the standard OIDC `auth_time` claim. Refresh forwards the same `auth_time` forward — never re-stamps. `RefreshTokenCommandHandler` rejects with `Result<string>.Unauthorized` when `now − auth_time ≥ AbsoluteExpirationMinutes`. The controller maps this to 401 + `AuthCookies.ClearAuthCookie`. A configuration validator enforces `AbsoluteExpirationMinutes ≥ ExpirationMinutes`.
+Stamped once at first login as the standard OIDC `auth_time` claim. Refresh forwards the same `auth_time` — never re-stamps. `SessionLifetimePolicy` (in `UseCases/Auth/SessionLifetime/`) is invoked from `JwtBearerEvents.OnTokenValidated` on every authenticated request: tokens missing `auth_time` or older than the cap fail authentication (401), with the cookie cleared inline. A configuration validator enforces `AbsoluteExpirationMinutes ≥ ExpirationMinutes`.
 
 `/api/auth/status` exposes both `expiresAt` and `absoluteExpiresAt` so the SPA can schedule and halt refreshes without round-tripping for the JWT contents.
 
@@ -28,6 +28,6 @@ The activity-tracking and refresh-scheduling logic is hand-rolled (~3 small modu
 
 - Idle sessions expire after 15 min of no activity. Active users renew silently.
 - All sessions terminate at 60 min regardless of activity. Returning users re-authenticate.
-- Tokens minted before this change lack `auth_time` and are rejected on refresh — a one-time forced re-login window when this deploys (acceptable; ≤15 min cleared by the new idle window).
+- Tokens minted before this change lack `auth_time` and are rejected by the bearer middleware on the **next authenticated API call** — effectively immediate for any open tab, since the SPA re-fetches `/api/auth/status` on mount and on most navigations.
 - Per-tab activity tracking: each tab schedules its own refresh, so activity in one tab does not silently extend another idle tab's session.
 - Defaults are tighter than NIST IAL2 ceilings; can be relaxed via configuration without code changes.

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -45,6 +45,11 @@ public class AuthController(
         logger.LogInformation("Authorization status check successful for UserId {UserId}, Phone={MaskedPhone}",
             userId?.ToString() ?? "unknown", GetMaskedPhone());
 
+        long? expiresAt = long.TryParse(User.FindFirst("exp")?.Value, out var exp) ? exp : null;
+        long? absoluteExpiresAt = long.TryParse(User.FindFirst("auth_time")?.Value, out var authTime)
+            ? authTime + jwtSettingsOptions.Value.AbsoluteExpirationMinutes * 60L
+            : null;
+
         return Ok(new AuthorizationStatusResponse(
             IsAuthorized: true,
             Email: User.GetUserEmail(),
@@ -52,7 +57,9 @@ public class AuthController(
             IdProofingStatus: int.TryParse(User.FindFirst(JwtClaimTypes.IdProofingStatus)?.Value, out var s) ? s : null,
             IdProofingCompletedAt: long.TryParse(User.FindFirst(JwtClaimTypes.IdProofingCompletedAt)?.Value, out var c) ? c : null,
             IdProofingExpiresAt: long.TryParse(User.FindFirst(JwtClaimTypes.IdProofingExpiresAt)?.Value, out var e) ? e : null,
-            IsCoLoaded: bool.TryParse(User.FindFirst(JwtClaimTypes.IsCoLoaded)?.Value, out var cl) ? cl : null));
+            IsCoLoaded: bool.TryParse(User.FindFirst(JwtClaimTypes.IsCoLoaded)?.Value, out var cl) ? cl : null,
+            ExpiresAt: expiresAt,
+            AbsoluteExpiresAt: absoluteExpiresAt));
     }
 
     /// <summary>
@@ -159,6 +166,15 @@ public class AuthController(
             if (result is ValidationFailedResult<string> validationFailed)
             {
                 return BadRequest(new ErrorResponse(result.Message, validationFailed.Errors));
+            }
+
+            if (result is UnauthorizedResult<string>)
+            {
+                // Absolute-timeout (or any handler-signaled "session is no longer valid")
+                // path: clear the cookie so the rejected JWT can't be replayed, then 401
+                // so the SPA's existing 401 handler redirects to /login.
+                AuthCookies.ClearAuthCookie(Response);
+                return Unauthorized(new ErrorResponse(result.Message));
             }
 
             if (result is PreconditionFailedResult<string> preconditionFailed)

--- a/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -168,15 +168,6 @@ public class AuthController(
                 return BadRequest(new ErrorResponse(result.Message, validationFailed.Errors));
             }
 
-            if (result is UnauthorizedResult<string>)
-            {
-                // Absolute-timeout (or any handler-signaled "session is no longer valid")
-                // path: clear the cookie so the rejected JWT can't be replayed, then 401
-                // so the SPA's existing 401 handler redirects to /login.
-                AuthCookies.ClearAuthCookie(Response);
-                return Unauthorized(new ErrorResponse(result.Message));
-            }
-
             if (result is PreconditionFailedResult<string> preconditionFailed)
             {
                 // Return 404 for NotFound, 409 for Conflict, etc.

--- a/src/SEBT.Portal.Api/Models/AuthorizationStatusResponse.cs
+++ b/src/SEBT.Portal.Api/Models/AuthorizationStatusResponse.cs
@@ -24,6 +24,15 @@ namespace SEBT.Portal.Api.Models;
 /// <param name="IsCoLoaded">
 /// Whether the user's record was co-loaded from an external state system. Null when the claim is absent.
 /// </param>
+/// <param name="ExpiresAt">
+/// Unix seconds timestamp at which the current session cookie expires (sliding/idle expiry).
+/// The SPA uses this to schedule activity-gated refreshes. Null when the claim is absent.
+/// </param>
+/// <param name="AbsoluteExpiresAt">
+/// Unix seconds timestamp at which the session reaches its absolute lifetime cap, regardless of
+/// activity. Computed from the JWT <c>auth_time</c> claim plus <c>JwtSettings.AbsoluteExpirationMinutes</c>.
+/// Null when <c>auth_time</c> is absent.
+/// </param>
 public record AuthorizationStatusResponse(
     bool IsAuthorized,
     string? Email = null,
@@ -31,5 +40,7 @@ public record AuthorizationStatusResponse(
     int? IdProofingStatus = null,
     long? IdProofingCompletedAt = null,
     long? IdProofingExpiresAt = null,
-    bool? IsCoLoaded = null);
+    bool? IsCoLoaded = null,
+    long? ExpiresAt = null,
+    long? AbsoluteExpiresAt = null);
 

--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -20,6 +20,7 @@ using SEBT.Portal.Infrastructure.Configuration;
 using SEBT.Portal.Infrastructure.Services;
 using SEBT.Portal.Infrastructure.Seeding.Services;
 using SEBT.Portal.UseCases;
+using SEBT.Portal.UseCases.Auth.SessionLifetime;
 using SEBT.Portal.Infrastructure;
 using SEBT.Portal.Api.Startup;
 
@@ -230,6 +231,31 @@ builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationSc
                     {
                         context.Token = cookieToken;
                     }
+                }
+                return Task.CompletedTask;
+            },
+            OnTokenValidated = context =>
+            {
+                // Enforce the absolute session lifetime cap on every authenticated request.
+                // Tokens missing auth_time (e.g., minted before the cap was introduced) or
+                // older than the cap are rejected here so the SPA's 401 handler kicks in.
+                if (context.Principal is null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                var policy = context.HttpContext.RequestServices
+                    .GetRequiredService<SessionLifetimePolicy>();
+                var outcome = policy.Evaluate(context.Principal);
+
+                if (outcome != SessionLifetimePolicy.Outcome.Valid)
+                {
+                    AuthCookies.ClearAuthCookie(context.Response);
+                    var logger = context.HttpContext.RequestServices
+                        .GetRequiredService<ILogger<JwtBearerEvents>>();
+                    logger.LogInformation(
+                        "JWT rejected by absolute session lifetime policy: {Outcome}", outcome);
+                    context.Fail($"Absolute session lifetime: {outcome}");
                 }
                 return Task.CompletedTask;
             }

--- a/src/SEBT.Portal.Api/appsettings.Development.example.json
+++ b/src/SEBT.Portal.Api/appsettings.Development.example.json
@@ -13,7 +13,8 @@
     "SecretKey": "YOUR_JWT_SECRET_AT_LEAST_32_CHARS",
     "Issuer": "SEBT.Portal.Api",
     "Audience": "SEBT.Portal.Web",
-    "ExpirationMinutes": 60
+    "ExpirationMinutes": 15,
+    "AbsoluteExpirationMinutes": 60
   },
   "PluginAssemblyPaths": ["plugins-dc", "plugins-co"],
   "Cbms": {

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -78,7 +78,9 @@
     "SecretKey": "",
     "Issuer": "SEBT.Portal.Api",
     "Audience": "SEBT.Portal.Web",
-    "ExpirationMinutes": 60
+    // Idle and absolute timeouts together implement OWASP / NIST SP 800-63B IAL2 session policy.
+    "ExpirationMinutes": 15,
+    "AbsoluteExpirationMinutes": 60
   },
   "IdProofingRequirements": {
     "address+view": "IAL1plus",

--- a/src/SEBT.Portal.Core/AppSettings/JwtSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/JwtSettings.cs
@@ -5,6 +5,11 @@ namespace SEBT.Portal.Core.AppSettings;
 /// <summary>
 /// Configuration settings for JWT token generation.
 /// </summary>
+/// <remarks>
+/// Idle and absolute timeouts together implement the session lifetime policy described in
+/// OWASP Session Management and NIST SP 800-63B (§7.1, IAL2 sessions: ≤30 min idle,
+/// ≤12 hr absolute). The portal's defaults are tighter than the NIST ceiling.
+/// </remarks>
 public class JwtSettings
 {
     public static readonly string SectionName = "JwtSettings";
@@ -29,9 +34,18 @@ public class JwtSettings
     public string Audience { get; set; } = string.Empty;
 
     /// <summary>
-    /// Token expiration time in minutes.
+    /// Sliding (idle) session lifetime, in minutes. The session cookie is renewed on
+    /// activity-driven refresh; an idle session expires when this window elapses.
     /// </summary>
     [Range(1, 1440, ErrorMessage = "ExpirationMinutes must be between 1 and 1440 (24 hours).")]
-    public int ExpirationMinutes { get; set; } = 60;
-}
+    public int ExpirationMinutes { get; set; } = 15;
 
+    /// <summary>
+    /// Absolute session lifetime, in minutes, measured from the user's original
+    /// authentication time (<c>auth_time</c> claim). Refresh requests are rejected
+    /// once this cap is reached, regardless of activity. Must be greater than or
+    /// equal to <see cref="ExpirationMinutes"/> — enforced by JwtSettingsValidator.
+    /// </summary>
+    [Range(1, 1440, ErrorMessage = "AbsoluteExpirationMinutes must be between 1 and 1440 (24 hours).")]
+    public int AbsoluteExpirationMinutes { get; set; } = 60;
+}

--- a/src/SEBT.Portal.Infrastructure/Configuration/JwtSettingsValidator.cs
+++ b/src/SEBT.Portal.Infrastructure/Configuration/JwtSettingsValidator.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
+
+namespace SEBT.Portal.Infrastructure.Configuration;
+
+/// <summary>
+/// Validates cross-field invariants on <see cref="JwtSettings"/> that data annotations
+/// cannot express. Range-only checks live on the settings type itself.
+/// </summary>
+public class JwtSettingsValidator : IValidateOptions<JwtSettings>
+{
+    /// <inheritdoc />
+    public ValidateOptionsResult Validate(string? name, JwtSettings options)
+    {
+        if (options is null)
+        {
+            return ValidateOptionsResult.Fail("JwtSettings configuration section is not present.");
+        }
+
+        // An idle window longer than the absolute cap is nonsensical: the absolute cap
+        // would never be reached in normal use because the idle timeout would always
+        // have already revoked the session.
+        if (options.AbsoluteExpirationMinutes < options.ExpirationMinutes)
+        {
+            return ValidateOptionsResult.Fail(
+                "JwtSettings:AbsoluteExpirationMinutes must be greater than or equal to ExpirationMinutes.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/SEBT.Portal.Infrastructure/Dependencies.cs
+++ b/src/SEBT.Portal.Infrastructure/Dependencies.cs
@@ -251,6 +251,7 @@ public static class Dependencies
         services.AddOptionsWithValidateOnStart<OtpRateLimitSettings>()
             .BindConfiguration(OtpRateLimitSettings.SectionName)
             .ValidateDataAnnotations();
+        services.AddSingleton<IValidateOptions<JwtSettings>, JwtSettingsValidator>();
         services.AddOptionsWithValidateOnStart<JwtSettings>()
             .BindConfiguration(JwtSettings.SectionName)
             .ValidateDataAnnotations();

--- a/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
@@ -52,6 +52,7 @@ public class JwtTokenService : ILocalLoginTokenService, IOidcTokenService, ISess
             JwtRegisteredClaimNames.Nbf,
             JwtRegisteredClaimNames.Aud,
             JwtRegisteredClaimNames.Iss,
+            JwtRegisteredClaimNames.AuthTime,
             JwtClaimTypes.Ial,
             JwtClaimTypes.IdProofingStatus,
             JwtClaimTypes.IdProofingSessionId,
@@ -328,6 +329,11 @@ public class JwtTokenService : ILocalLoginTokenService, IOidcTokenService, ISess
         var now = DateTimeOffset.UtcNow;
         var unixTimeSeconds = now.ToUnixTimeSeconds();
 
+        // auth_time anchors the absolute-timeout window. Forward the inbound value on
+        // refresh; stamp `now` only on a fresh login (when the caller didn't supply one).
+        var authTimeValue = resolvedClaims.GetValueOrDefault(JwtRegisteredClaimNames.AuthTime)
+            ?? unixTimeSeconds.ToString();
+
         var claims = new List<Claim>
         {
             new(ClaimTypes.Email, email),
@@ -337,6 +343,7 @@ public class JwtTokenService : ILocalLoginTokenService, IOidcTokenService, ISess
             new(JwtRegisteredClaimNames.Nbf, unixTimeSeconds.ToString(), ClaimValueTypes.Integer64),
             new(JwtRegisteredClaimNames.Aud, "SEBT.Portal.Web"),
             new(JwtRegisteredClaimNames.Iss, "SEBT.Portal.Api"),
+            new(JwtRegisteredClaimNames.AuthTime, authTimeValue, ClaimValueTypes.Integer64),
             new(JwtClaimTypes.IdProofingStatus, idProofingStatusValue, ClaimValueTypes.Integer32),
             new(JwtClaimTypes.Ial, ialValue),
             new(JwtClaimTypes.IsCoLoaded, isCoLoadedValue, ClaimValueTypes.Boolean)

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
@@ -13,17 +15,15 @@ namespace SEBT.Portal.UseCases.Auth;
 /// Handles the refresh of JWT tokens for authenticated users.
 /// </summary>
 /// <remarks>
-/// This handler validates the command, retrieves the current user information from the repository,
-/// and generates a new JWT token with updated ID proofing status and other user claims.
+/// Validates the command, enforces the absolute-session-lifetime cap by reading the
+/// inbound <c>auth_time</c> claim, and (when within the cap) generates a new JWT with
+/// updated user claims.
 /// </remarks>
-/// <param name="userRepository">Repository for user data and ID proofing status.</param>
-/// <param name="jwtTokenService">Service for generating JWT tokens.</param>
-/// <param name="validator">Validator for the <see cref="RefreshTokenCommand"/>.</param>
-/// <param name="logger">Logger for tracking token refresh attempts and results.</param>
 public class RefreshTokenCommandHandler(
     IUserRepository userRepository,
     ISessionRefreshTokenService jwtTokenService,
     IValidator<RefreshTokenCommand> validator,
+    IOptions<JwtSettings> jwtSettings,
     ILogger<RefreshTokenCommandHandler> logger)
     : ICommandHandler<RefreshTokenCommand, string>
 {
@@ -45,6 +45,15 @@ public class RefreshTokenCommandHandler(
             logger.LogWarning("Token refresh rejected: principal missing or invalid sub claim");
             return Result<string>.PreconditionFailed(
                 PreconditionFailedReason.NotFound, "User not found.");
+        }
+
+        // Absolute-session-lifetime check (per OWASP / NIST SP 800-63B §7.1).
+        // The JWT 'auth_time' claim records when the user originally authenticated; we never
+        // re-stamp it on refresh, so this enforces a hard ceiling regardless of activity.
+        var absoluteCapResult = CheckAbsoluteCap(command, userId.Value);
+        if (absoluteCapResult is not null)
+        {
+            return absoluteCapResult;
         }
 
         try
@@ -82,5 +91,36 @@ public class RefreshTokenCommandHandler(
                 "An error occurred while refreshing the authentication token.");
         }
     }
-}
 
+    /// <summary>
+    /// Returns an Unauthorized result when the inbound principal's auth_time is missing,
+    /// unparseable, or older than the configured absolute cap. Returns null when refresh
+    /// may proceed.
+    /// </summary>
+    private Result<string>? CheckAbsoluteCap(RefreshTokenCommand command, Guid userId)
+    {
+        // Standard OIDC/JWT claim name (RFC 7519/OIDC Core); using the string literal keeps
+        // the UseCases layer free of a JWT-package dependency.
+        const string AuthTimeClaim = "auth_time";
+        var authTimeClaim = command.CurrentPrincipal.FindFirst(AuthTimeClaim)?.Value;
+        if (!long.TryParse(authTimeClaim, out var authTimeUnixSeconds))
+        {
+            logger.LogWarning(
+                "Token refresh rejected: missing or invalid auth_time claim for UserId {UserId}", userId);
+            return Result<string>.Unauthorized("Session is invalid; please sign in again.");
+        }
+
+        var nowUnixSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var ageSeconds = nowUnixSeconds - authTimeUnixSeconds;
+        var capSeconds = jwtSettings.Value.AbsoluteExpirationMinutes * 60L;
+        if (ageSeconds >= capSeconds)
+        {
+            logger.LogInformation(
+                "Token refresh rejected: absolute session lifetime exceeded for UserId {UserId} " +
+                "(age={AgeSeconds}s, cap={CapSeconds}s)", userId, ageSeconds, capSeconds);
+            return Result<string>.Unauthorized("Session has reached its maximum lifetime; please sign in again.");
+        }
+
+        return null;
+    }
+}

--- a/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs
@@ -1,7 +1,5 @@
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
@@ -15,15 +13,15 @@ namespace SEBT.Portal.UseCases.Auth;
 /// Handles the refresh of JWT tokens for authenticated users.
 /// </summary>
 /// <remarks>
-/// Validates the command, enforces the absolute-session-lifetime cap by reading the
-/// inbound <c>auth_time</c> claim, and (when within the cap) generates a new JWT with
-/// updated user claims.
+/// The absolute session lifetime cap is enforced upstream by
+/// <see cref="SessionLifetime.SessionLifetimePolicy"/>, wired into the JWT bearer
+/// middleware. If a request reaches this handler, its principal has already passed
+/// that check.
 /// </remarks>
 public class RefreshTokenCommandHandler(
     IUserRepository userRepository,
     ISessionRefreshTokenService jwtTokenService,
     IValidator<RefreshTokenCommand> validator,
-    IOptions<JwtSettings> jwtSettings,
     ILogger<RefreshTokenCommandHandler> logger)
     : ICommandHandler<RefreshTokenCommand, string>
 {
@@ -45,15 +43,6 @@ public class RefreshTokenCommandHandler(
             logger.LogWarning("Token refresh rejected: principal missing or invalid sub claim");
             return Result<string>.PreconditionFailed(
                 PreconditionFailedReason.NotFound, "User not found.");
-        }
-
-        // Absolute-session-lifetime check (per OWASP / NIST SP 800-63B §7.1).
-        // The JWT 'auth_time' claim records when the user originally authenticated; we never
-        // re-stamp it on refresh, so this enforces a hard ceiling regardless of activity.
-        var absoluteCapResult = CheckAbsoluteCap(command, userId.Value);
-        if (absoluteCapResult is not null)
-        {
-            return absoluteCapResult;
         }
 
         try
@@ -90,37 +79,5 @@ public class RefreshTokenCommandHandler(
                 DependencyFailedReason.ConnectionFailed,
                 "An error occurred while refreshing the authentication token.");
         }
-    }
-
-    /// <summary>
-    /// Returns an Unauthorized result when the inbound principal's auth_time is missing,
-    /// unparseable, or older than the configured absolute cap. Returns null when refresh
-    /// may proceed.
-    /// </summary>
-    private Result<string>? CheckAbsoluteCap(RefreshTokenCommand command, Guid userId)
-    {
-        // Standard OIDC/JWT claim name (RFC 7519/OIDC Core); using the string literal keeps
-        // the UseCases layer free of a JWT-package dependency.
-        const string AuthTimeClaim = "auth_time";
-        var authTimeClaim = command.CurrentPrincipal.FindFirst(AuthTimeClaim)?.Value;
-        if (!long.TryParse(authTimeClaim, out var authTimeUnixSeconds))
-        {
-            logger.LogWarning(
-                "Token refresh rejected: missing or invalid auth_time claim for UserId {UserId}", userId);
-            return Result<string>.Unauthorized("Session is invalid; please sign in again.");
-        }
-
-        var nowUnixSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        var ageSeconds = nowUnixSeconds - authTimeUnixSeconds;
-        var capSeconds = jwtSettings.Value.AbsoluteExpirationMinutes * 60L;
-        if (ageSeconds >= capSeconds)
-        {
-            logger.LogInformation(
-                "Token refresh rejected: absolute session lifetime exceeded for UserId {UserId} " +
-                "(age={AgeSeconds}s, cap={CapSeconds}s)", userId, ageSeconds, capSeconds);
-            return Result<string>.Unauthorized("Session has reached its maximum lifetime; please sign in again.");
-        }
-
-        return null;
     }
 }

--- a/src/SEBT.Portal.UseCases/Auth/SessionLifetime/SessionLifetimePolicy.cs
+++ b/src/SEBT.Portal.UseCases/Auth/SessionLifetime/SessionLifetimePolicy.cs
@@ -1,0 +1,48 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
+
+namespace SEBT.Portal.UseCases.Auth.SessionLifetime;
+
+/// <summary>
+/// Evaluates whether a portal session has exceeded its absolute lifetime cap, anchored
+/// to the JWT <c>auth_time</c> claim (RFC 7519 / OIDC Core).
+/// </summary>
+/// <remarks>
+/// Pure business rule; no I/O. The bearer middleware calls this on every authenticated
+/// request, so a session that lacks <c>auth_time</c> or has aged past the cap is rejected
+/// before any controller runs — not just at <c>/api/auth/refresh</c>.
+/// </remarks>
+public class SessionLifetimePolicy(
+    IOptions<JwtSettings> jwtSettings,
+    TimeProvider timeProvider)
+{
+    /// <summary>
+    /// Standard OIDC claim name. With <c>MapInboundClaims = false</c> the bearer middleware
+    /// leaves it as a literal claim type on the principal.
+    /// </summary>
+    public const string AuthTimeClaimName = "auth_time";
+
+    public enum Outcome
+    {
+        /// <summary>Session is within its absolute lifetime window.</summary>
+        Valid,
+        /// <summary>The principal has no <c>auth_time</c> claim (or it's not parseable).</summary>
+        MissingAuthTime,
+        /// <summary>Session age has reached or passed the configured cap.</summary>
+        Expired
+    }
+
+    public Outcome Evaluate(ClaimsPrincipal principal)
+    {
+        var claim = principal.FindFirst(AuthTimeClaimName)?.Value;
+        if (!long.TryParse(claim, out var authTimeUnixSeconds))
+        {
+            return Outcome.MissingAuthTime;
+        }
+
+        var ageSeconds = timeProvider.GetUtcNow().ToUnixTimeSeconds() - authTimeUnixSeconds;
+        var capSeconds = jwtSettings.Value.AbsoluteExpirationMinutes * 60L;
+        return ageSeconds >= capSeconds ? Outcome.Expired : Outcome.Valid;
+    }
+}

--- a/src/SEBT.Portal.UseCases/Dependencies.cs
+++ b/src/SEBT.Portal.UseCases/Dependencies.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using SEBT.Portal.Core.Models.Household;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.StatesPlugins.Interfaces.Models.EnrollmentCheck;
 using SEBT.Portal.UseCases.Auth;
+using SEBT.Portal.UseCases.Auth.SessionLifetime;
 using SEBT.Portal.UseCases.EnrollmentCheck;
 using SEBT.Portal.UseCases.Household;
 using SEBT.Portal.UseCases.IdProofing;
@@ -25,6 +27,11 @@ public static class Dependencies
         services.RegisterCommandHandler<CheckEnrollmentCommand, EnrollmentCheckResult, CheckEnrollmentCommandHandler>();
         services.RegisterCommandHandler<UpdateAddressCommand, Core.Services.AddressValidationResult, UpdateAddressCommandHandler>();
         services.RegisterCommandHandler<RequestCardReplacementCommand, RequestCardReplacementCommandHandler>();
+
+        // SessionLifetimePolicy is invoked by the JWT bearer middleware on every authenticated
+        // request. TryAdd lets a host (e.g., tests) substitute a different TimeProvider.
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddSingleton<SessionLifetimePolicy>();
 
         return services;
     }

--- a/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
+++ b/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
       <PackageReference Include="DistributedLock.Core" Version="1.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
     </ItemGroup>
 
   <!-- State connector as sibling repo only. Sibling under parent of portal, or CI path. -->

--- a/src/SEBT.Portal.Web/src/api/client.test.ts
+++ b/src/SEBT.Portal.Web/src/api/client.test.ts
@@ -8,7 +8,7 @@
  * - Schema validation
  */
 import { http, HttpResponse } from 'msw'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 
 import { server } from '@/mocks/server'
@@ -331,6 +331,79 @@ describe('apiFetch', () => {
 
       await apiFetch('/test', { method: 'DELETE' })
       expect(requestMethod).toBe('DELETE')
+    })
+  })
+
+  describe('401 Redirect Behavior', () => {
+    // Stub window.location.replace so we can verify which endpoints trigger the
+    // session-invalid redirect to /login.
+    let replaceSpy: ReturnType<typeof vi.fn>
+    const originalLocation = window.location
+
+    beforeEach(() => {
+      replaceSpy = vi.fn()
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, replace: replaceSpy }
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation
+      })
+    })
+
+    it('redirects to /login on 401 from a resource endpoint', async () => {
+      // Bug fix: bearer middleware rejects an aged/missing-auth_time token with 401
+      // on /household/data. Without this, the dashboard rendered an error message
+      // instead of sending the user to log in again.
+      server.use(
+        http.get('/api/household/data', () =>
+          HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
+        )
+      )
+
+      await expect(apiFetch('/household/data')).rejects.toBeInstanceOf(ApiError)
+      expect(replaceSpy).toHaveBeenCalledWith('/login')
+    })
+
+    it('redirects to /login on 401 from /auth/refresh', async () => {
+      server.use(
+        http.post('/api/auth/refresh', () =>
+          HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
+        )
+      )
+
+      await expect(apiFetch('/auth/refresh', { method: 'POST' })).rejects.toBeInstanceOf(ApiError)
+      expect(replaceSpy).toHaveBeenCalledWith('/login')
+    })
+
+    it('does NOT redirect on 401 from /auth/status (bootstrap probe)', async () => {
+      // AuthContext uses /auth/status on mount to learn whether the user is logged in;
+      // a 401 here means "no session yet" and must not navigate the page.
+      server.use(
+        http.get('/api/auth/status', () =>
+          HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
+        )
+      )
+
+      await expect(apiFetch('/auth/status')).rejects.toBeInstanceOf(ApiError)
+      expect(replaceSpy).not.toHaveBeenCalled()
+    })
+
+    it('does NOT redirect on non-401 errors', async () => {
+      // 403 (e.g., IAL gating) and 500 leave the user on the page so they can see
+      // the appropriate inline message.
+      server.use(
+        http.get('/api/household/data', () =>
+          HttpResponse.json({ message: 'Forbidden' }, { status: 403 })
+        )
+      )
+
+      await expect(apiFetch('/household/data')).rejects.toBeInstanceOf(ApiError)
+      expect(replaceSpy).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/api/client.test.ts
+++ b/src/SEBT.Portal.Web/src/api/client.test.ts
@@ -109,6 +109,13 @@ describe('apiFetch', () => {
     })
 
     it('should throw ApiError for 401 Unauthorized', async () => {
+      // 401 also triggers window.location.replace; this test covers the throw shape.
+      // The redirect side-effect has its own coverage in '401 Redirect Behavior' below.
+      const originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, replace: vi.fn() }
+      })
       server.use(
         http.get('/api/test', () => {
           return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
@@ -117,10 +124,16 @@ describe('apiFetch', () => {
 
       try {
         await apiFetch('/test')
+        expect.fail('Expected ApiError to be thrown')
       } catch (error) {
         expect(error).toBeInstanceOf(ApiError)
         expect((error as ApiError).status).toBe(401)
         expect((error as ApiError).message).toBe('Unauthorized')
+      } finally {
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          value: originalLocation
+        })
       }
     })
 
@@ -355,18 +368,28 @@ describe('apiFetch', () => {
       })
     })
 
-    it('redirects to /login on 401 from a resource endpoint', async () => {
+    it('redirects to /login on 401 from a resource endpoint and marks the error as redirecting', async () => {
       // Bug fix: bearer middleware rejects an aged/missing-auth_time token with 401
-      // on /household/data. Without this, the dashboard rendered an error message
-      // instead of sending the user to log in again.
+      // on /household/data. The error is thrown so consumers can decide what to do,
+      // but the `isRedirecting` flag tells them the page is navigating away — they
+      // should treat it as a loading state and not flash an error UI.
       server.use(
         http.get('/api/household/data', () =>
           HttpResponse.json({ message: 'Unauthorized' }, { status: 401 })
         )
       )
 
-      await expect(apiFetch('/household/data')).rejects.toBeInstanceOf(ApiError)
+      let caught: unknown
+      try {
+        await apiFetch('/household/data')
+      } catch (err) {
+        caught = err
+      }
+
       expect(replaceSpy).toHaveBeenCalledWith('/login')
+      expect(caught).toBeInstanceOf(ApiError)
+      expect((caught as ApiError).status).toBe(401)
+      expect((caught as ApiError).isRedirecting).toBe(true)
     })
 
     it('redirects to /login on 401 from /auth/refresh', async () => {
@@ -376,8 +399,15 @@ describe('apiFetch', () => {
         )
       )
 
-      await expect(apiFetch('/auth/refresh', { method: 'POST' })).rejects.toBeInstanceOf(ApiError)
+      let caught: unknown
+      try {
+        await apiFetch('/auth/refresh', { method: 'POST' })
+      } catch (err) {
+        caught = err
+      }
+
       expect(replaceSpy).toHaveBeenCalledWith('/login')
+      expect((caught as ApiError).isRedirecting).toBe(true)
     })
 
     it('does NOT redirect on 401 from /auth/status (bootstrap probe)', async () => {
@@ -389,8 +419,16 @@ describe('apiFetch', () => {
         )
       )
 
-      await expect(apiFetch('/auth/status')).rejects.toBeInstanceOf(ApiError)
+      let caught: unknown
+      try {
+        await apiFetch('/auth/status')
+      } catch (err) {
+        caught = err
+      }
+
       expect(replaceSpy).not.toHaveBeenCalled()
+      expect(caught).toBeInstanceOf(ApiError)
+      expect((caught as ApiError).isRedirecting).toBe(false)
     })
 
     it('does NOT redirect on non-401 errors', async () => {
@@ -402,8 +440,15 @@ describe('apiFetch', () => {
         )
       )
 
-      await expect(apiFetch('/household/data')).rejects.toBeInstanceOf(ApiError)
+      let caught: unknown
+      try {
+        await apiFetch('/household/data')
+      } catch (err) {
+        caught = err
+      }
+
       expect(replaceSpy).not.toHaveBeenCalled()
+      expect((caught as ApiError).isRedirecting).toBe(false)
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/api/client.ts
+++ b/src/SEBT.Portal.Web/src/api/client.ts
@@ -89,11 +89,14 @@ export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions<T> 
   }
 
   if (!response.ok) {
-    // Auto-redirect on 401 from auth endpoints (session invalid), except /auth/status —
-    // that's the bootstrap probe AuthContext uses to detect "not logged in" without redirecting.
-    // Other endpoints may 401 for resource-level reasons (IAL gating) where the session is still valid.
-    const shouldRedirectOn401 = endpoint.startsWith('/auth/') && endpoint !== '/auth/status'
-    if (response.status === 401 && shouldRedirectOn401 && typeof window !== 'undefined') {
+    // 401 from any controller means the session is invalid (bearer middleware rejected
+    // the JWT — expired exp, missing/expired auth_time, etc). Redirect to /login on
+    // every endpoint EXCEPT /auth/status, which is the bootstrap probe AuthContext uses
+    // to detect "not logged in" without redirecting. Resource-level access denial (e.g.,
+    // IAL gating) returns 403 with structured ProblemDetails — never 401 — so any 401
+    // here is unambiguously session-level.
+    const isBootstrapProbe = endpoint === '/auth/status'
+    if (response.status === 401 && !isBootstrapProbe && typeof window !== 'undefined') {
       window.location.replace('/login')
     }
 

--- a/src/SEBT.Portal.Web/src/api/client.ts
+++ b/src/SEBT.Portal.Web/src/api/client.ts
@@ -9,7 +9,13 @@ export class ApiError extends Error {
   constructor(
     message: string,
     public status: number,
-    public data?: ApiErrorResponse
+    public data?: ApiErrorResponse,
+    /**
+     * True when the 401 path triggered `window.location.replace('/login')`. Consumers
+     * that render error UIs should treat this as a loading state — the page is
+     * unmounting, and the user shouldn't briefly see an error before the redirect.
+     */
+    public readonly isRedirecting: boolean = false
   ) {
     super(message)
     this.name = 'ApiError'
@@ -96,14 +102,16 @@ export async function apiFetch<T>(endpoint: string, options: ApiFetchOptions<T> 
     // IAL gating) returns 403 with structured ProblemDetails — never 401 — so any 401
     // here is unambiguously session-level.
     const isBootstrapProbe = endpoint === '/auth/status'
-    if (response.status === 401 && !isBootstrapProbe && typeof window !== 'undefined') {
+    const isRedirecting =
+      response.status === 401 && !isBootstrapProbe && typeof window !== 'undefined'
+    if (isRedirecting) {
       window.location.replace('/login')
     }
 
     const errorData = data as ApiErrorResponse | undefined
     const message =
       errorData?.error ?? errorData?.message ?? `Request failed with status ${response.status}`
-    throw new ApiError(message, response.status, errorData)
+    throw new ApiError(message, response.status, errorData, isRedirecting)
   }
 
   if (schema && data !== undefined) {

--- a/src/SEBT.Portal.Web/src/features/auth/api/auth-status/schema.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/auth-status/schema.ts
@@ -13,7 +13,11 @@ export const AuthorizationStatusResponseSchema = z.object({
   idProofingStatus: z.number().int().nullish(),
   idProofingCompletedAt: z.number().int().nullish(),
   idProofingExpiresAt: z.number().int().nullish(),
-  isCoLoaded: z.boolean().nullish()
+  isCoLoaded: z.boolean().nullish(),
+  /** Sliding (idle) cookie expiry — Unix epoch seconds. */
+  expiresAt: z.number().int().nullish(),
+  /** Absolute session lifetime cap — Unix epoch seconds. */
+  absoluteExpiresAt: z.number().int().nullish()
 })
 
 export type AuthorizationStatusResponse = z.infer<typeof AuthorizationStatusResponseSchema>

--- a/src/SEBT.Portal.Web/src/features/auth/components/TokenRefresher/TokenRefresher.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/TokenRefresher/TokenRefresher.test.tsx
@@ -5,28 +5,40 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vite
 
 import { TokenRefresher } from './TokenRefresher'
 
-// Mock the hooks
+// Substantive scheduling/activity logic lives in `useUserActivity` and
+// `useSessionRefresh` — those hooks have their own tests. This file only
+// verifies that the component wires session/expiry from `useAuth` to those
+// hooks and re-reads `/auth/status` after a successful refresh.
+
 const mockLogin = vi.fn()
 const mockMutate = vi.fn()
 
-vi.mock('../../context', () => ({
-  useAuth: vi.fn()
-}))
-
+vi.mock('../../context', () => ({ useAuth: vi.fn() }))
 vi.mock('../../api', () => ({
-  useRefreshToken: () => ({
-    mutate: mockMutate
-  })
+  useRefreshToken: () => ({ mutate: mockMutate })
 }))
 
 import { useAuth } from '../../context'
+
+const NOW_MS = new Date('2026-01-01T00:00:00Z').getTime()
+const NOW_SEC = Math.floor(NOW_MS / 1000)
 
 describe('TokenRefresher', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW_MS))
     ;(useAuth as Mock).mockReturnValue({
-      isAuthenticated: true,
+      session: {
+        email: 'user@example.com',
+        ial: '1plus',
+        idProofingStatus: 2,
+        idProofingCompletedAt: null,
+        idProofingExpiresAt: null,
+        isCoLoaded: false,
+        expiresAt: NOW_SEC + 15 * 60,
+        absoluteExpiresAt: NOW_SEC + 60 * 60
+      },
       login: mockLogin
     })
   })
@@ -35,96 +47,44 @@ describe('TokenRefresher', () => {
     vi.useRealTimers()
   })
 
-  it('should call refresh when authenticated', () => {
-    render(<TokenRefresher />)
-
-    expect(mockMutate).toHaveBeenCalledTimes(1)
-    expect(mockMutate).toHaveBeenCalledWith(undefined, expect.any(Object))
+  it('renders nothing', () => {
+    const { container } = render(<TokenRefresher />)
+    expect(container).toBeEmptyDOMElement()
   })
 
-  it('should re-read session on successful refresh', () => {
+  it('schedules a refresh keyed off session.expiresAt and re-reads on success', () => {
     render(<TokenRefresher />)
 
-    // Get the onSuccess callback from the mutate call
-    const mutateCall = mockMutate.mock.calls[0] as [undefined, { onSuccess: () => void }]
-    const options = mutateCall[1]
+    // No upfront mutate — schedule waits until just before expiresAt.
+    expect(mockMutate).not.toHaveBeenCalled()
 
-    // Simulate successful refresh — cookie is rotated server-side; frontend re-reads session
+    // Simulate an active user (an event in the throttle window).
+    act(() => {
+      window.dispatchEvent(new Event('mousedown'))
+    })
+
+    // Fire just past 14 min (15 min - 60 s safety margin).
+    act(() => {
+      vi.advanceTimersByTime(14 * 60 * 1000)
+    })
+
+    expect(mockMutate).toHaveBeenCalledTimes(1)
+
+    // Simulate refresh success → component should re-read /auth/status.
+    const [, options] = mockMutate.mock.calls[0] as [undefined, { onSuccess: () => void }]
     options.onSuccess()
-
     expect(mockLogin).toHaveBeenCalledWith()
   })
 
-  it('should set up periodic refresh interval', () => {
-    render(<TokenRefresher />)
-
-    expect(mockMutate).toHaveBeenCalledTimes(1)
-
-    // Advance time by 10 minutes
-    act(() => {
-      vi.advanceTimersByTime(10 * 60 * 1000)
-    })
-    expect(mockMutate).toHaveBeenCalledTimes(2)
-
-    act(() => {
-      vi.advanceTimersByTime(10 * 60 * 1000)
-    })
-    expect(mockMutate).toHaveBeenCalledTimes(3)
-  })
-
-  it('should clear interval on unmount', () => {
-    const { unmount } = render(<TokenRefresher />)
-
-    expect(mockMutate).toHaveBeenCalledTimes(1)
-
-    unmount()
-
-    act(() => {
-      vi.advanceTimersByTime(10 * 60 * 1000)
-    })
-
-    expect(mockMutate).toHaveBeenCalledTimes(1)
-  })
-
-  it('should not refresh when not authenticated', () => {
-    ;(useAuth as Mock).mockReturnValue({
-      isAuthenticated: false,
-      login: mockLogin
-    })
+  it('does not schedule a refresh when there is no session', () => {
+    ;(useAuth as Mock).mockReturnValue({ session: null, login: mockLogin })
 
     render(<TokenRefresher />)
 
-    expect(mockMutate).not.toHaveBeenCalled()
-
-    // Advance time - should still not call refresh
     act(() => {
-      vi.advanceTimersByTime(10 * 60 * 1000)
+      vi.advanceTimersByTime(60 * 60 * 1000)
     })
 
     expect(mockMutate).not.toHaveBeenCalled()
-  })
-
-  it('should clear interval when authentication state changes to false', () => {
-    const { rerender } = render(<TokenRefresher />)
-
-    expect(mockMutate).toHaveBeenCalledTimes(1)
-    ;(useAuth as Mock).mockReturnValue({
-      isAuthenticated: false,
-      login: mockLogin
-    })
-
-    rerender(<TokenRefresher />)
-
-    act(() => {
-      vi.advanceTimersByTime(10 * 60 * 1000)
-    })
-
-    expect(mockMutate).toHaveBeenCalledTimes(1)
-  })
-
-  it('should render nothing', () => {
-    const { container } = render(<TokenRefresher />)
-
-    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/src/SEBT.Portal.Web/src/features/auth/components/TokenRefresher/TokenRefresher.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/TokenRefresher/TokenRefresher.tsx
@@ -1,55 +1,50 @@
 'use client'
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback } from 'react'
 
 import { useRefreshToken } from '../../api'
 import { useAuth } from '../../context'
-
-// Refresh token every 10 minutes while authenticated
-const REFRESH_INTERVAL_MS = 10 * 60 * 1000
+import { useSessionRefresh, useUserActivity } from '../../idle'
 
 /**
- * TokenRefresher proactively refreshes the session cookie while the user is authenticated.
- * This prevents cookie expiration during active sessions. After a successful refresh,
- * it re-reads /auth/status so updated claims (IAL, ID proofing) propagate to the UI.
- * Should be rendered inside authenticated routes.
+ * Idle window that gates the refresh.
+ *
+ * Mirrors the server's `JwtSettings.ExpirationMinutes` (15 min sliding). If the
+ * user has been inactive for at least this long when the refresh timer fires,
+ * the cookie is allowed to lapse — the next API call returns 401 and the
+ * existing 401 handler redirects to /login.
+ *
+ * Per OWASP Session Management; aligns with NIST SP 800-63B IAL2 (≤30 min idle).
+ */
+const IDLE_THRESHOLD_MS = 15 * 60 * 1000
+
+/**
+ * Composes activity tracking with expiry-driven scheduling. The actual logic
+ * lives in {@link useUserActivity} and {@link useSessionRefresh} — this component
+ * is only here to wire `useAuth` and `useRefreshToken` to those hooks and to
+ * mount inside the authenticated layout.
  */
 export function TokenRefresher() {
-  const { isAuthenticated, login } = useAuth()
+  const { session, login } = useAuth()
   const { mutate } = useRefreshToken()
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const { getLastActivityAt } = useUserActivity()
 
-  const doRefresh = useCallback(() => {
+  const refresh = useCallback(() => {
     mutate(undefined, {
       onSuccess: () => {
-        // Backend rotated the HttpOnly session cookie; pick up any updated claims.
+        // Pick up rotated cookie's new expiresAt and any updated claims.
         void login()
       }
-      // Error handling (401 redirect) is done in apiFetch
-      // Other errors are silently ignored - we'll retry on next interval
     })
   }, [mutate, login])
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
-      }
-      return
-    }
+  useSessionRefresh({
+    expiresAt: session?.expiresAt ?? null,
+    absoluteExpiresAt: session?.absoluteExpiresAt ?? null,
+    getLastActivityAt,
+    idleThresholdMs: IDLE_THRESHOLD_MS,
+    refresh
+  })
 
-    doRefresh()
-    intervalRef.current = setInterval(doRefresh, REFRESH_INTERVAL_MS)
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
-      }
-    }
-  }, [isAuthenticated, doRefresh])
-
-  // This component doesn't render anything
   return null
 }

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingWithDi.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingWithDi.test.tsx
@@ -64,7 +64,9 @@ function session(isCoLoaded: boolean): SessionInfo {
     idProofingStatus: 0,
     idProofingCompletedAt: null,
     idProofingExpiresAt: null,
-    isCoLoaded
+    isCoLoaded,
+    expiresAt: null,
+    absoluteExpiresAt: null
   }
 }
 

--- a/src/SEBT.Portal.Web/src/features/auth/context/AuthContext.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/context/AuthContext.test.tsx
@@ -71,7 +71,9 @@ describe('AuthContext', () => {
         idProofingStatus: 2,
         idProofingCompletedAt: 1735689600,
         idProofingExpiresAt: 1767225600,
-        isCoLoaded: null
+        isCoLoaded: null,
+        expiresAt: null,
+        absoluteExpiresAt: null
       })
     })
 

--- a/src/SEBT.Portal.Web/src/features/auth/context/AuthContext.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/context/AuthContext.tsx
@@ -26,6 +26,10 @@ export interface SessionInfo {
   idProofingCompletedAt: number | null
   idProofingExpiresAt: number | null
   isCoLoaded: boolean | null
+  /** Unix epoch seconds when the sliding session cookie expires. */
+  expiresAt: number | null
+  /** Unix epoch seconds when the absolute session lifetime cap is reached. */
+  absoluteExpiresAt: number | null
 }
 
 interface AuthContextValue {
@@ -52,7 +56,9 @@ async function fetchSession(): Promise<SessionInfo | null> {
       idProofingStatus: response.idProofingStatus ?? null,
       idProofingCompletedAt: response.idProofingCompletedAt ?? null,
       idProofingExpiresAt: response.idProofingExpiresAt ?? null,
-      isCoLoaded: response.isCoLoaded ?? null
+      isCoLoaded: response.isCoLoaded ?? null,
+      expiresAt: response.expiresAt ?? null,
+      absoluteExpiresAt: response.absoluteExpiresAt ?? null
     }
   } catch (error) {
     // 401 means not logged in; anything else we also treat as unauthenticated

--- a/src/SEBT.Portal.Web/src/features/auth/idle/index.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/index.ts
@@ -1,0 +1,4 @@
+export { useSessionRefresh } from './useSessionRefresh'
+export type { UseSessionRefreshOptions } from './useSessionRefresh'
+export { useUserActivity } from './useUserActivity'
+export type { UserActivityTracker } from './useUserActivity'

--- a/src/SEBT.Portal.Web/src/features/auth/idle/throttle.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/throttle.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { throttle } from './throttle'
+
+describe('throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('invokes immediately on the first call (leading edge)', () => {
+    const spy = vi.fn()
+    const throttled = throttle(spy, 1000)
+
+    throttled()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops calls within the interval', () => {
+    const spy = vi.fn()
+    const throttled = throttle(spy, 1000)
+
+    throttled()
+    vi.advanceTimersByTime(500)
+    throttled()
+    throttled()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes again after the interval has elapsed', () => {
+    const spy = vi.fn()
+    const throttled = throttle(spy, 1000)
+
+    throttled()
+    vi.advanceTimersByTime(1000)
+    throttled()
+
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('forwards arguments to the wrapped function', () => {
+    const spy = vi.fn()
+    const throttled = throttle(spy, 1000)
+
+    throttled('a', 42)
+
+    expect(spy).toHaveBeenCalledWith('a', 42)
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/idle/throttle.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/throttle.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns a throttled wrapper that invokes `fn` at most once per `intervalMs`.
+ *
+ * Leading-edge: the first call after a quiet period fires immediately, and
+ * subsequent calls within the interval are dropped (not deferred). This is the
+ * right shape for activity tracking — we want the *first* event of a burst to
+ * register, not the last.
+ */
+export function throttle<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => void,
+  intervalMs: number
+): (...args: TArgs) => void {
+  let lastInvokedAt = -Infinity
+  return (...args: TArgs) => {
+    const now = Date.now()
+    if (now - lastInvokedAt >= intervalMs) {
+      lastInvokedAt = now
+      fn(...args)
+    }
+  }
+}

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.test.ts
@@ -1,0 +1,126 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useSessionRefresh } from './useSessionRefresh'
+
+const NOW_MS = new Date('2026-01-01T00:00:00Z').getTime()
+const NOW_SEC = Math.floor(NOW_MS / 1000)
+const IDLE_THRESHOLD_MS = 15 * 60 * 1000
+
+describe('useSessionRefresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW_MS))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function setup(overrides: Partial<Parameters<typeof useSessionRefresh>[0]> = {}) {
+    const refresh = vi.fn()
+    // Default: user is always "currently active". Tests that need stale activity
+    // override `getLastActivityAt`.
+    const getLastActivityAt = vi.fn(() => Date.now())
+    const props = {
+      expiresAt: NOW_SEC + 15 * 60, // 15 min from now (sliding)
+      absoluteExpiresAt: NOW_SEC + 60 * 60, // 60 min from now (absolute)
+      getLastActivityAt,
+      idleThresholdMs: IDLE_THRESHOLD_MS,
+      refresh,
+      ...overrides
+    }
+    const { rerender, unmount } = renderHook((p: typeof props) => useSessionRefresh(p), {
+      initialProps: props
+    })
+    return { refresh, getLastActivityAt, props, rerender, unmount }
+  }
+
+  it('schedules refresh 60 seconds before expiresAt and fires when active', () => {
+    const { refresh } = setup()
+
+    // 15 min - 60 s = 14 min. Not yet at fire time.
+    act(() => {
+      vi.advanceTimersByTime(14 * 60 * 1000 - 1)
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh when user has been idle past the threshold', () => {
+    // Activity timestamp is older than IDLE_THRESHOLD_MS at fire time.
+    const staleActivity = NOW_MS - IDLE_THRESHOLD_MS - 1000
+    const { refresh } = setup({ getLastActivityAt: () => staleActivity })
+
+    act(() => {
+      vi.advanceTimersByTime(15 * 60 * 1000)
+    })
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('does not refresh once the absolute cap has been reached', () => {
+    // Schedule fires at expiresAt - 60s. If absoluteExpiresAt is in the past
+    // by then, refresh is suppressed even with recent activity.
+    const { refresh } = setup({
+      expiresAt: NOW_SEC + 15 * 60,
+      absoluteExpiresAt: NOW_SEC + 5 * 60 // cap reached well before fire time
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(15 * 60 * 1000)
+    })
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('does not schedule when expiresAt is null', () => {
+    const { refresh } = setup({ expiresAt: null })
+
+    act(() => {
+      vi.advanceTimersByTime(60 * 60 * 1000)
+    })
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('reschedules on a new expiresAt (post-refresh)', () => {
+    const { refresh, props, rerender } = setup()
+
+    // Don't reach the original fire time (14 min). Update expiresAt to a new value
+    // (simulating /auth/status returning a fresh expiry after refresh).
+    act(() => {
+      vi.advanceTimersByTime(13 * 60 * 1000)
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    rerender({ ...props, expiresAt: NOW_SEC + 13 * 60 + 15 * 60 })
+
+    // New fire time = (13min + 15min) - 60s = 27min from t=0. We're at 13min now,
+    // so 14min more. Just under that should not have fired.
+    act(() => {
+      vi.advanceTimersByTime(14 * 60 * 1000 - 1)
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the pending timer on unmount', () => {
+    const { refresh, unmount } = setup()
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(60 * 60 * 1000)
+    })
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.test.ts
@@ -84,9 +84,11 @@ describe('useSessionRefresh', () => {
     expect(refresh).toHaveBeenCalledTimes(1)
   })
 
-  it('does not refresh at the absolute cap when the user is idle', () => {
-    // The activity gate still applies: an idle user past absolute is left alone;
-    // the next user-initiated API call will surface the 401 → redirect path.
+  it('refreshes at the absolute cap even when the user is idle', () => {
+    // At the absolute cap the session is dead regardless of activity. Firing the
+    // refresh gets a 401 from the bearer middleware, which the SPA turns into a
+    // redirect to /login — so an idle user sitting on the page gets a clean kick
+    // instead of a stale tab.
     const staleActivity = NOW_MS - IDLE_THRESHOLD_MS - 1000
     const { refresh } = setup({
       expiresAt: NOW_SEC + 15 * 60,
@@ -98,7 +100,7 @@ describe('useSessionRefresh', () => {
       vi.advanceTimersByTime(5 * 60 * 1000)
     })
 
-    expect(refresh).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalledTimes(1)
   })
 
   it('does not schedule when expiresAt is null', () => {

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.test.ts
@@ -63,16 +63,39 @@ describe('useSessionRefresh', () => {
     expect(refresh).not.toHaveBeenCalled()
   })
 
-  it('does not refresh once the absolute cap has been reached', () => {
-    // Schedule fires at expiresAt - 60s. If absoluteExpiresAt is in the past
-    // by then, refresh is suppressed even with recent activity.
+  it('fires at absoluteExpiresAt when the cap precedes the idle fire time', () => {
+    // When the absolute cap arrives sooner than `expiresAt - safetyMargin`, the
+    // schedule moves to the cap. Firing then gets 401 from the bearer middleware
+    // (server-side cap enforcement) and the SPA redirects — instead of leaving
+    // the user on a dead page until they click something.
     const { refresh } = setup({
-      expiresAt: NOW_SEC + 15 * 60,
-      absoluteExpiresAt: NOW_SEC + 5 * 60 // cap reached well before fire time
+      expiresAt: NOW_SEC + 15 * 60, // sliding fire time would be at 14 min
+      absoluteExpiresAt: NOW_SEC + 5 * 60 // absolute cap arrives at 5 min — sooner
     })
 
     act(() => {
-      vi.advanceTimersByTime(15 * 60 * 1000)
+      vi.advanceTimersByTime(5 * 60 * 1000 - 1)
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh at the absolute cap when the user is idle', () => {
+    // The activity gate still applies: an idle user past absolute is left alone;
+    // the next user-initiated API call will surface the 401 → redirect path.
+    const staleActivity = NOW_MS - IDLE_THRESHOLD_MS - 1000
+    const { refresh } = setup({
+      expiresAt: NOW_SEC + 15 * 60,
+      absoluteExpiresAt: NOW_SEC + 5 * 60,
+      getLastActivityAt: () => staleActivity
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(5 * 60 * 1000)
     })
 
     expect(refresh).not.toHaveBeenCalled()

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts
@@ -53,16 +53,18 @@ export function useSessionRefresh({
       return
     }
 
-    const expiresAtMs = expiresAt * 1000
-    const fireAt = expiresAtMs - REFRESH_SAFETY_MARGIN_MS
-    const delayMs = Math.max(0, fireAt - Date.now())
+    const idleFireAtMs = expiresAt * 1000 - REFRESH_SAFETY_MARGIN_MS
+    // Fire whichever happens first: the sliding refresh point or the absolute cap.
+    // When the absolute cap arrives sooner, the refresh request hits the cap on the
+    // server, gets 401 from the bearer middleware, and the SPA's 401 handler
+    // redirects to /login — instead of leaving the user on a dead page until they
+    // click something.
+    const absoluteFireAtMs =
+      absoluteExpiresAt !== null ? absoluteExpiresAt * 1000 : Number.POSITIVE_INFINITY
+    const fireAtMs = Math.min(idleFireAtMs, absoluteFireAtMs)
+    const delayMs = Math.max(0, fireAtMs - Date.now())
 
     const timer = setTimeout(() => {
-      const absoluteCapReached =
-        absoluteExpiresAt !== null && Date.now() >= absoluteExpiresAt * 1000
-      if (absoluteCapReached) {
-        return
-      }
       if (!isWithinIdleThreshold(getLastActivityAt(), idleThresholdMs)) {
         return
       }

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts
@@ -1,0 +1,76 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * How long before `expiresAt` to fire the refresh. Gives the request time to
+ * complete before the cookie expires and avoids racing the server clock.
+ */
+const REFRESH_SAFETY_MARGIN_MS = 60 * 1000
+
+/**
+ * If the user has been inactive for at least this long when the refresh timer
+ * fires, the session is allowed to lapse. The threshold matches the sliding
+ * idle window — keeping it in sync with the server's `ExpirationMinutes` lets
+ * the same activity that would have refreshed the cookie also drive the refresh.
+ */
+function isWithinIdleThreshold(lastActivityAt: number, idleThresholdMs: number): boolean {
+  return Date.now() - lastActivityAt < idleThresholdMs
+}
+
+export interface UseSessionRefreshOptions {
+  /** Sliding-cookie expiry (Unix epoch seconds), or null when no session is active. */
+  expiresAt: number | null
+  /** Absolute lifetime cap (Unix epoch seconds). Past this, scheduling halts. */
+  absoluteExpiresAt: number | null
+  /** Returns the timestamp (ms since epoch) of the user's most recent activity. */
+  getLastActivityAt: () => number
+  /** Idle threshold in milliseconds — refresh fires only if activity is within this window. */
+  idleThresholdMs: number
+  /** Triggers a session refresh (e.g., the `useRefreshToken` mutation). */
+  refresh: () => void
+}
+
+/**
+ * Schedules a single, expiry-driven session refresh. On each tick:
+ *
+ *   - if the absolute cap has been reached → do nothing (let the session lapse)
+ *   - if the user has been idle past the threshold → do nothing
+ *   - otherwise → call `refresh()`
+ *
+ * The hook reschedules whenever `expiresAt` changes (i.e., after each successful
+ * refresh re-reads `/auth/status`).
+ */
+export function useSessionRefresh({
+  expiresAt,
+  absoluteExpiresAt,
+  getLastActivityAt,
+  idleThresholdMs,
+  refresh
+}: UseSessionRefreshOptions): void {
+  useEffect(() => {
+    if (expiresAt === null) {
+      return
+    }
+
+    const expiresAtMs = expiresAt * 1000
+    const fireAt = expiresAtMs - REFRESH_SAFETY_MARGIN_MS
+    const delayMs = Math.max(0, fireAt - Date.now())
+
+    const timer = setTimeout(() => {
+      const absoluteCapReached =
+        absoluteExpiresAt !== null && Date.now() >= absoluteExpiresAt * 1000
+      if (absoluteCapReached) {
+        return
+      }
+      if (!isWithinIdleThreshold(getLastActivityAt(), idleThresholdMs)) {
+        return
+      }
+      refresh()
+    }, delayMs)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [expiresAt, absoluteExpiresAt, getLastActivityAt, idleThresholdMs, refresh])
+}

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts
@@ -65,7 +65,14 @@ export function useSessionRefresh({
     const delayMs = Math.max(0, fireAtMs - Date.now())
 
     const timer = setTimeout(() => {
-      if (!isWithinIdleThreshold(getLastActivityAt(), idleThresholdMs)) {
+      // At the absolute cap the session is dead regardless of activity — fire the
+      // refresh anyway so the server rejects, the bearer middleware clears the
+      // cookie, and apiFetch's 401 handler redirects the user to /login. The
+      // idle gate only applies at the sliding fire point, where skipping the
+      // refresh lets an idle session lapse naturally.
+      const reachedAbsoluteCap =
+        absoluteExpiresAt !== null && Date.now() >= absoluteExpiresAt * 1000
+      if (!reachedAbsoluteCap && !isWithinIdleThreshold(getLastActivityAt(), idleThresholdMs)) {
         return
       }
       refresh()

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useUserActivity.test.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useUserActivity.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useUserActivity } from './useUserActivity'
+
+describe('useUserActivity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('initializes lastActivityAt to the current time', () => {
+    const { result } = renderHook(() => useUserActivity())
+
+    expect(result.current.getLastActivityAt()).toBe(Date.now())
+  })
+
+  it('updates lastActivityAt on mousedown', () => {
+    const { result } = renderHook(() => useUserActivity())
+    const initial = result.current.getLastActivityAt()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+      window.dispatchEvent(new Event('mousedown'))
+    })
+
+    expect(result.current.getLastActivityAt()).toBeGreaterThan(initial)
+    expect(result.current.getLastActivityAt()).toBe(Date.now())
+  })
+
+  it('updates lastActivityAt on keydown', () => {
+    const { result } = renderHook(() => useUserActivity())
+    const initial = result.current.getLastActivityAt()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+      window.dispatchEvent(new Event('keydown'))
+    })
+
+    expect(result.current.getLastActivityAt()).toBeGreaterThan(initial)
+  })
+
+  it('updates lastActivityAt on visibilitychange', () => {
+    // A user returning to the tab is meaningful activity — otherwise a refresh
+    // could fire just after they switch back, before they've moved the mouse.
+    const { result } = renderHook(() => useUserActivity())
+    const initial = result.current.getLastActivityAt()
+
+    act(() => {
+      vi.advanceTimersByTime(3000)
+      window.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    expect(result.current.getLastActivityAt()).toBeGreaterThan(initial)
+  })
+
+  it('throttles rapid events to at most once per second', () => {
+    const { result } = renderHook(() => useUserActivity())
+    const initial = result.current.getLastActivityAt()
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+      window.dispatchEvent(new Event('mousedown'))
+    })
+    const firstUpdate = result.current.getLastActivityAt()
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+      window.dispatchEvent(new Event('mousedown'))
+    })
+
+    // Second event was within the 1s throttle window — timestamp shouldn't change.
+    expect(result.current.getLastActivityAt()).toBe(firstUpdate)
+    expect(firstUpdate).toBeGreaterThan(initial)
+  })
+
+  it('removes listeners on unmount', () => {
+    const { result, unmount } = renderHook(() => useUserActivity())
+    unmount()
+    const beforeEvent = result.current.getLastActivityAt()
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+      window.dispatchEvent(new Event('mousedown'))
+    })
+
+    expect(result.current.getLastActivityAt()).toBe(beforeEvent)
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/idle/useUserActivity.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/idle/useUserActivity.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+import { throttle } from './throttle'
+
+/**
+ * DOM events that count as user activity for idle-timeout purposes.
+ *
+ * Mirrors the OWASP Session Management guidance: any meaningful interaction
+ * should reset the idle clock. Tab visibility transitions are included so a
+ * user returning to the tab from another window doesn't get logged out
+ * mid-action by a refresh that fires in the gap.
+ */
+const ACTIVITY_EVENTS = [
+  'mousedown',
+  'keydown',
+  'touchstart',
+  'scroll',
+  'visibilitychange'
+] as const
+
+const ACTIVITY_THROTTLE_MS = 1000
+
+export interface UserActivityTracker {
+  /** Returns the timestamp (ms since epoch) of the most recent recorded activity. */
+  getLastActivityAt: () => number
+}
+
+/**
+ * Tracks the most recent user-activity timestamp via passive DOM listeners.
+ * Listeners are throttled so a steady stream of events (e.g., scrolling) doesn't
+ * thrash React state. The hook exposes a getter rather than re-rendering on
+ * activity — consumers (the refresh scheduler) only sample on a timer.
+ */
+export function useUserActivity(): UserActivityTracker {
+  // Initialized in the mount effect — keeps render pure.
+  const lastActivityAtRef = useRef<number>(0)
+
+  useEffect(() => {
+    lastActivityAtRef.current = Date.now()
+
+    const recordActivity = throttle(() => {
+      lastActivityAtRef.current = Date.now()
+    }, ACTIVITY_THROTTLE_MS)
+
+    for (const event of ACTIVITY_EVENTS) {
+      window.addEventListener(event, recordActivity, { passive: true })
+    }
+
+    return () => {
+      for (const event of ACTIVITY_EVENTS) {
+        window.removeEventListener(event, recordActivity)
+      }
+    }
+  }, [])
+
+  return {
+    getLastActivityAt: () => lastActivityAtRef.current
+  }
+}

--- a/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.test.tsx
@@ -234,8 +234,8 @@ describe('CardSelection', () => {
   // --- Error handling ---
 
   it('shows error alert when household data fails to load', async () => {
-    // 503 surfaces the error UI; 401 is suppressed by useHouseholdData while the
-    // SPA redirects to /login.
+    // 400 surfaces the error UI without retries (4xx skips retry); 401 is suppressed
+    // by useHouseholdData while the SPA redirects to /login.
     server.use(
       http.get('/api/household/data', () => {
         return HttpResponse.json({ error: 'Bad Request' }, { status: 400 })

--- a/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.test.tsx
@@ -234,9 +234,11 @@ describe('CardSelection', () => {
   // --- Error handling ---
 
   it('shows error alert when household data fails to load', async () => {
+    // 503 surfaces the error UI; 401 is suppressed by useHouseholdData while the
+    // SPA redirects to /login.
     server.use(
       http.get('/api/household/data', () => {
-        return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        return HttpResponse.json({ error: 'Bad Request' }, { status: 400 })
       })
     )
 

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
@@ -179,8 +179,17 @@ describe('useHouseholdData', () => {
       expect(requestCount).toBe(1)
     })
 
-    it('should NOT retry on 401 unauthorized', async () => {
+    it('should NOT retry on 401 unauthorized and suppresses error while redirecting', async () => {
+      // 401 from /household/data means the bearer middleware rejected the JWT.
+      // apiFetch redirects to /login and marks the error as redirecting; the hook
+      // suppresses isError so the dashboard stays in its loading shell instead of
+      // flashing an error UI before the browser navigates.
       let requestCount = 0
+      const originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...originalLocation, replace: vi.fn() }
+      })
 
       server.use(
         http.get('/api/household/data', () => {
@@ -198,10 +207,17 @@ describe('useHouseholdData', () => {
       })
 
       await waitFor(() => {
-        expect(result.current.isError).toBe(true)
+        expect(result.current.isLoading).toBe(true)
       })
 
+      expect(result.current.isError).toBe(false)
       expect(requestCount).toBe(1)
+      expect(window.location.replace).toHaveBeenCalledWith('/login')
+
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation
+      })
     })
 
     it('should retry on 5xx server errors up to 2 times', async () => {

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -56,11 +56,18 @@ export function useHouseholdData({ redirectOnInsufficientIal = true } = {}) {
     query.error.status === 403 &&
     'requiredIal' in ((query.error.data as Record<string, unknown>) ?? {})
 
+  // When apiFetch has triggered a 401 redirect to /login, suppress the error
+  // state so the dashboard stays in its loading shell instead of flashing the
+  // error alert before the browser navigates.
+  const isRedirecting = query.error instanceof ApiError && query.error.isRedirecting
+  const isError = query.isError && !isRedirecting
+  const isLoading = query.isLoading || isRedirecting
+
   useEffect(() => {
     if (requiresProofing && redirectOnInsufficientIal) {
       router.push('/login/id-proofing')
     }
   }, [requiresProofing, redirectOnInsufficientIal, router])
 
-  return { ...query, requiresProofing }
+  return { ...query, isError, isLoading, requiresProofing }
 }

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -108,10 +108,12 @@ describe('DashboardContent', () => {
   })
 
   it('renders error alert on API failure', async () => {
-    // Use 401 to avoid hook retry logic (4xx errors are not retried)
+    // 503 represents a generic server-side failure that should surface the error UI.
+    // (401 is suppressed by useHouseholdData because the SPA redirects to /login on
+    // session-invalid responses; using it here would test the redirect path instead.)
     server.use(
       http.get('/api/household/data', () => {
-        return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        return HttpResponse.json({ error: 'Bad Request' }, { status: 400 })
       })
     )
 
@@ -125,7 +127,7 @@ describe('DashboardContent', () => {
   it('renders sign-out link in error state', async () => {
     server.use(
       http.get('/api/household/data', () => {
-        return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        return HttpResponse.json({ error: 'Bad Request' }, { status: 400 })
       })
     )
 

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -371,9 +371,12 @@ describe('DashboardContent', () => {
     })
 
     it('does not emit a cohort property when the API returns an error', async () => {
+      // 400 surfaces the error UI without retries (4xx skips the hook's retry logic).
+      // 401 is suppressed by useHouseholdData while the SPA redirects to /login, so it
+      // would leave the component in `isLoading` and never run the error-analytics branch.
       server.use(
         http.get('/api/household/data', () => {
-          return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 })
+          return HttpResponse.json({ error: 'Bad Request' }, { status: 400 })
         })
       )
 

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -108,9 +108,9 @@ describe('DashboardContent', () => {
   })
 
   it('renders error alert on API failure', async () => {
-    // 503 represents a generic server-side failure that should surface the error UI.
-    // (401 is suppressed by useHouseholdData because the SPA redirects to /login on
-    // session-invalid responses; using it here would test the redirect path instead.)
+    // 400 surfaces the error UI without retries (4xx skips the hook's retry logic).
+    // 401 is suppressed by useHouseholdData because the SPA redirects to /login on
+    // session-invalid responses; using it here would test the redirect path instead.
     server.use(
       http.get('/api/household/data', () => {
         return HttpResponse.json({ error: 'Bad Request' }, { status: 400 })

--- a/src/SEBT.Portal.Web/src/lib/jwt.test.ts
+++ b/src/SEBT.Portal.Web/src/lib/jwt.test.ts
@@ -10,7 +10,9 @@ const EMPTY_SESSION: SessionInfo = {
   idProofingStatus: null,
   idProofingCompletedAt: null,
   idProofingExpiresAt: null,
-  isCoLoaded: null
+  isCoLoaded: null,
+  expiresAt: null,
+  absoluteExpiresAt: null
 }
 
 function sessionWith(partial: Partial<SessionInfo>): SessionInfo {

--- a/test/SEBT.Portal.Tests/Integration/AuthCookieAuthenticationTests.cs
+++ b/test/SEBT.Portal.Tests/Integration/AuthCookieAuthenticationTests.cs
@@ -80,10 +80,13 @@ public class AuthCookieAuthenticationTests : IClassFixture<PortalWebApplicationF
     {
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(PortalWebApplicationFactory.JwtSecretKey));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var nowUnixSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
         var claims = new[]
         {
             new Claim("email", email),
-            new Claim("sub", email)
+            new Claim("sub", email),
+            // auth_time required by SessionLifetimePolicy in the bearer middleware.
+            new Claim("auth_time", nowUnixSeconds)
         };
         var now = DateTime.UtcNow;
         // notBefore must precede expires; pad it well behind expires to cover negative

--- a/test/SEBT.Portal.Tests/Unit/Configuration/JwtSettingsValidatorTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Configuration/JwtSettingsValidatorTests.cs
@@ -1,0 +1,76 @@
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Infrastructure.Configuration;
+
+namespace SEBT.Portal.Tests.Unit.Configuration;
+
+public class JwtSettingsValidatorTests
+{
+    private static JwtSettings ValidSettings() => new()
+    {
+        SecretKey = new string('x', 32),
+        Issuer = "test",
+        Audience = "test",
+        ExpirationMinutes = 15,
+        AbsoluteExpirationMinutes = 60
+    };
+
+    [Fact]
+    public void Validate_Succeeds_WhenAbsoluteIsGreaterThanIdle()
+    {
+        var settings = ValidSettings();
+        var validator = new JwtSettingsValidator();
+
+        var result = validator.Validate(null, settings);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_Succeeds_WhenAbsoluteEqualsIdle()
+    {
+        var settings = ValidSettings();
+        settings.ExpirationMinutes = 30;
+        settings.AbsoluteExpirationMinutes = 30;
+        var validator = new JwtSettingsValidator();
+
+        var result = validator.Validate(null, settings);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_Fails_WhenAbsoluteIsLessThanIdle()
+    {
+        var settings = ValidSettings();
+        settings.ExpirationMinutes = 30;
+        settings.AbsoluteExpirationMinutes = 15;
+        var validator = new JwtSettingsValidator();
+
+        var result = validator.Validate(null, settings);
+
+        Assert.True(result.Failed);
+        Assert.Contains("AbsoluteExpirationMinutes", result.FailureMessage);
+        Assert.Contains("ExpirationMinutes", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_Fails_WhenSettingsAreNull()
+    {
+        var validator = new JwtSettingsValidator();
+
+        var result = validator.Validate(null, null!);
+
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void DefaultJwtSettings_HasIdleAt15AndAbsoluteAt60()
+    {
+        // Locks the documented defaults: idle 15 min, absolute 60 min.
+        // Both are tighter than the NIST SP 800-63B IAL2 ceilings (30 min idle, 12 hr absolute).
+        var settings = new JwtSettings();
+
+        Assert.Equal(15, settings.ExpirationMinutes);
+        Assert.Equal(60, settings.AbsoluteExpirationMinutes);
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -238,30 +238,6 @@ public class AuthControllerTests
     }
 
     [Fact]
-    public async Task RefreshToken_WhenHandlerReturnsUnauthorized_Returns401AndClearsCookie()
-    {
-        // Arrange — handler signals absolute-timeout exceeded by returning Unauthorized.
-        // Controller must (a) return 401 so the SPA's 401 redirect kicks in, and
-        // (b) clear the auth cookie so the rejected JWT can't be replayed.
-        var userId = Guid.NewGuid();
-        SetupAuthenticatedUserWithSub(userId);
-
-        var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
-        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
-            .Returns(Result<string>.Unauthorized("Session has reached its maximum lifetime; please sign in again."));
-
-        // Act
-        var result = await _controller.RefreshToken(handlerMock);
-
-        // Assert
-        Assert.IsType<UnauthorizedObjectResult>(result);
-        var setCookie = _controller.Response.Headers["Set-Cookie"].ToString();
-        Assert.Contains($"{AuthCookies.AuthCookieName}=", setCookie);
-        // ClearAuthCookie sets an expires= in the past
-        Assert.Contains("expires=", setCookie, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
     public void GetAuthorizationStatus_WhenExpClaimNotANumber_ReturnsNullExpiresAt()
     {
         // Arrange — defensive: a non-numeric exp claim should not crash the endpoint

--- a/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -155,6 +155,137 @@ public class AuthControllerTests
     }
 
     [Fact]
+    public void GetAuthorizationStatus_WhenExpClaimPresent_IncludesExpiresAtInResponse()
+    {
+        // Arrange — the SPA needs to know when the session cookie expires so it can
+        // schedule activity-gated refreshes (preventing indefinite-session bypass of
+        // idle timeout). The JWT 'exp' claim is the source of truth.
+        const long expEpochSeconds = 1767225600L;
+        var claims = new List<Claim>
+        {
+            new Claim("email", "user@example.com"),
+            new Claim("exp", expEpochSeconds.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        // Act
+        var result = _controller.GetAuthorizationStatus();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<AuthorizationStatusResponse>(okResult.Value);
+        Assert.Equal(expEpochSeconds, response.ExpiresAt);
+    }
+
+    [Fact]
+    public void GetAuthorizationStatus_WhenExpClaimAbsent_ReturnsNullExpiresAt()
+    {
+        // Arrange
+        SetupAuthenticatedUser("user@example.com");
+
+        // Act
+        var result = _controller.GetAuthorizationStatus();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<AuthorizationStatusResponse>(okResult.Value);
+        Assert.Null(response.ExpiresAt);
+    }
+
+    [Fact]
+    public void GetAuthorizationStatus_WhenAuthTimePresent_IncludesAbsoluteExpiresAtInResponse()
+    {
+        // Arrange — controller derives AbsoluteExpiresAt from auth_time + AbsoluteExpirationMinutes.
+        // Test controller is configured with AbsoluteExpirationMinutes=60.
+        const long authTimeEpochSeconds = 1700000000L;
+        var claims = new List<Claim>
+        {
+            new Claim("email", "user@example.com"),
+            new Claim("auth_time", authTimeEpochSeconds.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        // Act
+        var result = _controller.GetAuthorizationStatus();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<AuthorizationStatusResponse>(okResult.Value);
+        Assert.Equal(authTimeEpochSeconds + 60 * 60L, response.AbsoluteExpiresAt);
+    }
+
+    [Fact]
+    public void GetAuthorizationStatus_WhenAuthTimeAbsent_ReturnsNullAbsoluteExpiresAt()
+    {
+        // Arrange
+        SetupAuthenticatedUser("user@example.com");
+
+        // Act
+        var result = _controller.GetAuthorizationStatus();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<AuthorizationStatusResponse>(okResult.Value);
+        Assert.Null(response.AbsoluteExpiresAt);
+    }
+
+    [Fact]
+    public async Task RefreshToken_WhenHandlerReturnsUnauthorized_Returns401AndClearsCookie()
+    {
+        // Arrange — handler signals absolute-timeout exceeded by returning Unauthorized.
+        // Controller must (a) return 401 so the SPA's 401 redirect kicks in, and
+        // (b) clear the auth cookie so the rejected JWT can't be replayed.
+        var userId = Guid.NewGuid();
+        SetupAuthenticatedUserWithSub(userId);
+
+        var handlerMock = Substitute.For<ICommandHandler<RefreshTokenCommand, string>>();
+        handlerMock.Handle(Arg.Any<RefreshTokenCommand>())
+            .Returns(Result<string>.Unauthorized("Session has reached its maximum lifetime; please sign in again."));
+
+        // Act
+        var result = await _controller.RefreshToken(handlerMock);
+
+        // Assert
+        Assert.IsType<UnauthorizedObjectResult>(result);
+        var setCookie = _controller.Response.Headers["Set-Cookie"].ToString();
+        Assert.Contains($"{AuthCookies.AuthCookieName}=", setCookie);
+        // ClearAuthCookie sets an expires= in the past
+        Assert.Contains("expires=", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetAuthorizationStatus_WhenExpClaimNotANumber_ReturnsNullExpiresAt()
+    {
+        // Arrange — defensive: a non-numeric exp claim should not crash the endpoint
+        var claims = new List<Claim>
+        {
+            new Claim("email", "user@example.com"),
+            new Claim("exp", "not-a-number")
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+
+        // Act
+        var result = _controller.GetAuthorizationStatus();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<AuthorizationStatusResponse>(okResult.Value);
+        Assert.Null(response.ExpiresAt);
+    }
+
+    [Fact]
     public async Task Logout_WithOidcConfigured_ClearsCookieAndRedirectsToIdpEndSessionEndpoint()
     {
         // Arrange

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/BuildAndSignTokenTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/BuildAndSignTokenTests.cs
@@ -132,4 +132,39 @@ public class BuildAndSignTokenTests : JwtTokenServiceTestBase
         var jwt = ReadJwt(token);
         Assert.Equal("false", jwt.Claims.First(c => c.Type == JwtClaimTypes.IsCoLoaded).Value);
     }
+
+    [Fact]
+    public void AuthTime_IsStampedAtCurrentTime_WhenAbsentFromResolvedClaims()
+    {
+        // Fresh login: no auth_time in resolved claims → stamp now.
+        // Drives absolute-timeout enforcement on later refresh.
+        var before = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var claims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var token = Service.BuildAndSignToken(Guid.NewGuid(), "user@example.com", claims);
+        var after = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        var jwt = ReadJwt(token);
+        var authTime = long.Parse(jwt.Claims.First(c => c.Type == "auth_time").Value);
+        Assert.InRange(authTime, before, after);
+    }
+
+    [Fact]
+    public void AuthTime_IsForwardedFromResolvedClaims_OnRefresh()
+    {
+        // Refresh path: caller passes the existing auth_time forward so the absolute
+        // timeout window does not reset on every renewal.
+        const long originalAuthTime = 1700000000L;
+        var claims = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["auth_time"] = originalAuthTime.ToString()
+        };
+
+        var token = Service.BuildAndSignToken(Guid.NewGuid(), "user@example.com", claims);
+
+        var jwt = ReadJwt(token);
+        var authTimeClaims = jwt.Claims.Where(c => c.Type == "auth_time").ToList();
+        Assert.Single(authTimeClaims);
+        Assert.Equal(originalAuthTime.ToString(), authTimeClaims[0].Value);
+    }
 }

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
@@ -1,10 +1,7 @@
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using NSubstitute;
-using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
@@ -16,8 +13,6 @@ namespace SEBT.Portal.Tests.Unit.UseCases.Auth;
 
 public class RefreshTokenCommandHandlerTests
 {
-    private const int AbsoluteCapMinutes = 60;
-
     private readonly IUserRepository userRepository = Substitute.For<IUserRepository>();
     private readonly ISessionRefreshTokenService jwtTokenService = Substitute.For<ISessionRefreshTokenService>();
     private readonly NullLogger<RefreshTokenCommandHandler> logger = NullLogger<RefreshTokenCommandHandler>.Instance;
@@ -26,46 +21,21 @@ public class RefreshTokenCommandHandlerTests
 
     public RefreshTokenCommandHandlerTests()
     {
-        var jwtSettings = Options.Create(new JwtSettings
-        {
-            SecretKey = new string('x', 32),
-            Issuer = "test",
-            Audience = "test",
-            ExpirationMinutes = 15,
-            AbsoluteExpirationMinutes = AbsoluteCapMinutes
-        });
+        // The absolute-cap is enforced upstream by SessionLifetimePolicy in the bearer
+        // middleware; principals reaching this handler have already passed that check.
         handler = new RefreshTokenCommandHandler(
             userRepository,
             jwtTokenService,
             validator,
-            jwtSettings,
             logger);
     }
 
-    /// <summary>Builds a ClaimsPrincipal carrying a sub claim (the portal's user ID) and
-    /// a recent auth_time claim (so absolute-cap checks pass), plus any additional claims
-    /// the test needs to pass through to the refreshed token.</summary>
+    /// <summary>Builds a ClaimsPrincipal carrying a sub claim (the portal's user ID), plus
+    /// any additional claims the test needs to pass through to the refreshed token.</summary>
     private static ClaimsPrincipal PrincipalWithSub(string userIdSub, params Claim[] extraClaims)
     {
-        var nowSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
-        var claims = new List<Claim>
-        {
-            new("sub", userIdSub),
-            new(JwtRegisteredClaimNames.AuthTime, nowSeconds)
-        };
-        claims.AddRange(extraClaims);
-        return new ClaimsPrincipal(new ClaimsIdentity(claims));
-    }
-
-    /// <summary>Builds a principal with sub but with a custom auth_time (or no auth_time
-    /// at all when <paramref name="authTimeUnixSeconds"/> is null) — for absolute-cap tests.</summary>
-    private static ClaimsPrincipal PrincipalWithAuthTime(string userIdSub, long? authTimeUnixSeconds)
-    {
         var claims = new List<Claim> { new("sub", userIdSub) };
-        if (authTimeUnixSeconds.HasValue)
-        {
-            claims.Add(new Claim(JwtRegisteredClaimNames.AuthTime, authTimeUnixSeconds.Value.ToString()));
-        }
+        claims.AddRange(extraClaims);
         return new ClaimsPrincipal(new ClaimsIdentity(claims));
     }
 
@@ -323,69 +293,6 @@ public class RefreshTokenCommandHandlerTests
             u.IalLevel == UserIalLevel.IAL1plus &&
             u.IdProofingSessionId == "session-xyz" &&
             u.IdProofingCompletedAt == completedAt), Arg.Any<ClaimsPrincipal>());
-    }
-
-    [Fact]
-    public async Task Handle_WhenAbsoluteTimeoutExceeded_ReturnsUnauthorized()
-    {
-        // Arrange — a session whose original auth_time is older than the absolute cap.
-        var userId = Guid.NewGuid();
-        var staleAuthTime = DateTimeOffset.UtcNow.AddMinutes(-(AbsoluteCapMinutes + 1)).ToUnixTimeSeconds();
-        var command = new RefreshTokenCommand
-        {
-            CurrentPrincipal = PrincipalWithAuthTime(userId.ToString(), staleAuthTime)
-        };
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        Assert.IsType<UnauthorizedResult<string>>(result);
-        await userRepository.DidNotReceive().GetUserByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
-        jwtTokenService.DidNotReceive().GenerateForSessionRefresh(Arg.Any<User>(), Arg.Any<ClaimsPrincipal>());
-    }
-
-    [Fact]
-    public async Task Handle_WhenAuthTimeWithinAbsoluteCap_AllowsRefresh()
-    {
-        // Arrange — auth_time is just inside the cap, refresh should still succeed.
-        var userId = Guid.NewGuid();
-        var freshAuthTime = DateTimeOffset.UtcNow.AddMinutes(-(AbsoluteCapMinutes - 1)).ToUnixTimeSeconds();
-        var command = new RefreshTokenCommand
-        {
-            CurrentPrincipal = PrincipalWithAuthTime(userId.ToString(), freshAuthTime)
-        };
-
-        var user = new User { Id = userId, Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
-        userRepository.GetUserByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
-        jwtTokenService.GenerateForSessionRefresh(Arg.Any<User>(), Arg.Any<ClaimsPrincipal>())
-            .Returns("token");
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-    }
-
-    [Fact]
-    public async Task Handle_WhenAuthTimeMissing_ReturnsUnauthorized()
-    {
-        // Defensive: a token without auth_time predates this code path. Reject so the
-        // user re-authenticates rather than allowing an unbounded session by omission.
-        var userId = Guid.NewGuid();
-        var command = new RefreshTokenCommand
-        {
-            CurrentPrincipal = PrincipalWithAuthTime(userId.ToString(), authTimeUnixSeconds: null)
-        };
-
-        // Act
-        var result = await handler.Handle(command, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        Assert.IsType<UnauthorizedResult<string>>(result);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs
@@ -1,7 +1,10 @@
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using NSubstitute;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
@@ -13,6 +16,8 @@ namespace SEBT.Portal.Tests.Unit.UseCases.Auth;
 
 public class RefreshTokenCommandHandlerTests
 {
+    private const int AbsoluteCapMinutes = 60;
+
     private readonly IUserRepository userRepository = Substitute.For<IUserRepository>();
     private readonly ISessionRefreshTokenService jwtTokenService = Substitute.For<ISessionRefreshTokenService>();
     private readonly NullLogger<RefreshTokenCommandHandler> logger = NullLogger<RefreshTokenCommandHandler>.Instance;
@@ -21,19 +26,46 @@ public class RefreshTokenCommandHandlerTests
 
     public RefreshTokenCommandHandlerTests()
     {
+        var jwtSettings = Options.Create(new JwtSettings
+        {
+            SecretKey = new string('x', 32),
+            Issuer = "test",
+            Audience = "test",
+            ExpirationMinutes = 15,
+            AbsoluteExpirationMinutes = AbsoluteCapMinutes
+        });
         handler = new RefreshTokenCommandHandler(
             userRepository,
             jwtTokenService,
             validator,
+            jwtSettings,
             logger);
     }
 
-    /// <summary>Builds a ClaimsPrincipal carrying a sub claim (the portal's user ID) plus
-    /// any additional claims the test needs to pass through to the refreshed token.</summary>
+    /// <summary>Builds a ClaimsPrincipal carrying a sub claim (the portal's user ID) and
+    /// a recent auth_time claim (so absolute-cap checks pass), plus any additional claims
+    /// the test needs to pass through to the refreshed token.</summary>
     private static ClaimsPrincipal PrincipalWithSub(string userIdSub, params Claim[] extraClaims)
     {
-        var claims = new List<Claim> { new("sub", userIdSub) };
+        var nowSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+        var claims = new List<Claim>
+        {
+            new("sub", userIdSub),
+            new(JwtRegisteredClaimNames.AuthTime, nowSeconds)
+        };
         claims.AddRange(extraClaims);
+        return new ClaimsPrincipal(new ClaimsIdentity(claims));
+    }
+
+    /// <summary>Builds a principal with sub but with a custom auth_time (or no auth_time
+    /// at all when <paramref name="authTimeUnixSeconds"/> is null) — for absolute-cap tests.</summary>
+    private static ClaimsPrincipal PrincipalWithAuthTime(string userIdSub, long? authTimeUnixSeconds)
+    {
+        var claims = new List<Claim> { new("sub", userIdSub) };
+        if (authTimeUnixSeconds.HasValue)
+        {
+            claims.Add(new Claim(JwtRegisteredClaimNames.AuthTime, authTimeUnixSeconds.Value.ToString()));
+        }
         return new ClaimsPrincipal(new ClaimsIdentity(claims));
     }
 
@@ -291,6 +323,69 @@ public class RefreshTokenCommandHandlerTests
             u.IalLevel == UserIalLevel.IAL1plus &&
             u.IdProofingSessionId == "session-xyz" &&
             u.IdProofingCompletedAt == completedAt), Arg.Any<ClaimsPrincipal>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenAbsoluteTimeoutExceeded_ReturnsUnauthorized()
+    {
+        // Arrange — a session whose original auth_time is older than the absolute cap.
+        var userId = Guid.NewGuid();
+        var staleAuthTime = DateTimeOffset.UtcNow.AddMinutes(-(AbsoluteCapMinutes + 1)).ToUnixTimeSeconds();
+        var command = new RefreshTokenCommand
+        {
+            CurrentPrincipal = PrincipalWithAuthTime(userId.ToString(), staleAuthTime)
+        };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.IsType<UnauthorizedResult<string>>(result);
+        await userRepository.DidNotReceive().GetUserByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        jwtTokenService.DidNotReceive().GenerateForSessionRefresh(Arg.Any<User>(), Arg.Any<ClaimsPrincipal>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenAuthTimeWithinAbsoluteCap_AllowsRefresh()
+    {
+        // Arrange — auth_time is just inside the cap, refresh should still succeed.
+        var userId = Guid.NewGuid();
+        var freshAuthTime = DateTimeOffset.UtcNow.AddMinutes(-(AbsoluteCapMinutes - 1)).ToUnixTimeSeconds();
+        var command = new RefreshTokenCommand
+        {
+            CurrentPrincipal = PrincipalWithAuthTime(userId.ToString(), freshAuthTime)
+        };
+
+        var user = new User { Id = userId, Email = "user@example.com", IalLevel = UserIalLevel.IAL1 };
+        userRepository.GetUserByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        jwtTokenService.GenerateForSessionRefresh(Arg.Any<User>(), Arg.Any<ClaimsPrincipal>())
+            .Returns("token");
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAuthTimeMissing_ReturnsUnauthorized()
+    {
+        // Defensive: a token without auth_time predates this code path. Reject so the
+        // user re-authenticates rather than allowing an unbounded session by omission.
+        var userId = Guid.NewGuid();
+        var command = new RefreshTokenCommand
+        {
+            CurrentPrincipal = PrincipalWithAuthTime(userId.ToString(), authTimeUnixSeconds: null)
+        };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.IsType<UnauthorizedResult<string>>(result);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Auth/SessionLifetime/SessionLifetimePolicyTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Auth/SessionLifetime/SessionLifetimePolicyTests.cs
@@ -1,0 +1,86 @@
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.UseCases.Auth.SessionLifetime;
+
+namespace SEBT.Portal.Tests.Unit.UseCases.Auth.SessionLifetime;
+
+public class SessionLifetimePolicyTests
+{
+    private const int CapMinutes = 60;
+    private static readonly DateTimeOffset Now = new(2026, 5, 4, 12, 0, 0, TimeSpan.Zero);
+
+    private static SessionLifetimePolicy CreatePolicy(FakeTimeProvider timeProvider)
+    {
+        var settings = Options.Create(new JwtSettings
+        {
+            SecretKey = new string('x', 32),
+            Issuer = "test",
+            Audience = "test",
+            ExpirationMinutes = 15,
+            AbsoluteExpirationMinutes = CapMinutes
+        });
+        return new SessionLifetimePolicy(settings, timeProvider);
+    }
+
+    private static ClaimsPrincipal PrincipalWith(params (string type, string value)[] claims)
+    {
+        var identity = new ClaimsIdentity(claims.Select(c => new Claim(c.type, c.value)));
+        return new ClaimsPrincipal(identity);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsValid_WhenAuthTimeIsRecent()
+    {
+        var time = new FakeTimeProvider(Now);
+        var policy = CreatePolicy(time);
+        var authTime = Now.AddMinutes(-(CapMinutes - 1)).ToUnixTimeSeconds();
+        var principal = PrincipalWith(("auth_time", authTime.ToString()));
+
+        Assert.Equal(SessionLifetimePolicy.Outcome.Valid, policy.Evaluate(principal));
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsMissingAuthTime_WhenClaimAbsent()
+    {
+        // Pre-existing sessions issued before auth_time stamping land here.
+        var policy = CreatePolicy(new FakeTimeProvider(Now));
+        var principal = PrincipalWith(("sub", Guid.NewGuid().ToString()));
+
+        Assert.Equal(SessionLifetimePolicy.Outcome.MissingAuthTime, policy.Evaluate(principal));
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsMissingAuthTime_WhenClaimIsNotNumeric()
+    {
+        // Defensive: a non-numeric value is treated as if absent rather than crashing.
+        var policy = CreatePolicy(new FakeTimeProvider(Now));
+        var principal = PrincipalWith(("auth_time", "not-a-number"));
+
+        Assert.Equal(SessionLifetimePolicy.Outcome.MissingAuthTime, policy.Evaluate(principal));
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsExpired_AtCapBoundary()
+    {
+        // ageSeconds == capSeconds → expired. Documents the >= boundary.
+        var time = new FakeTimeProvider(Now);
+        var policy = CreatePolicy(time);
+        var authTime = Now.AddMinutes(-CapMinutes).ToUnixTimeSeconds();
+        var principal = PrincipalWith(("auth_time", authTime.ToString()));
+
+        Assert.Equal(SessionLifetimePolicy.Outcome.Expired, policy.Evaluate(principal));
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsExpired_PastCap()
+    {
+        var time = new FakeTimeProvider(Now);
+        var policy = CreatePolicy(time);
+        var authTime = Now.AddMinutes(-(CapMinutes + 5)).ToUnixTimeSeconds();
+        var principal = PrincipalWith(("auth_time", authTime.ToString()));
+
+        Assert.Equal(SessionLifetimePolicy.Outcome.Expired, policy.Evaluate(principal));
+    }
+}


### PR DESCRIPTION
## Jira ticket

[DC-371](https://codeforamerica.atlassian.net/browse/DC-371)

Fixes #267 — security bug: portal session was kept alive indefinitely while any authenticated tab stayed open.

## Description

The portal session cookie was renewed every 10 minutes by a fixed-interval client refresher with no notion of user activity, completely bypassing idle timeout. This PR introduces two complementary timeouts (per OWASP Session Management and NIST SP 800-63B) and the redirect plumbing needed to land users on `/login` cleanly when either fires.

### Timeouts

- **Idle (sliding) — `JwtSettings.ExpirationMinutes`, default 15 min.** `TokenRefresher` schedules a single timer keyed off the server-returned `expiresAt`; at fire time it refreshes only if the user has been active within the threshold. Activity sources: `mousedown`, `keydown`, `touchstart`, `scroll`, `visibilitychange` (throttled 1s). Idle users stop refreshing → cookie lapses → 401 → redirect.
- **Absolute — `JwtSettings.AbsoluteExpirationMinutes`, default 60 min.** Stamped once at first login as the standard OIDC `auth_time` claim and forwarded on every refresh (never re-stamped). Enforced by `SessionLifetimePolicy` (in `UseCases/Auth/SessionLifetime/`), invoked from `JwtBearerEvents.OnTokenValidated` on **every** authenticated request. A token missing `auth_time` or older than the cap fails authentication, the bearer middleware clears the cookie inline, and the request returns 401. A configuration validator enforces `AbsoluteExpirationMinutes ≥ ExpirationMinutes`.

### Client-side redirect & flash suppression

- `apiFetch` redirects to `/login` on 401 from any endpoint except `/auth/status` (the bootstrap probe `AuthContext` uses to detect "not logged in" without redirecting). Resource-level access denial is 403 with `ProblemDetails`, never 401, so any 401 is unambiguously session-level.
- The thrown `ApiError` carries an `isRedirecting` flag when the redirect was triggered. `useHouseholdData` checks it and treats the redirecting case as `isLoading`, so the dashboard stays in its skeleton state rather than flashing "Error loading dashboard" before the browser navigates.

### Schedule corner cases

- Timer fires at `min(expiresAt − safetyMargin, absoluteExpiresAt)`. When the absolute cap arrives sooner, refresh fires *at the cap*, gets 401 from the bearer, and the SPA redirects.
- The activity gate only applies at the *sliding* fire point. At the *absolute* cap the session is dead regardless of activity, so the refresh fires for both active and idle users — guaranteeing an idle tab past the cap gets a clean kick instead of sitting on a dead page.

### Library decision

Activity tracking and refresh scheduling are hand-rolled (~140 LoC across 3 modules in `features/auth/idle/`). `react-idle-timer` was evaluated and rejected (3-year release gap, no React 19 verification, we'd use <10% of its surface, cross-tab sync would be counterproductive).

See [ADR 0014](docs/adr/0014-session-idle-and-absolute-timeout.md) for full rationale.

## Related PRs

n/a

---

## PR Review Priority Guide

**Risk Level**: 🔴 High | **Files**: 40 | **Lines**: +1238 / −147

Adds idle (sliding) and absolute session timeouts. Server enforces the absolute cap at the JWT bearer layer (every authenticated request); client schedules an activity-gated refresh. Reviewer attention should focus on the new bearer hook, the `auth_time` stamping/forwarding, the broadened 401-redirect logic, and the scheduling asymmetry that fires the refresh at the cap regardless of activity.

### Priority Review Table

| Priority | File | Function/Change | Lines | Sec | Cpx | Nov | Notes |
| :-: | --- | --- | :-: | :-: | :-: | :-: | --- |
| 🔴 | [src/SEBT.Portal.Api/Program.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-d7863947ab6e8ca166388b7badb6c7f8829743ebab06854d1cb5fa11ff360eaf) | `OnTokenValidated` handler | +26 | 🔴 | 🟡 | 🔴 | New bearer hook; clears cookie + fails auth |
| 🔴 | [src/SEBT.Portal.Api/appsettings.json](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-b292786a8ea5c76439808bfba75f8de952b57016b474756ef5e672c80c3e16c6) | `JwtSettings` defaults | +4/−2 | 🟡 | 🟢 | 🔴 | Idle 60→15, new `AbsoluteExpirationMinutes: 60` |
| 🔴 | [src/SEBT.Portal.Core/AppSettings/JwtSettings.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-c6e4979a1c367b034775eb37794ef0360744fc083ae644a6b5ad2183369bf3bc) | New `AbsoluteExpirationMinutes`; default change | +20/−1 | 🟡 | 🟢 | 🔴 | New config key — verify Tofu/AppConfig overlays |
| 🔴 | [src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-d42fd0576b5f1c61df907b7e7ab2af6b4c96ce9300f4e60645d56f9f499fe469) | `auth_time` stamp/forward in `BuildAndSignToken` | +7/−0 | 🔴 | 🟡 | 🟡 | Carry-forward correctness gates the cap |
| 🔴 | [src/SEBT.Portal.UseCases/Auth/SessionLifetime/SessionLifetimePolicy.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-06ea3c9f42b15368fb977ad647784e4ff63d53e2f456df536504e080062d6d5b) | `Evaluate(principal) → Outcome` | 1–48 | 🔴 | 🟡 | 🔴 | Single source of truth for cap |
| 🔴 | [src/SEBT.Portal.Web/src/api/client.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-f783fb4ad201da3d4d6786745f0578368be248468930043380a23cde01239942) | 401 redirect broadened; `ApiError.isRedirecting` | +25/−5 | 🔴 | 🟢 | 🔴 | Any 401 except `/auth/status` redirects |
| 🔴 | [src/SEBT.Portal.Web/src/features/auth/idle/useSessionRefresh.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-76a3a02d56ffaa21366dca1fa9dbbd45f2f0a7a6fa7b7b695a91f0547a180d00) | Schedule at `min(idle, abs)`; idle gate skipped at cap | 1–85 | 🟡 | 🟡 | 🔴 | Asymmetric activity gate |
| 🔴 | [src/SEBT.Portal.Web/src/features/auth/idle/useUserActivity.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-d5b075e672774fd103ef00131293d8f00e9765f8013628f0ac178bb15e114c5a) | DOM-event tracker | 1–61 | 🟡 | 🟡 | 🔴 | Event set + 1s throttle |
| 🟡 | [src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-11a19c48b4bbd1f811ef5915d2bad4627ccab19ec17e8cdd847ea9634fe63197) | `/auth/status` returns new expiry fields | +9/−1 | 🟡 | 🟢 | 🟡 | Drives client scheduling |
| 🟡 | [src/SEBT.Portal.Api/Models/AuthorizationStatusResponse.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-8d59ad6c5a6dc02c0518b281e2d430216f60b5a2b25a8be824684da1370c08fc) | `ExpiresAt`, `AbsoluteExpiresAt` (nullable) | +13/−2 | 🟢 | 🟢 | 🟢 | Backward-compatible |
| 🟡 | [src/SEBT.Portal.Api/appsettings.Development.example.json](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-2081802a8792d4c0a2ab1ccaf2719ba6c731c13aa77dbb35ef47087bd72ca2c6) | Defaults mirror | +3/−1 | 🟢 | 🟢 | 🟡 | Dev/example mirror |
| 🟡 | [src/SEBT.Portal.Infrastructure/Configuration/JwtSettingsValidator.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-2215a4f48637f38717f24d389f039ffc4a55d1cf23ba6f9079a6d4a9b50f532b) | New cross-field validator | 1–31 | 🟡 | 🟢 | 🟡 | Enforces `Absolute ≥ Idle` |
| 🟡 | [src/SEBT.Portal.Infrastructure/Dependencies.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-5662853b974fc38d7693f59adfb695f42fb617c909d151f5d3686b8d8649b367) | Register `JwtSettingsValidator` | +1 | 🟢 | 🟢 | 🟢 | One-line DI |
| 🟡 | [src/SEBT.Portal.UseCases/Auth/RefreshToken/RefreshTokenCommandHandler.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-8305654172717c9d202761efbc7a059891473652ede9ae5aca5e97424277cca6) | Removed `CheckAbsoluteCap` (moved upstream) | +11/−0 | 🟡 | 🟢 | 🟡 | Single source of truth at bearer |
| 🟡 | [src/SEBT.Portal.UseCases/Dependencies.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-9b66748d627deb37ac2ce3971c063d6e939cb50db6ce04045d9befd6855f6e98) | Register policy + `TimeProvider.System` | +7/−0 | 🟢 | 🟢 | 🟡 | `TryAdd` so tests can swap clock |
| 🟡 | [src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-b9e5023fbe67680af0312e087503d4fdfec71434623321bb3364ab31bcb2de45) | Add `Microsoft.Extensions.Options 10.0.5` | +1 | 🟢 | 🟢 | 🟡 | Pinned to test-project transitive |
| 🟡 | [src/SEBT.Portal.Web/src/features/auth/api/auth-status/schema.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-77889752ed2f6a07b70280a9fbb0f142724030aca97621a482c4d3d4b429680a) | Zod fields for new expiries | +6/−2 | 🟢 | 🟢 | 🟢 | Mirrors server response |
| 🟡 | [src/SEBT.Portal.Web/src/features/auth/components/TokenRefresher/TokenRefresher.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-03b0d08b908ef089a01d961fd704e437f2682eb91fee1497c1e388ae7c96769f) | Rewrite as thin composer | +61/−47 | 🟡 | 🟢 | 🟡 | `IDLE_THRESHOLD_MS` mirrors server default |
| 🟡 | [src/SEBT.Portal.Web/src/features/auth/context/AuthContext.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-381b2c20467596c5fa38a755d288b2b0810dd7b8a51465bb6f25f0ffca71c020) | `SessionInfo` adds `expiresAt`, `absoluteExpiresAt` | +8/−2 | 🟢 | 🟢 | 🟢 | Plumbs new claims to UI |
| 🟡 | [src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-d85b7f5b3e567bd8680d863598ba509b554c990ab03780ad4c3bdc33635f1645) | Suppresses `isError` while `isRedirecting` | +9/−2 | 🟡 | 🟢 | 🟡 | Dashboard flash fix |
| 🟢 | [docs/adr/0014-session-idle-and-absolute-timeout.md](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-0d0074fc30a77ea7fcba8e987dd5982aab935994bf41d018aac7a67168d60699) | New ADR | 1–33 | 🟢 | 🟢 | 🟢 | OWASP / NIST refs, deploy consequences |
| 🟢 | Backend tests (6 files) | New / extended TDD coverage | +313/−0 | 🟢 | 🟢 | 🟢 | See "Test files (grouped)" below |
| 🟢 | Frontend tests (10 files) | New hook suites + adjustments | +394/−98 | 🟢 | 🟢 | 🟢 | See "Test files (grouped)" below |
| 🟢 | Trivial helpers (2 files) | Throttle util + idle/ barrel | +25 | 🟢 | 🟢 | 🟢 | Pure / re-exports |

### Summary by Priority

**🔴 Critical Review (8 items)**

- `Program.cs` `OnTokenValidated` — verify cookie cleared *before* `context.Fail`; policy resolved per-request from `RequestServices`; `OnMessageReceived` cookie-token bridge still works alongside.
- `appsettings.json` — new `AbsoluteExpirationMinutes` config key; verify no per-environment overlay (Tofu, AppConfig) raises `ExpirationMinutes` back above 15.
- `JwtSettings.cs` — defaults are tighter than NIST IAL2 ceilings (30 idle / 720 absolute); confirm acceptable.
- `JwtTokenService.cs` — fresh login stamps `auth_time`; refresh forwards inbound; OIDC IdP `auth_time` is filtered (we always use our portal-issued value).
- `SessionLifetimePolicy.cs` — verify `>=` boundary, missing-claim reject, non-numeric defensive case. Single source of truth for the cap.
- `client.ts` — broadened correctly (`!== '/auth/status'`); `isRedirecting` only set when `replace` was actually called (window present).
- `useSessionRefresh.ts` — `min(idleFire, absoluteFire)` math; idle gate skipped at the cap so an unattended tab still gets a clean kick.
- `useUserActivity.ts` — event set (`mousedown` / `keydown` / `touchstart` / `scroll` / `visibilitychange`) and 1s throttle.

**🟡 Recommended Review (12 items)**

Plumbing for the new expiry fields, the cross-field validator, the cap-check removal in `RefreshTokenCommandHandler`, the `TokenRefresher` rewrite, and the `useHouseholdData` redirect-suppression. Each is small individually but worth a quick read for correctness.

**🟢 Low Priority (20 items, grouped above)**

ADR, throttle utility, barrel, and 16 test files. Skim for coverage and the ADR for rationale; the test status-code swap (401 → 400) in `DashboardContent` / `CardSelection` is mechanical realignment with the new redirect path.

### Test files (grouped)

<details>
<summary>Backend tests (6 files, +313 lines)</summary>

| File | What |
| --- | --- |
| [Tests/Integration/AuthCookieAuthenticationTests.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-0a3cd220f3adb2bdadf69618a8582124fffc5eb7170974145d0303969204e06d) | Hand-built JWT fixture stamps `auth_time` (required by new bearer policy) |
| [Tests/Unit/Configuration/JwtSettingsValidatorTests.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-bdcb71f120b20f1c41857c9a13038f9110548cf70d8ecf077192a2941ec946ce) | Cross-field validator coverage |
| [Tests/Unit/Controllers/AuthControllerTests.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-3e3a896851ccdadaa87642b0c3d62614e005947981b542ac57c552e7e6ad939a) | `exp` / `auth_time` / `AbsoluteExpiresAt` cases |
| [Tests/Unit/Infrastructure/Services/BuildAndSignTokenTests.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-6e83bd0ae0f7f5c4215fa72587357bc17e07384f8489cfd961865029b59dbfe3) | `auth_time` stamp/forward cases |
| [Tests/Unit/UseCases/Auth/RefreshTokenCommandHandlerTests.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-fb3f8eb7d2690635816f6de2b972c17412ff1df7f6b2e84f606b510eaf9a8f5f) | Drop cap-check setup (cap moved upstream) |
| [Tests/Unit/UseCases/Auth/SessionLifetime/SessionLifetimePolicyTests.cs](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-2f60d0349d9c0d6c995bafbd893c4b6b32ce484b2bab60541a4cb62620f71db3) | Pure rule: valid / missing / non-numeric / boundary / past-cap |

</details>

<details>
<summary>Frontend tests (10 files, +394/−98 lines)</summary>

| File | What |
| --- | --- |
| [src/api/client.test.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-c96b11aac2df53274dd6ce7fce22d5e7b32777b031659b08adc04fe0946fe709) | 401 redirect + `isRedirecting` cases |
| [features/auth/components/TokenRefresher/TokenRefresher.test.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-99fd19769f2614fb72c4b320c85fab83de3ee4a373ad04ceb21b3034574c71d4) | Rewrite as thin composition test (substantive logic moved to hook tests) |
| [features/auth/context/AuthContext.test.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-6daa9e57c981d13bc464e0447d121cff00eb67f4eda69760c408077346c7facc) | New session fields in expectation |
| [features/auth/components/id-proofing/IdProofingWithDi.test.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-8792ef2375eeba0b655bd4e6db3ba70da6a81dbc0c826b82e3d9a261864962d2) | `SessionInfo` literal updated (compile-fix) |
| [src/lib/jwt.test.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-194405bfdab3e7f321aaedba98a9c6fef9b0c69c8d330fac0bbb089a41574770) | `SessionInfo` literal updated (compile-fix) |
| [features/auth/idle/throttle.test.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-5a10e0127b9ae635fb14f1f07ddf6faaa4c87f6854bc70bff3b56b2475b5a17e) | Throttle util coverage |
| [features/auth/idle/useSessionRefresh.test.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-ed2a0925071186af3fd31402e969c900b4e38da9fe33e727930e81197aeb020d) | Active / idle / cap / reschedule cases |
| [features/auth/idle/useUserActivity.test.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-bb53834a698a55cf08c07b7bf6d850ff72bd190f720a06e1115ff2ecf339a2cc) | Event-set + cleanup cases |
| [features/cards/components/CardSelection/CardSelection.test.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-0546ebad685b6d21c922a4e22f35c29df9b95a97a20fa67a5b16f21268765420) | Mocked status 401 → 400 (realigns with non-redirect path) |
| [features/household/api/useHouseholdData.test.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-a5cd6c6f8ed7a8b5b2559b489cbcc1b65493999c2990f6cc8dc34a9b6194f67a) | Asserts `isLoading` + redirect (suppression coverage) |
| [features/household/components/DashboardContent/DashboardContent.test.tsx](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-383512a03b0a8e210a449c6c7d7c4b60ad2454a2604de264d105f88096c20695) | Mocked status 401 → 400 (realigns with non-redirect path) |

</details>

<details>
<summary>Trivial helpers (2 files, +25 lines)</summary>

| File | What |
| --- | --- |
| [features/auth/idle/throttle.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-5745be90e7eb7b621bcaaab51e1980faa6f0f40be5ace8d1cafbb5b3c3e41807) | Pure leading-edge throttle util |
| [features/auth/idle/index.ts](https://github.com/codeforamerica/sebt-self-service-portal/pull/269/files#diff-d6ee0000ccdf22bfd82c2c8ef4014dbdfc08c892c6e4fbef37cf29349374d85b) | Barrel re-exports |

</details>

### Review Recommendation

Start with the ADR (`docs/adr/0014`, ~30 lines) for the design tree. Then walk the security perimeter: `SessionLifetimePolicy` → `Program.cs OnTokenValidated` → `JwtTokenService.cs`. Next the client redirect path: `client.ts` → `useHouseholdData.ts`. Then the scheduler: `useSessionRefresh.ts` and `useUserActivity.ts`. Verify defaults in `JwtSettings.cs` + `appsettings.json` match production policy. Tests can be skimmed — they're TDD coverage of the above; the 401→400 mock change in `DashboardContent`/`CardSelection` is intentional realignment with the new redirect path.

**Operational note**: existing in-flight sessions (issued before this deploy) lack `auth_time` and will be rejected by the bearer middleware on their next authenticated API call — effectively immediate for any open tab.

---

## Completion checklist

- [x] Backend unit tests (1115 pass; new `SessionLifetimePolicyTests`, `JwtSettingsValidatorTests`, plus `auth_time` cases in `BuildAndSignTokenTests` and `AuthControllerTests`)
- [x] Frontend unit tests (727 pass; new `throttle` / `useUserActivity` / `useSessionRefresh` suites; `TokenRefresher` rewritten as composition test; `apiFetch` 401 redirect cases; `useHouseholdData` redirect-suppress case)
- [x] Lint clean (0 errors)
- [x] ADR 0014 added
- [x] Manual browser verification: idle-out → 401 → redirect (no flash); absolute cap → redirect even when idle
- [ ] Confirm no per-environment override of `JwtSettings:ExpirationMinutes` raises it back above 15

## Test plan

- [x] Active session: refresh fires ~1 min before cookie expiry; `/auth/status` returns updated `expiresAt`
- [x] Idle session: no XHR polling after ~15 min; next interaction → 401 → redirect to `/login`
- [x] Active for 60+ min: rejected at absolute cap, redirected to `/login`, cookie cleared
- [x] Idle past absolute cap: timer fires at the cap, refresh attempt 401s, user lands on `/login` without needing to click
- [x] Pre-existing token (no `auth_time`): rejected on next authenticated request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DC-371]: https://codeforamerica.atlassian.net/browse/DC-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ