### PR TITLE
DC-361 - remove outdated id options for dc

### DIFF
--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/dc-id-options.ts
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/dc-id-options.ts
@@ -1,0 +1,61 @@
+import { type IdOption } from '@/features/auth'
+
+// DC-only: CO uses external auth and never reaches this route.
+export const DC_ID_OPTIONS: IdOption[] = [
+  {
+    value: 'ssn',
+    labelKey: 'optionLabelSsn',
+    inputLabelKey: 'labelSsn',
+    // SSN is federally 9 digits. Shared Zod schema also enforces this.
+    validation: { digits: 9 }
+  },
+  {
+    value: 'itin',
+    labelKey: 'optionLabelItin',
+    inputLabelKey: 'labelItin',
+    // ITIN is federally 9 digits. Shared Zod schema also enforces this.
+    validation: { digits: 9 }
+  },
+  {
+    value: 'snapAccountId',
+    labelKey: 'optionAccountId',
+    helperKey: 'optionHelperAccountId',
+    inputLabelKey: 'labelAccountId',
+    // DC CSV: "typically 7 or 8 digits long".
+    validation: { digits: [7, 8] }
+  },
+  {
+    value: 'none',
+    // Cross-namespace lookup: the label key "noneOfTheAbove" lives in the
+    // common namespace (sourced from CSV row "GLOBAL - Option - None of the
+    // above"). The form's useTranslation() targets the idProofing namespace,
+    // so the "common:" prefix tells i18next to resolve from common instead.
+    labelKey: 'common:noneOfTheAbove',
+    // No validation: "none of the above" skips the ID value input entirely.
+    dividerBefore: true
+  }
+]
+
+// For co-loaded users, the SNAP/TANF account ID is the Household lookup key in DC's CMS.
+export const DC_ID_OPTIONS_CO_LOADED: IdOption[] = [
+  {
+    value: 'snapAccountId',
+    labelKey: 'optionAccountId',
+    helperKey: 'optionHelperAccountId',
+    inputLabelKey: 'labelAccountId',
+    // DC CSV: "typically 7 or 8 digits long".
+    validation: { digits: [7, 8] }
+  },
+  {
+    value: 'itin',
+    labelKey: 'optionLabelItin',
+    inputLabelKey: 'labelItin',
+    // ITIN is federally 9 digits. Shared Zod schema also enforces this.
+    validation: { digits: 9 }
+  },
+  {
+    value: 'none',
+    labelKey: 'common:noneOfTheAbove',
+    dividerBefore: true
+  }
+]

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/page.tsx
@@ -22,26 +22,10 @@ const DC_ID_OPTIONS: IdOption[] = [
     validation: { digits: 9 }
   },
   {
-    value: 'medicaidId',
-    labelKey: 'optionLabelMedicaidId',
-    helperKey: 'optionHelperMedicaidId',
-    inputLabelKey: 'labelMedicaidId',
-    // DC CSV: "typically 7 or 8 digits long".
-    validation: { digits: [7, 8] }
-  },
-  {
     value: 'snapAccountId',
     labelKey: 'optionAccountId',
     helperKey: 'optionHelperAccountId',
     inputLabelKey: 'labelAccountId',
-    // DC CSV: "typically 7 or 8 digits long".
-    validation: { digits: [7, 8] }
-  },
-  {
-    value: 'snapPersonId',
-    labelKey: 'optionPersonId',
-    helperKey: 'optionHelperPersonId',
-    inputLabelKey: 'labelPersonId',
     // DC CSV: "typically 7 or 8 digits long".
     validation: { digits: [7, 8] }
   },

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/page.tsx
@@ -1,69 +1,10 @@
 'use client'
 
-import { type IdOption } from '@/features/auth'
 import { IdProofingWithDi } from '@/features/auth/components/id-proofing/IdProofingWithDi'
 import { getState, getStateLinks } from '@sebt/design-system'
 import { useTranslation } from 'react-i18next'
 
-// DC-only: CO uses external auth and never reaches this route.
-const DC_ID_OPTIONS: IdOption[] = [
-  {
-    value: 'ssn',
-    labelKey: 'optionLabelSsn',
-    inputLabelKey: 'labelSsn',
-    // SSN is federally 9 digits. Shared Zod schema also enforces this.
-    validation: { digits: 9 }
-  },
-  {
-    value: 'itin',
-    labelKey: 'optionLabelItin',
-    inputLabelKey: 'labelItin',
-    // ITIN is federally 9 digits. Shared Zod schema also enforces this.
-    validation: { digits: 9 }
-  },
-  {
-    value: 'snapAccountId',
-    labelKey: 'optionAccountId',
-    helperKey: 'optionHelperAccountId',
-    inputLabelKey: 'labelAccountId',
-    // DC CSV: "typically 7 or 8 digits long".
-    validation: { digits: [7, 8] }
-  },
-  {
-    value: 'none',
-    // Cross-namespace lookup: the label key "noneOfTheAbove" lives in the
-    // common namespace (sourced from CSV row "GLOBAL - Option - None of the
-    // above"). The form's useTranslation() targets the idProofing namespace,
-    // so the "common:" prefix tells i18next to resolve from common instead.
-    labelKey: 'common:noneOfTheAbove',
-    // No validation: "none of the above" skips the ID value input entirely.
-    dividerBefore: true
-  }
-]
-
-// For co-loaded users, the SNAP/TANF account ID is the Household lookup key in DC's CMS.
-const DC_ID_OPTIONS_CO_LOADED: IdOption[] = [
-  {
-    value: 'snapAccountId',
-    labelKey: 'optionAccountId',
-    helperKey: 'optionHelperAccountId',
-    inputLabelKey: 'labelAccountId',
-    // DC CSV: "typically 7 or 8 digits long".
-    validation: { digits: [7, 8] }
-  },
-  {
-    value: 'itin',
-    labelKey: 'optionLabelItin',
-    inputLabelKey: 'labelItin',
-    // ITIN is federally 9 digits. Shared Zod schema also enforces this.
-    validation: { digits: 9 }
-  },
-  {
-    value: 'none',
-    labelKey: 'common:noneOfTheAbove',
-    dividerBefore: true
-  }
-]
+import { DC_ID_OPTIONS, DC_ID_OPTIONS_CO_LOADED } from './dc-id-options'
 
 export default function IdProofingPage() {
   const state = getState()

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingWithDi.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingWithDi.test.tsx
@@ -1,13 +1,18 @@
 /**
  * Covers the option-set switching logic: co-loaded users see the narrower
- * co-loaded set; everyone else sees the full option list.
+ * co-loaded set; everyone else sees the full option list. Also pins the
+ * production DC option arrays so removed entries (medicaidId, snapPersonId)
+ * can't quietly come back.
  */
+import {
+  DC_ID_OPTIONS,
+  DC_ID_OPTIONS_CO_LOADED
+} from '@/app/(public)/login/id-proofing/dc-id-options'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '../../context'
-import type { IdOption } from './IdProofingForm'
 import { IdProofingWithDi } from './IdProofingWithDi'
 
 const TEST_CONTACT_LINK = 'https://example.com/contact'
@@ -25,22 +30,14 @@ vi.mock('@/features/auth/context', () => ({
   useAuth: () => mockUseAuth()
 }))
 
-const FULL_OPTIONS: IdOption[] = [
-  { value: 'ssn', labelKey: 'optionLabelSsn', inputLabelKey: 'labelSsn' },
-  { value: 'snapAccountId', labelKey: 'optionAccountId', inputLabelKey: 'labelAccountId' },
-  { value: 'snapPersonId', labelKey: 'optionPersonId', inputLabelKey: 'labelPersonId' }
-]
-
-const CO_LOADED_OPTIONS: IdOption[] = [
-  { value: 'snapAccountId', labelKey: 'optionAccountId', inputLabelKey: 'labelAccountId' },
-  { value: 'itin', labelKey: 'optionLabelItin', inputLabelKey: 'labelItin' },
-  { value: 'none', labelKey: 'optionLabelNone', dividerBefore: true }
-]
-
-const LABEL_SSN = 'Social Security Number (SSN)'
-const LABEL_ITIN = 'Individual Taxpayer ID Number (ITIN)'
-const LABEL_SNAP_ACCOUNT = 'SNAP or TANF account ID'
-const LABEL_SNAP_PERSON = 'SNAP or TANF person ID'
+// Helper-text decorated options (snapAccountId) extend the radio's accessible
+// name beyond the bold label, so we match on a regex anchored to the bold label.
+const LABEL_SSN = /Social Security Number \(SSN\)/
+const LABEL_ITIN = /Individual Taxpayer ID Number \(ITIN\)/
+const LABEL_SNAP_ACCOUNT = /SNAP or TANF account ID/
+const LABEL_SNAP_PERSON = /SNAP or TANF person ID/
+const LABEL_MEDICAID = /^Medicaid ID/
+const LABEL_NONE = /None of the above/
 
 function renderComponent() {
   const queryClient = new QueryClient({
@@ -49,8 +46,8 @@ function renderComponent() {
   return render(
     <QueryClientProvider client={queryClient}>
       <IdProofingWithDi
-        idOptions={FULL_OPTIONS}
-        coLoadedIdOptions={CO_LOADED_OPTIONS}
+        idOptions={DC_ID_OPTIONS}
+        coLoadedIdOptions={DC_ID_OPTIONS_CO_LOADED}
         contactLink={TEST_CONTACT_LINK}
       />
     </QueryClientProvider>
@@ -71,6 +68,11 @@ function session(isCoLoaded: boolean): SessionInfo {
 }
 
 describe('IdProofingWithDi', () => {
+  it('exposes only the approved DC ID option values (regression guard)', () => {
+    expect(DC_ID_OPTIONS.map((o) => o.value)).toEqual(['ssn', 'itin', 'snapAccountId', 'none'])
+    expect(DC_ID_OPTIONS_CO_LOADED.map((o) => o.value)).toEqual(['snapAccountId', 'itin', 'none'])
+  })
+
   it('renders the co-loaded option set with a divider before "None"', () => {
     mockUseAuth.mockReturnValue({ session: session(true) })
 
@@ -78,28 +80,25 @@ describe('IdProofingWithDi', () => {
 
     expect(screen.getByRole('radio', { name: LABEL_SNAP_ACCOUNT })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: LABEL_ITIN })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: LABEL_NONE })).toBeInTheDocument()
     expect(screen.queryByRole('radio', { name: LABEL_SSN })).not.toBeInTheDocument()
     expect(screen.queryByRole('radio', { name: LABEL_SNAP_PERSON })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: LABEL_MEDICAID })).not.toBeInTheDocument()
     expect(container.querySelector('hr')).toBeInTheDocument()
-  })
-
-  it('does not render a divider for the non-co-loaded option set', () => {
-    mockUseAuth.mockReturnValue({ session: session(false) })
-
-    const { container } = renderComponent()
-
-    expect(container.querySelector('hr')).not.toBeInTheDocument()
   })
 
   it('renders the full option set when session.isCoLoaded is false', () => {
     mockUseAuth.mockReturnValue({ session: session(false) })
 
-    renderComponent()
+    const { container } = renderComponent()
 
     expect(screen.getByRole('radio', { name: LABEL_SSN })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: LABEL_ITIN })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: LABEL_SNAP_ACCOUNT })).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: LABEL_SNAP_PERSON })).toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: LABEL_ITIN })).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: LABEL_NONE })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: LABEL_SNAP_PERSON })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: LABEL_MEDICAID })).not.toBeInTheDocument()
+    expect(container.querySelector('hr')).toBeInTheDocument()
   })
 
   it('renders the full option set when session is unknown', () => {
@@ -108,7 +107,10 @@ describe('IdProofingWithDi', () => {
     renderComponent()
 
     expect(screen.getByRole('radio', { name: LABEL_SSN })).toBeInTheDocument()
-    expect(screen.getByRole('radio', { name: LABEL_SNAP_PERSON })).toBeInTheDocument()
-    expect(screen.queryByRole('radio', { name: LABEL_ITIN })).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: LABEL_ITIN })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: LABEL_SNAP_ACCOUNT })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: LABEL_NONE })).toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: LABEL_SNAP_PERSON })).not.toBeInTheDocument()
+    expect(screen.queryByRole('radio', { name: LABEL_MEDICAID })).not.toBeInTheDocument()
   })
 })

--- a/src/SEBT.Portal.Web/src/mocks/handlers.ts
+++ b/src/SEBT.Portal.Web/src/mocks/handlers.ts
@@ -295,12 +295,6 @@ export const handlers = [
       })
     }
 
-    // Simulate step-up failure (canApply: false) with Medicaid ID for dev testing.
-    // In production, the backend determines canApply based on the user's enrollment pathway.
-    if (body.idType === 'medicaidId') {
-      return HttpResponse.json({ result: 'failed', canApply: false })
-    }
-
     // Default: identity matched
     return HttpResponse.json({ result: 'matched' })
   }),


### PR DESCRIPTION
## PR Description

#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-361

#### ✍️ Description
Trims the DC ID-proofing screen down to the four options DC wants users picking between: SSN, ITIN, SNAP/TANF account ID, and "None of the above." Drops the Medicaid ID and SNAP person ID entries from the non-co-loaded option list. The co-loaded list was already minimal and is unchanged.

The Zod schema (`IdTypeSchema`) and backend `IdProofingBenefitIdentifierTypes` still recognize the removed values defensively — they aren't user-facing surfaces, so leaving them avoids widening the blast radius beyond DC's UI.

Dead i18n keys for the dropped options remain in `dc.csv` until the content owner marks them `!N/A!` in the source sheet — generated locale JSONs aren't hand-edited.

#### 🔗 Links to related PRs
- None.

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
