### PR TITLE
DC-364 - Abbreviate known addresses for DC + Smarty client call fix

### DIFF
--- a/src/SEBT.Portal.Web/src/features/address/components/AddressAutocomplete/types.ts
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressAutocomplete/types.ts
@@ -25,8 +25,12 @@ export interface SelectedAddress {
   zipcode: string
 }
 
-/** Per-state comma-delimited, prioritized list of state abbreviations for Smarty's prefer_states parameter. */
+/** Per-state prioritized list of state abbreviations for Smarty's prefer_states parameter.
+ *  Semicolons rather than commas: the embedded key's dashboard config trips a validator on
+ *  any comma-delimited multi-value `*_states` input. Smarty parses semicolons equivalently
+ *  for prefer_states and include_only_states, so this delimiter swap preserves the bias
+ *  semantics while bypassing the dashboard bug. */
 export const STATE_PREFER_STATES: Record<string, string> = {
-  dc: 'DC,VA,MD',
+  dc: 'DC;VA;MD',
   co: 'CO'
 }

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressAutocomplete/useAddressAutocomplete.test.ts
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressAutocomplete/useAddressAutocomplete.test.ts
@@ -134,7 +134,7 @@ describe('useAddressAutocomplete', () => {
     await waitFor(() => {
       expect(capturedUrl).toBeTruthy()
       const url = new URL(capturedUrl)
-      expect(url.searchParams.get('prefer_states')).toBe('DC,VA,MD')
+      expect(url.searchParams.get('prefer_states')).toBe('DC;VA;MD')
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx
@@ -251,7 +251,20 @@ describe('AddressForm', () => {
     expect(errorMessages.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('shows inline error when street address exceeds 30 characters', async () => {
+  it('shows inline error when backend rejects an unabbreviatable long address', async () => {
+    server.use(
+      http.put('/api/household/address', () =>
+        HttpResponse.json(
+          {
+            status: 'invalid',
+            reason: 'too_long',
+            message: 'Enter a street address shorter than 30 characters.'
+          },
+          { status: 422 }
+        )
+      )
+    )
+
     const { user } = renderForm()
 
     await user.type(getStreetInput(), '1234567890 Northeast Pennsylvania Ave NW')
@@ -260,12 +273,27 @@ describe('AddressForm', () => {
     const submitButton = screen.getByRole('button', { name: /continue/i })
     await user.click(submitButton)
 
-    const inlineError = document.querySelector('.usa-error-message')
-    expect(inlineError).toBeInTheDocument()
-    expect(inlineError).toHaveTextContent(/shorter than 30 characters/i)
+    await waitFor(() => {
+      const inlineError = document.querySelector('.usa-error-message')
+      expect(inlineError).toBeInTheDocument()
+      expect(inlineError).toHaveTextContent(/shorter than 30 characters/i)
+    })
   })
 
-  it('shows page-level error alert with contact link when street address exceeds 30 characters', async () => {
+  it('shows page-level error alert with contact link when backend rejects an unabbreviatable long address', async () => {
+    server.use(
+      http.put('/api/household/address', () =>
+        HttpResponse.json(
+          {
+            status: 'invalid',
+            reason: 'too_long',
+            message: 'Enter a street address shorter than 30 characters.'
+          },
+          { status: 422 }
+        )
+      )
+    )
+
     const { user } = renderForm()
 
     await user.type(getStreetInput(), '1234567890 Northeast Pennsylvania Ave NW')
@@ -274,13 +302,51 @@ describe('AddressForm', () => {
     const submitButton = screen.getByRole('button', { name: /continue/i })
     await user.click(submitButton)
 
-    const siteAlerts = document.getElementById('site-alerts')!
-    expect(siteAlerts.textContent).toContain('issue with the address')
+    await waitFor(() => {
+      const siteAlerts = document.getElementById('site-alerts')!
+      expect(siteAlerts.textContent).toContain('issue with the address')
+    })
 
+    const siteAlerts = document.getElementById('site-alerts')!
     const contactLink = siteAlerts.querySelector('a.usa-link')
     expect(contactLink).toBeInTheDocument()
     expect(contactLink).toHaveTextContent(/contact us/i)
     expect(contactLink).toHaveAttribute('href', expect.stringContaining('contact'))
+  })
+
+  it('routes to Suggested Address when backend returns an abbreviation for a long DC street', async () => {
+    server.use(
+      http.put('/api/household/address', () => {
+        return HttpResponse.json(
+          {
+            status: 'suggestion',
+            reason: 'abbreviated',
+            suggestedAddress: {
+              streetAddress1: '2100 MLK JR Avenue SE',
+              streetAddress2: null,
+              city: 'Washington',
+              state: 'DC',
+              postalCode: '20020'
+            }
+          },
+          { status: 422 }
+        )
+      })
+    )
+
+    const { user } = renderForm()
+
+    // 36 chars: longer than the 30-char DC limit, abbreviates to "2100 MLK JR Avenue SE" (21).
+    await user.type(getStreetInput(), '2100 Martin Luther King Jr Avenue SE')
+    await user.clear(getPostalInput())
+    await user.type(getPostalInput(), '20020')
+
+    const submitButton = screen.getByRole('button', { name: /continue/i })
+    await user.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/profile/address/suggested-address')
+    })
   })
 
   it('allows street address of exactly 30 characters', async () => {

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
@@ -92,12 +92,6 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
 
     if (!streetAddress1.trim()) {
       errors.streetAddress1 = required
-    } else if (streetAddress1.trim().length > 30) {
-      // TODO: Backend does not yet enforce this limit — add [MaxLength(30)] when confirmed
-      errors.streetAddress1 = t(
-        'streetAddressTooLong',
-        'Enter a street address shorter than 30 characters.'
-      )
     }
     if (!city.trim()) errors.city = required
     if (!stateValue.trim()) errors.state = required
@@ -138,7 +132,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
         return
       }
 
-      // too_long stays on the form with inline + banner errors
+      // too_long stays on the form: inline field error + portal banner via showStreetLengthAlert.
       if (result.reason === 'too_long') {
         setFieldErrors({
           streetAddress1: t(
@@ -146,7 +140,6 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
             'Enter a street address shorter than 30 characters'
           )
         })
-        setSubmitError('too_long')
         return
       }
 


### PR DESCRIPTION
## PR Description

#### 🔗 Jira ticket
[DC-364](https://codeforamerica.atlassian.net/browse/DC-364)

#### ✍️ Description
Restores the DC street-address abbreviation flow that has been silently broken since the DC-152 restore. Two changes: (1) removes the client-side 30-character gate in the Update Mailing Address form so any length flows through to the API, where `AddressValidationService` either returns an abbreviated suggestion (e.g., `Martin Luther King Jr Ave SE` → `MLK JR Ave SE`) or a structured rejection. (2) Switches the Smarty US Autocomplete Pro `prefer_states` delimiter for DC from comma to semicolon — the embedded key's dashboard config rejects comma-delimited multi-value `*_states` input; Smarty parses semicolons equivalently and biasing semantics are preserved.

Backend `AddressValidationData` (blocked addresses, abbreviation map, 30-char limit) must be populated in the DC AWS AppConfig "AppSettings" profile for the abbreviation flow to be functional in deployed environments. The shape mirrors `src/SEBT.Portal.Api/appsettings.dc.example.json:23-40`. Local dev reads from gitignored `appsettings.dc.json`; deployed reads from AppConfig.

#### 🔗 Links to related PRs
- *(none — single-repo PR)*

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

- **Branch:** `fix/DC-364-abbreviate-known-addresses-dc` -> `main`
- **Risk Level:** Medium

Files changed:
- `src/SEBT.Portal.Web/src/features/address/components/AddressAutocomplete/types.ts` (modified)
- `src/SEBT.Portal.Web/src/features/address/components/AddressAutocomplete/useAddressAutocomplete.test.ts` (modified)
- `src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx` (modified)
- `src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx` (modified)

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `AddressAutocomplete/types.ts` | `STATE_PREFER_STATES.dc` | Low | Low | Med | semicolon delimiter workaround |
| 🟢 | `AddressAutocomplete/useAddressAutocomplete.test.ts` | `passes prefer_states based on stateCode` | Low | Low | Low | |
| 🟢 | `AddressForm/AddressForm.test.tsx` | new + reworked too_long tests | Low | Low | Low | new abbreviation suggestion test |
| 🟢 | `AddressForm/AddressForm.tsx` | `validate()` | Low | Low | Low | client length-gate removed |
| 🟢 | `AddressForm/AddressForm.tsx` | `handleSubmit` too_long branch | Low | Low | Low | drops setSubmitError flag |

### High-priority items

1. **`STATE_PREFER_STATES.dc` value** (`AddressAutocomplete/types.ts:30`) — verify Smarty parses semicolon-delimited values for `prefer_states` and that biasing semantics are preserved. The change is `'DC,VA,MD'` → `'DC;VA;MD'`. The wrapping comment explains the upstream config trigger; the parameter shape is the only thing reviewers should confirm against Smarty's API behavior, since no other code path constructs `*_states` parameters.
2. **`AddressForm.validate()`** (`AddressForm/AddressForm.tsx:89-110`) — the previous client-side rejection of street addresses longer than 30 characters is removed. Long input now flows to `PUT /api/household/address`. Verify the backend handler `UpdateAddressCommandHandler.Handle` (`src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs:84-91`) returns `AddressValidationResult.Suggestion(...)` with `reason: "abbreviated"` for inputs that match `StreetAbbreviations` after Smarty normalization, and that the resulting 422 response shape matches `AddressUpdateResponseSchema` (`src/SEBT.Portal.Web/src/features/address/api/schema.ts:51-56`).
3. **`handleSubmit` `too_long` branch** (`AddressForm/AddressForm.tsx:133-141`) — `setSubmitError('too_long')` was removed. The portal-rendered alert that displays "There was an issue with the address provided…" is now driven solely by `showStreetLengthAlert = hasErrors && streetAddress1.trim().length > 30` (line 161). Verify the inline field error and portal alert both render when the backend returns `reason: "too_long"`.
4. **`AddressValidationData` in AWS AppConfig (DC dev)** — the deployed API container ships only the base `appsettings.json` with empty defaults for `BlockedAddresses`, `StreetAbbreviations`, and `MaxStreetAddressLength: 0`. The DC "AppSettings" AppConfig profile is the override. Confirm the profile contains the block matching `appsettings.dc.example.json:23-40` before merging, otherwise the abbreviation feature is reachable but inert in deployed dev.

### Test coverage notes

- New test in `AddressForm.test.tsx` (`routes to Suggested Address when backend returns an abbreviation for a long DC street`) mocks `PUT /api/household/address` with a 422 `{ status: "suggestion", reason: "abbreviated", suggestedAddress: {...} }` and asserts `mockPush` was called with `/profile/address/suggested-address`.
- Two existing tests (`shows inline error when backend rejects an unabbreviatable long address` and `shows page-level error alert with contact link…`) now mock a 422 `{ status: "invalid", reason: "too_long", … }` instead of relying on the removed client-side gate; assertions on inline error text and portal banner copy still hold.
- `useAddressAutocomplete.test.ts:137` assertion updated from `'DC,VA,MD'` to `'DC;VA;MD'`.
- Backend unit tests (`AddressValidationServiceTests.cs`, 17 tests) exercise the abbreviation map, blocked-address normalization, and 30-char enforcement against in-memory configured settings; they do not exercise AppConfig binding.
- End-to-end coverage with the real Smarty US Street Address API (server-side validate/normalize on submit) and AppConfig-bound settings is not exercised by automated tests; manual verification against deployed dev is required after the AppConfig profile is updated.


[DC-364]: https://codeforamerica.atlassian.net/browse/DC-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ