### PR TITLE
DC-148: load Mixpanel via the official boot snippet

### DIFF
--- a/packages/analytics/src/mixpanel-bridge.ts
+++ b/packages/analytics/src/mixpanel-bridge.ts
@@ -83,7 +83,11 @@ function attachBridge(dl: DataLayerRoot): () => void {
 
 export function initMixpanelBridge(token: string): () => void {
   const mp = window.mixpanel
-  if (!mp?.init || !mp?.track) {
+  // Only `init` is required up-front. The official Mixpanel boot snippet
+  // defines `init` immediately on the queue stub but only attaches `track`
+  // (and the rest of the API surface) the first time `init()` is called —
+  // checking for `track` here would always fail and never bootstrap the SDK.
+  if (!mp?.init) {
     return () => {}
   }
 

--- a/src/SEBT.Portal.Web/src/components/MixpanelAnalytics.test.tsx
+++ b/src/SEBT.Portal.Web/src/components/MixpanelAnalytics.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { initMixpanelBridge } = vi.hoisted(() => ({
+  initMixpanelBridge: vi.fn(() => () => {})
+}))
+vi.mock('@sebt/analytics', () => ({ initMixpanelBridge }))
+
+// Capture the props next/script receives so we can assert the wiring without
+// actually executing Mixpanel's boot snippet (which appends real <script>
+// tags to the DOM and is brittle under React's strict-mode double render).
+const scriptProps: {
+  html?: string | undefined
+  onReady?: (() => void) | undefined
+} = {}
+vi.mock('next/script', () => ({
+  default: ({
+    dangerouslySetInnerHTML,
+    onReady
+  }: {
+    dangerouslySetInnerHTML?: { __html: string }
+    onReady?: () => void
+  }) => {
+    scriptProps.html = dangerouslySetInnerHTML?.__html
+    scriptProps.onReady = onReady
+    return null
+  }
+}))
+
+import { MixpanelAnalytics } from './MixpanelAnalytics'
+
+afterEach(() => {
+  initMixpanelBridge.mockClear()
+  scriptProps.html = undefined
+  scriptProps.onReady = undefined
+})
+
+describe('MixpanelAnalytics', () => {
+  it('inlines the Mixpanel boot snippet so window.mixpanel is defined before the CDN lib loads', () => {
+    render(<MixpanelAnalytics token="test-token" />)
+
+    // The CDN script alone never defines `window.mixpanel`. Without the snippet
+    // pre-defining the queue stub, the bridge silently no-ops and any mixpanel.*
+    // call hits "object not initialized".
+    expect(scriptProps.html).toContain('window.mixpanel=a')
+    expect(scriptProps.html).toContain('cdn.mxpnl.com/libs/mixpanel-2-latest.min.js')
+  })
+
+  it('calls initMixpanelBridge with the provided token after the snippet is ready', () => {
+    render(<MixpanelAnalytics token="test-token" />)
+    scriptProps.onReady?.()
+
+    expect(initMixpanelBridge).toHaveBeenCalledWith('test-token')
+  })
+
+  it('does not initialize the bridge before the snippet has executed', () => {
+    render(<MixpanelAnalytics token="test-token" />)
+    expect(initMixpanelBridge).not.toHaveBeenCalled()
+  })
+})

--- a/src/SEBT.Portal.Web/src/components/MixpanelAnalytics.tsx
+++ b/src/SEBT.Portal.Web/src/components/MixpanelAnalytics.tsx
@@ -9,9 +9,19 @@ interface MixpanelAnalyticsProps {
   nonce?: string
 }
 
+// Mixpanel's official boot snippet: defines `window.mixpanel` as a queue stub
+// (with init/track/etc. already attached) and asynchronously loads the full
+// library, which replays the queued calls once it executes. Pulling in the
+// CDN script directly skips this stub, so any caller that touches `mixpanel.*`
+// before the library finishes loading hits "object not initialized".
+// Source: https://docs.mixpanel.com/docs/quickstart/install-mixpanel#javascript
+const MIXPANEL_BOOT_SNIPPET = `(function(c,a){if(!a.__SV){var b=window;try{var d,m,j,k=b.location,f=k.hash;d=function(a,b){return(m=a.match(RegExp(b+"=([^&]*)")))?m[1]:null};f&&d(f,"state")&&(j=JSON.parse(decodeURIComponent(d(f,"state"))),"mpeditor"===j.action&&(b.sessionStorage.setItem("_mpcehash",f),history.replaceState(j.desiredHash||"",c.title,k.pathname+k.search)))}catch(n){}var l,h;window.mixpanel=a;a._i=[];a.init=function(b,d,g){function c(b,i){var a=i.split(".");2==a.length&&(b=b[a[0]],i=a[1]);b[i]=function(){b.push([i].concat(Array.prototype.slice.call(arguments,0)))}}var e=a;"undefined"!==typeof g?e=a[g]=[]:g="mixpanel";e.people=e.people||[];e.toString=function(b){var a="mixpanel";"mixpanel"!==g&&(a+="."+g);b||(a+=" (stub)");return a};e.people.toString=function(){return e.toString(1)+".people (stub)"};l="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");for(h=0;h<l.length;h++)c(e,l[h]);var f="set set_once union unset remove delete".split(" ");e.get_group=function(){function a(c){b[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));e.push([d,call2])}}for(var b={},d=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<f.length;c++)a(f[c]);return b};a._i.push([b,d,g])};a.__SV=1.5;b=c.createElement("script");b.type="text/javascript";b.async=!0;b.src="https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";d=c.getElementsByTagName("script")[0];d.parentNode.insertBefore(b,d)}})(document,window.mixpanel||[]);`
+
 export function MixpanelAnalytics({ token, nonce }: MixpanelAnalyticsProps) {
   const teardownRef = useRef<(() => void) | null>(null)
 
+  // Detach the bridge's DOM listeners on unmount so they don't leak across
+  // hot reloads / route changes that remount the analytics root.
   useEffect(() => {
     return () => {
       teardownRef.current?.()
@@ -19,15 +29,16 @@ export function MixpanelAnalytics({ token, nonce }: MixpanelAnalyticsProps) {
     }
   }, [token])
 
-  const scriptProps = {
-    src: 'https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js',
-    strategy: 'afterInteractive' as const,
-    nonce,
-    onLoad: () => {
-      if (teardownRef.current) return
-      teardownRef.current = initMixpanelBridge(token)
-    }
-  }
-
-  return <Script {...scriptProps} />
+  return (
+    <Script
+      id="mixpanel-boot-snippet"
+      strategy="afterInteractive"
+      nonce={nonce}
+      dangerouslySetInnerHTML={{ __html: MIXPANEL_BOOT_SNIPPET }}
+      onReady={() => {
+        if (teardownRef.current) return
+        teardownRef.current = initMixpanelBridge(token)
+      }}
+    />
+  )
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-148

#### ✍️ Description
Fixes the runtime error \`Mixpanel error: \"mixpanel\" object not initialized\` reported in dev across CO and DC.

**Root cause**: \`MixpanelAnalytics\` was loading the Mixpanel CDN library directly with \`<Script src=\"…mixpanel-2-latest.min.js\">\`. The library by itself never assigns \`window.mixpanel\` — that's the job of Mixpanel's official boot snippet, which pre-defines a queue stub on \`window.mixpanel\` and then asynchronously loads the lib (which upgrades the stub on execution). Skipping the snippet meant \`window.mixpanel\` stayed undefined, the bridge's gate \`if (!mp?.init || !mp?.track)\` silently no-op'd, and any later \`mixpanel.*\` call fell into the lib's \"not initialized\" complaint.

**Fix**:
- \`MixpanelAnalytics.tsx\` now inlines Mixpanel's official boot snippet via \`<Script dangerouslySetInnerHTML>\` (CSP-friendly with the existing \`nonce\` prop). The snippet itself loads the CDN script asynchronously, so the explicit \`src=\"…\"\` is gone.
- \`mixpanel-bridge.ts\` gate relaxes from \`!mp?.init || !mp?.track\` to \`!mp?.init\`. The snippet defines \`init\` immediately on the queue stub but only attaches \`track\` (and the rest of the API surface) the first time \`init()\` runs — checking for \`track\` up-front would always fail and never bootstrap the SDK.
- New \`MixpanelAnalytics.test.tsx\` locks the wiring against regression: asserts the inline snippet contains the queue-stub assignment and the CDN URL, asserts \`initMixpanelBridge\` is called only after \`onReady\`, and asserts the token is forwarded.

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks
- [x] Added relevant tests (3 new + full portal suite 748/748, analytics package 92/92)
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu — n/a
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — n/a
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — n/a
  - [ ] If appsetttings are changed, update in AWS AppConfig — n/a

#### Validation
Local repro: dev server with \`NEXT_PUBLIC_MIXPANEL_TOKEN\` set → before this PR, the console emits \"mixpanel object not initialized\" on every page load. After this PR, the console is clean and Mixpanel's debug view shows incoming events.