### PR TITLE
DC-376: render SignOutLink on populated dashboard when userProfile is null

### DIFF
--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -216,6 +216,25 @@ describe('DashboardContent', () => {
     expect(screen.getByRole('link', { name: /logout|sign out/i })).toBeInTheDocument()
   })
 
+  it('renders sign-out link on the populated dashboard when userProfile is missing', async () => {
+    // DC's vw_HouseholdCases view does not surface guardian-name columns, so
+    // a fully populated DC household resolves with userProfile=null. The card
+    // returns null in that case; without a fallback the user has no logout.
+    server.use(
+      http.get('/api/household/data', () => {
+        return HttpResponse.json({ ...TEST_HOUSEHOLD_DATA, userProfile: null })
+      })
+    )
+
+    renderWithProviders(<DashboardContent />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Sophia Martinez')).toBeInTheDocument()
+    })
+
+    expect(screen.getByRole('link', { name: /logout|sign out/i })).toBeInTheDocument()
+  })
+
   it('renders sign-out link on 404', async () => {
     server.use(
       http.get('/api/household/data', () => {

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -124,7 +124,7 @@ export function DashboardContent() {
       {pageHeading}
       <DashboardAlerts />
       <ActionButtons allowedActions={data.allowedActions} />
-      <UserProfileCard />
+      {data.userProfile ? <UserProfileCard /> : <SignOutLink />}
       <HouseholdSummary />
       <EnrolledChildren />
       <EbtEdgeSection />


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-376

#### ✍️ Description
P1 fix: a logged-in DC user with cases/applications saw the dashboard but no logout link anywhere on the page.

**Root cause** — three layers, only the third is fixable here:

1. DC's `vw_HouseholdCases` view does not surface guardian-name columns (`GuardianFirstName/MiddleName/LastName`).
2. `DcSummerEbtCaseService.ResolveUserProfile` consequently returns `null`, so the API responds with `userProfile: null` for every populated DC household.
3. `DashboardContent` happy-path branch rendered `<UserProfileCard />` unconditionally; that card returns `null` when `userProfile` is missing — and unlike the empty/error branches, the happy path had no `<SignOutLink />` fallback.

**Fix** — mirror the empty-branch ternary into the happy-path branch:

```tsx
- <UserProfileCard />
+ {data.userProfile ? <UserProfileCard /> : <SignOutLink />}
```

This pattern was introduced in DC-234 (commit `4982a627`, *"OIDC RP-Initiated Logout + sign-out visibility fix"*) for the error and empty branches; the happy path was missed. This PR closes that gap.

**Out of scope (separate ticket worth filing):** plumbing guardian name into DC's data path so `<UserProfileCard />` actually renders with a name on DC. Either (a) add `Guardian*` columns to DC's `vw_HouseholdCases`, or (b) derive the guardian name from PingOne userinfo claims on the connector side. That's a feature, not a P1.

#### 🔗 Links to related PRs
None — frontend-only change.

#### ✅ Completion tasks
- [x] Added relevant tests (1 regression test asserting SignOutLink renders on the populated dashboard when `userProfile` is null; full suite 749/749 passing)
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu — n/a
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — n/a
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — n/a
  - [ ] If appsetttings are changed, update in AWS AppConfig — n/a