### PR TITLE
DC-359(Bug): Fix Update Address

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
@@ -100,7 +100,20 @@ public class HouseholdController : ControllerBase
             {
                 if (validationResult.IsValid)
                 {
-                    return Ok(new AddressUpdateResponse { Status = "valid" });
+                    return Ok(new AddressUpdateResponse
+                    {
+                        Status = "valid",
+                        NormalizedAddress = validationResult.NormalizedAddress != null
+                            ? new AddressResponse
+                            {
+                                StreetAddress1 = validationResult.NormalizedAddress.StreetAddress1,
+                                StreetAddress2 = validationResult.NormalizedAddress.StreetAddress2,
+                                City = validationResult.NormalizedAddress.City,
+                                State = validationResult.NormalizedAddress.State,
+                                PostalCode = validationResult.NormalizedAddress.PostalCode
+                            }
+                            : null
+                    });
                 }
 
                 var response = new AddressUpdateResponse

--- a/src/SEBT.Portal.Api/Models/Household/AddressUpdateResponse.cs
+++ b/src/SEBT.Portal.Api/Models/Household/AddressUpdateResponse.cs
@@ -25,6 +25,12 @@ public record AddressUpdateResponse
     public string? Message { get; init; }
 
     /// <summary>
+    /// The normalized address that was persisted when Status is "valid".
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public AddressResponse? NormalizedAddress { get; init; }
+
+    /// <summary>
     /// A suggested alternative address (e.g., abbreviated street for DC 30-char limit,
     /// or a Smarty-corrected address). Present only when Status is "suggestion".
     /// </summary>

--- a/src/SEBT.Portal.Web/src/features/address/api/client.ts
+++ b/src/SEBT.Portal.Web/src/features/address/api/client.ts
@@ -34,9 +34,9 @@ export function useUpdateAddress() {
 
   return useMutation({
     mutationFn: updateAddress,
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       if (result.status === 'valid') {
-        queryClient.invalidateQueries({ queryKey: ['householdData'] })
+        await queryClient.invalidateQueries({ queryKey: ['householdData'] })
       }
     },
     retry: (failureCount, error) => {

--- a/src/SEBT.Portal.Web/src/features/address/api/schema.ts
+++ b/src/SEBT.Portal.Web/src/features/address/api/schema.ts
@@ -52,6 +52,7 @@ export const AddressUpdateResponseSchema = z.object({
   status: z.enum(['valid', 'invalid', 'suggestion']),
   reason: z.string().nullable().optional(),
   message: z.string().nullable().optional(),
+  normalizedAddress: AddressResponseSchema.nullable().optional(),
   suggestedAddress: AddressResponseSchema.nullable().optional()
 })
 

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.integration.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.integration.test.tsx
@@ -20,7 +20,9 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
     back: vi.fn()
-  })
+  }),
+  usePathname: () => '/profile/address',
+  useSearchParams: () => new URLSearchParams()
 }))
 
 vi.mock('@sebt/design-system', async (importOriginal) => {

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.integration.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.integration.test.tsx
@@ -9,7 +9,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 import { describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/mocks/server'
 
 import { AddressFlowProvider, useAddressFlow } from '../../context'
 import { AddressForm } from './AddressForm'
@@ -99,6 +102,50 @@ describe('AddressForm integration', () => {
       expect(contextData.city).toBe('Washington')
       expect(contextData.state).toBe('DC')
       expect(contextData.postalCode).toBe('20001')
+    })
+  })
+
+  it('stores normalized address from API response in context', async () => {
+    server.use(
+      http.put('/api/household/address', () =>
+        HttpResponse.json({
+          status: 'valid',
+          normalizedAddress: {
+            streetAddress1: '456 K ST NW',
+            streetAddress2: null,
+            city: 'WASHINGTON',
+            state: 'DC',
+            postalCode: '20001-1234'
+          }
+        })
+      )
+    )
+
+    const queryClient = createTestQueryClient()
+    const user = userEvent.setup()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AddressFlowProvider>
+          <AddressForm initialAddress={null} />
+          <ContextSpy />
+        </AddressFlowProvider>
+      </QueryClientProvider>
+    )
+
+    const streetInput = screen.getByRole('textbox', { name: /^street address(?! line)/i })
+    const postalInput = screen.getByRole('textbox', { name: /zip code/i })
+
+    await user.type(streetInput, '456 K St NW')
+    await user.type(postalInput, '20001')
+    await user.click(screen.getByRole('button', { name: /continue/i }))
+
+    await waitFor(() => {
+      const spy = screen.getByTestId('context-spy')
+      const contextData = JSON.parse(spy.textContent!)
+      expect(contextData.streetAddress1).toBe('456 K ST NW')
+      expect(contextData.city).toBe('WASHINGTON')
+      expect(contextData.postalCode).toBe('20001-1234')
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx
@@ -17,7 +17,9 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
     back: mockBack
-  })
+  }),
+  usePathname: () => '/profile/address',
+  useSearchParams: () => new URLSearchParams()
 }))
 
 let mockState = 'dc'

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
@@ -58,8 +58,10 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
   const { t: tValidation } = useTranslation('validation')
   const { t: tCommon } = useTranslation('common')
   const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
   const updateAddress = useUpdateAddress()
-  const { setAddress, setValidationResult } = useAddressFlow()
+  const { setAddress, setValidationResult, setNavigationTargets } = useAddressFlow()
   const errorSummaryRef = useRef<HTMLDivElement>(null)
 
   const currentState = getState()
@@ -85,6 +87,15 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
       errorSummaryRef.current?.focus()
     }
   }, [hasErrors])
+
+  useEffect(() => {
+    const currentQuery = searchParams.toString()
+    const formPath = currentQuery ? `${pathname}?${currentQuery}` : pathname
+    setNavigationTargets({
+      formPath,
+      continuePath: redirectPath ?? DEFAULT_REDIRECT
+    })
+  }, [pathname, redirectPath, searchParams, setNavigationTargets])
 
   function validate(): FieldErrors {
     const errors: FieldErrors = {}

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
@@ -10,6 +10,7 @@ import { Alert, Button, InputField, getState, getStateLinks } from '@sebt/design
 import type { Address } from '@/features/household/api'
 
 import { isValidZip, useUpdateAddress } from '../../api'
+import type { AddressResponse, UpdateAddressRequest } from '../../api/schema'
 import { useAddressFlow } from '../../context'
 import { AddressAutocomplete, type SelectedAddress } from '../AddressAutocomplete'
 import { STATE_ABBREVIATIONS, US_STATE_OPTIONS } from './usStates'
@@ -52,6 +53,22 @@ function resolveStateValue(value: string | null | undefined, fallback: string): 
 }
 
 const DEFAULT_REDIRECT = '/profile/address/replacement-cards'
+
+function toUpdateAddressRequestOrNull(
+  address: AddressResponse | null | undefined
+): UpdateAddressRequest | null {
+  if (!address?.streetAddress1 || !address.city || !address.state || !address.postalCode) {
+    return null
+  }
+
+  return {
+    streetAddress1: address.streetAddress1,
+    streetAddress2: address.streetAddress2 ?? undefined,
+    city: address.city,
+    state: address.state,
+    postalCode: address.postalCode
+  }
+}
 
 export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) {
   const { t } = useTranslation('confirmInfo')
@@ -138,7 +155,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
       const result = await updateAddress.mutateAsync(addressData)
 
       if (result.status === 'valid') {
-        setAddress(addressData)
+        setAddress(toUpdateAddressRequestOrNull(result.normalizedAddress) ?? addressData)
         router.push(redirectPath ?? DEFAULT_REDIRECT)
         return
       }

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressNotFound/AddressNotFound.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressNotFound/AddressNotFound.test.tsx
@@ -56,16 +56,23 @@ const TEST_VALIDATION_RESULT: AddressUpdateResponse = {
 function ContextSeeder({
   enteredAddress,
   validationResult,
-  includeInspector = false
+  includeInspector = false,
+  formPath,
+  continuePath
 }: {
   enteredAddress: UpdateAddressRequest
   validationResult: AddressUpdateResponse
   includeInspector?: boolean
+  formPath?: string
+  continuePath?: string
 }) {
-  const { setValidationResult } = useAddressFlow()
+  const { setValidationResult, setNavigationTargets } = useAddressFlow()
 
   useEffect(() => {
     setValidationResult(validationResult, enteredAddress)
+    if (formPath && continuePath) {
+      setNavigationTargets({ formPath, continuePath })
+    }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
@@ -92,7 +99,11 @@ function ContextInspector() {
 function renderComponent(
   enteredAddress: UpdateAddressRequest = TEST_ADDRESS,
   validationResult: AddressUpdateResponse = TEST_VALIDATION_RESULT,
-  { includeInspector = false }: { includeInspector?: boolean } = {}
+  {
+    includeInspector = false,
+    formPath,
+    continuePath
+  }: { includeInspector?: boolean; formPath?: string; continuePath?: string } = {}
 ) {
   const user = userEvent.setup()
   return {
@@ -103,6 +114,8 @@ function renderComponent(
           enteredAddress={enteredAddress}
           validationResult={validationResult}
           includeInspector={includeInspector}
+          {...(formPath ? { formPath } : {})}
+          {...(continuePath ? { continuePath } : {})}
         />
       </AddressFlowProvider>
     )
@@ -211,6 +224,19 @@ describe('AddressNotFound', () => {
       expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
     })
 
+    it('CO: "Use this address" uses context continuePath when configured', async () => {
+      mockState = 'co'
+      const { user } = renderComponent(TEST_ADDRESS, TEST_VALIDATION_RESULT, {
+        formPath: '/cards/replace/address?case=SEBT-001',
+        continuePath: '/cards/replace/confirm?case=SEBT-001'
+      })
+
+      const useButton = screen.getByRole('button', { name: /use this address/i })
+      await user.click(useButton)
+
+      expect(mockPush).toHaveBeenCalledWith('/cards/replace/confirm?case=SEBT-001')
+    })
+
     it('CO: "Use this address" preserves validationResult in context (prevents FlowGuard race)', async () => {
       mockState = 'co'
       const { user } = renderComponent(TEST_ADDRESS, TEST_VALIDATION_RESULT, {
@@ -235,6 +261,18 @@ describe('AddressNotFound', () => {
     await user.click(editButton)
 
     expect(mockPush).toHaveBeenCalledWith('/profile/address')
+  })
+
+  it('"Edit the address" uses context formPath when configured', async () => {
+    const { user } = renderComponent(TEST_ADDRESS, TEST_VALIDATION_RESULT, {
+      formPath: '/cards/replace/address?case=SEBT-001',
+      continuePath: '/cards/replace/confirm?case=SEBT-001'
+    })
+
+    const editButton = screen.getByRole('button', { name: /edit the address/i })
+    await user.click(editButton)
+
+    expect(mockPush).toHaveBeenCalledWith('/cards/replace/address?case=SEBT-001')
   })
 
   // --- Blocked address ---

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressNotFound/AddressNotFound.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressNotFound/AddressNotFound.tsx
@@ -8,24 +8,29 @@ import { Alert, Button, getState, getStateLinks } from '@sebt/design-system'
 
 import { useAddressFlow } from '../../context'
 
-const DEFAULT_REDIRECT = '/profile/address/replacement-cards'
-
 export function AddressNotFound() {
   const { t } = useTranslation('confirmInfo')
   const router = useRouter()
   const currentState = getState()
-  const { enteredAddress, validationResult, setAddress, clearValidationResult } = useAddressFlow()
+  const {
+    enteredAddress,
+    validationResult,
+    setAddress,
+    clearValidationResult,
+    continuePath,
+    formPath
+  } = useAddressFlow()
   const isBlocked = validationResult?.reason === 'blocked'
 
   function handleEditAddress() {
     clearValidationResult()
-    router.push('/profile/address')
+    router.push(formPath)
   }
 
   function handleUseThisAddress() {
     if (enteredAddress) {
       flushSync(() => setAddress(enteredAddress))
-      router.push(DEFAULT_REDIRECT)
+      router.push(continuePath)
     }
   }
 

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
@@ -1,8 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
 import type { ReactNode } from 'react'
 import { useEffect } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/mocks/server'
 
 import type { AddressUpdateResponse, UpdateAddressRequest } from '../../api/schema'
 import { AddressFlowProvider, useAddressFlow } from '../../context'
@@ -97,19 +101,27 @@ function renderSuggestedAddress(
   entered: UpdateAddressRequest = mockEntered,
   { includeInspector = false }: { includeInspector?: boolean } = {}
 ) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  })
   const user = userEvent.setup()
   return {
     user,
     ...render(
-      <AddressFlowProvider>
-        <ContextSetter
-          result={result}
-          entered={entered}
-        >
-          <SuggestedAddress />
-          {includeInspector && <ContextInspector />}
-        </ContextSetter>
-      </AddressFlowProvider>
+      <QueryClientProvider client={queryClient}>
+        <AddressFlowProvider>
+          <ContextSetter
+            result={result}
+            entered={entered}
+          >
+            <SuggestedAddress />
+            {includeInspector && <ContextInspector />}
+          </ContextSetter>
+        </AddressFlowProvider>
+      </QueryClientProvider>
     )
   }
 }
@@ -166,12 +178,27 @@ describe('SuggestedAddress', () => {
   // --- Continue button ---
 
   it('calls setAddress with suggested address and navigates to replacement-cards', async () => {
+    server.use(
+      http.put('/api/household/address', async ({ request }) => {
+        const body = (await request.json()) as UpdateAddressRequest
+        expect(body).toMatchObject({
+          streetAddress1: '123 MLK Jr Ave NW',
+          city: 'Washington',
+          state: 'DC',
+          postalCode: '20001'
+        })
+        return HttpResponse.json({ status: 'valid' })
+      })
+    )
+
     const { user } = renderSuggestedAddress()
 
     const continueButton = screen.getByRole('button', { name: /continue/i })
     await user.click(continueButton)
 
-    expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
+    })
   })
 
   it('calls setAddress with entered address when "Address you entered" is selected', async () => {
@@ -187,6 +214,8 @@ describe('SuggestedAddress', () => {
   })
 
   it('preserves validationResult in context when Continue is clicked (prevents FlowGuard race)', async () => {
+    server.use(http.put('/api/household/address', () => HttpResponse.json({ status: 'valid' })))
+
     const { user } = renderSuggestedAddress(mockSuggestionResult, mockEntered, {
       includeInspector: true
     })
@@ -194,10 +223,30 @@ describe('SuggestedAddress', () => {
     const continueButton = screen.getByRole('button', { name: /continue/i })
     await user.click(continueButton)
 
-    // validationResult should still be present after Continue (not cleared)
-    expect(screen.getByTestId('has-validation-result')).toHaveTextContent('yes')
-    // address should now be set
-    expect(screen.getByTestId('has-address')).toHaveTextContent('yes')
+    await waitFor(() => {
+      // validationResult should still be present after Continue (not cleared)
+      expect(screen.getByTestId('has-validation-result')).toHaveTextContent('yes')
+      // address should now be set
+      expect(screen.getByTestId('has-address')).toHaveTextContent('yes')
+    })
+  })
+
+  it('shows an error and stays on the page when persisting the suggested address fails', async () => {
+    server.use(
+      http.put('/api/household/address', () =>
+        HttpResponse.json({ error: 'Bad request' }, { status: 400 })
+      )
+    )
+
+    const { user } = renderSuggestedAddress()
+
+    const continueButton = screen.getByRole('button', { name: /continue/i })
+    await user.click(continueButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/something went wrong/i)).toBeInTheDocument()
+    })
+    expect(mockPush).not.toHaveBeenCalled()
   })
 
   // --- Back button ---

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
@@ -99,6 +99,7 @@ function ContextInspector() {
     <div data-testid="context-inspector">
       <span data-testid="has-validation-result">{validationResult ? 'yes' : 'no'}</span>
       <span data-testid="has-address">{address ? 'yes' : 'no'}</span>
+      <span data-testid="address-json">{address ? JSON.stringify(address) : ''}</span>
     </div>
   )
 }
@@ -256,6 +257,39 @@ describe('SuggestedAddress', () => {
       expect(screen.getByTestId('has-validation-result')).toHaveTextContent('yes')
       // address should now be set
       expect(screen.getByTestId('has-address')).toHaveTextContent('yes')
+    })
+  })
+
+  it('stores normalized address from API response when suggested address is accepted', async () => {
+    server.use(
+      http.put('/api/household/address', () =>
+        HttpResponse.json({
+          status: 'valid',
+          normalizedAddress: {
+            streetAddress1: '123 MLK JR AVE NW',
+            streetAddress2: null,
+            city: 'WASHINGTON',
+            state: 'DC',
+            postalCode: '20001-0001'
+          }
+        })
+      )
+    )
+
+    const { user } = renderSuggestedAddress(mockSuggestionResult, mockEntered, {
+      includeInspector: true
+    })
+
+    const continueButton = screen.getByRole('button', { name: /continue/i })
+    await user.click(continueButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('has-address')).toHaveTextContent('yes')
+      const contextData = JSON.parse(screen.getByTestId('address-json').textContent ?? '{}')
+      expect(contextData.streetAddress1).toBe('123 MLK JR AVE NW')
+      expect(contextData.city).toBe('WASHINGTON')
+      expect(contextData.postalCode).toBe('20001-0001')
+      expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
@@ -69,15 +69,22 @@ const mockSuggestionResult: AddressUpdateResponse = {
 function ContextSetter({
   children,
   result,
-  entered
+  entered,
+  formPath,
+  continuePath
 }: {
   children: ReactNode
   result: AddressUpdateResponse
   entered: UpdateAddressRequest
+  formPath?: string
+  continuePath?: string
 }) {
-  const { setValidationResult } = useAddressFlow()
+  const { setValidationResult, setNavigationTargets } = useAddressFlow()
   useEffect(() => {
     setValidationResult(result, entered)
+    if (formPath && continuePath) {
+      setNavigationTargets({ formPath, continuePath })
+    }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
   return <>{children}</>
 }
@@ -99,7 +106,11 @@ function ContextInspector() {
 function renderSuggestedAddress(
   result: AddressUpdateResponse = mockSuggestionResult,
   entered: UpdateAddressRequest = mockEntered,
-  { includeInspector = false }: { includeInspector?: boolean } = {}
+  {
+    includeInspector = false,
+    formPath,
+    continuePath
+  }: { includeInspector?: boolean; formPath?: string; continuePath?: string } = {}
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -116,6 +127,8 @@ function renderSuggestedAddress(
           <ContextSetter
             result={result}
             entered={entered}
+            {...(formPath ? { formPath } : {})}
+            {...(continuePath ? { continuePath } : {})}
           >
             <SuggestedAddress />
             {includeInspector && <ContextInspector />}
@@ -213,6 +226,21 @@ describe('SuggestedAddress', () => {
     expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
   })
 
+  it('navigates using context continuePath when configured', async () => {
+    server.use(http.put('/api/household/address', () => HttpResponse.json({ status: 'valid' })))
+    const { user } = renderSuggestedAddress(mockSuggestionResult, mockEntered, {
+      formPath: '/cards/replace/address?case=SEBT-001',
+      continuePath: '/cards/replace/confirm?case=SEBT-001'
+    })
+
+    const continueButton = screen.getByRole('button', { name: /continue/i })
+    await user.click(continueButton)
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/cards/replace/confirm?case=SEBT-001')
+    })
+  })
+
   it('preserves validationResult in context when Continue is clicked (prevents FlowGuard race)', async () => {
     server.use(http.put('/api/household/address', () => HttpResponse.json({ status: 'valid' })))
 
@@ -258,6 +286,18 @@ describe('SuggestedAddress', () => {
     await user.click(backButton)
 
     expect(mockPush).toHaveBeenCalledWith('/profile/address')
+  })
+
+  it('back button uses context formPath when configured', async () => {
+    const { user } = renderSuggestedAddress(mockSuggestionResult, mockEntered, {
+      formPath: '/cards/replace/address?case=SEBT-001',
+      continuePath: '/cards/replace/confirm?case=SEBT-001'
+    })
+
+    const backButton = screen.getByRole('button', { name: /back/i })
+    await user.click(backButton)
+
+    expect(mockPush).toHaveBeenCalledWith('/cards/replace/address?case=SEBT-001')
   })
 
   // --- DC abbreviated variant ---

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
@@ -5,8 +5,9 @@ import { useState } from 'react'
 import { flushSync } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
-import { Button, getState } from '@sebt/design-system'
+import { Alert, Button, getState } from '@sebt/design-system'
 
+import { useUpdateAddress } from '../../api'
 import type { UpdateAddressRequest } from '../../api/schema'
 import { useAddressFlow } from '../../context'
 
@@ -17,7 +18,9 @@ export function SuggestedAddress() {
   const { t: tCommon } = useTranslation('common')
   const router = useRouter()
   const currentState = getState()
+  const updateAddress = useUpdateAddress()
   const { validationResult, enteredAddress, setAddress, clearValidationResult } = useAddressFlow()
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   const isAbbreviated = validationResult?.reason === 'abbreviated' && currentState === 'dc'
 
@@ -34,12 +37,29 @@ export function SuggestedAddress() {
 
   const [selection, setSelection] = useState<'suggested' | 'entered'>('suggested')
 
-  function handleContinue() {
+  async function handleContinue() {
     const selectedAddress = selection === 'suggested' ? suggestedAddr : enteredAddress
-    if (selectedAddress) {
-      flushSync(() => setAddress(selectedAddress))
-      router.push(DEFAULT_REDIRECT)
+    if (!selectedAddress) {
+      return
     }
+
+    if (selection === 'suggested') {
+      setSubmitError(null)
+
+      try {
+        const result = await updateAddress.mutateAsync(selectedAddress)
+        if (result.status !== 'valid') {
+          setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
+          return
+        }
+      } catch {
+        setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
+        return
+      }
+    }
+
+    flushSync(() => setAddress(selectedAddress))
+    router.push(DEFAULT_REDIRECT)
   }
 
   function handleBack() {
@@ -92,6 +112,16 @@ export function SuggestedAddress() {
       <h1 className="font-sans-xl text-primary">{title}</h1>
       <p>{body}</p>
       {bodyDetail && <p>{bodyDetail}</p>}
+
+      {submitError && (
+        <Alert
+          variant="error"
+          slim
+          className="margin-bottom-2"
+        >
+          {submitError}
+        </Alert>
+      )}
 
       <p className="font-sans-3xs text-base margin-bottom-0">
         {t('requiredFieldNote', 'Asterisks (*) indicate a required field.')}
@@ -153,8 +183,11 @@ export function SuggestedAddress() {
         <Button
           type="button"
           onClick={handleContinue}
+          disabled={updateAddress.isPending}
         >
-          {tCommon('continue', 'Continue')}
+          {updateAddress.isPending
+            ? tCommon('loading', 'Loading...')
+            : tCommon('continue', 'Continue')}
         </Button>
       </div>
     </div>

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
@@ -8,8 +8,24 @@ import { useTranslation } from 'react-i18next'
 import { Alert, Button, getState } from '@sebt/design-system'
 
 import { useUpdateAddress } from '../../api'
-import type { UpdateAddressRequest } from '../../api/schema'
+import type { AddressResponse, UpdateAddressRequest } from '../../api/schema'
 import { useAddressFlow } from '../../context'
+
+function toUpdateAddressRequestOrNull(
+  address: AddressResponse | null | undefined
+): UpdateAddressRequest | null {
+  if (!address?.streetAddress1 || !address.city || !address.state || !address.postalCode) {
+    return null
+  }
+
+  return {
+    streetAddress1: address.streetAddress1,
+    streetAddress2: address.streetAddress2 ?? undefined,
+    city: address.city,
+    state: address.state,
+    postalCode: address.postalCode
+  }
+}
 
 export function SuggestedAddress() {
   const { t } = useTranslation('confirmInfo')
@@ -55,6 +71,12 @@ export function SuggestedAddress() {
         const result = await updateAddress.mutateAsync(selectedAddress)
         if (result.status !== 'valid') {
           setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
+          return
+        }
+        const normalized = toUpdateAddressRequestOrNull(result.normalizedAddress)
+        if (normalized) {
+          flushSync(() => setAddress(normalized))
+          router.push(continuePath)
           return
         }
       } catch {

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
@@ -11,15 +11,20 @@ import { useUpdateAddress } from '../../api'
 import type { UpdateAddressRequest } from '../../api/schema'
 import { useAddressFlow } from '../../context'
 
-const DEFAULT_REDIRECT = '/profile/address/replacement-cards'
-
 export function SuggestedAddress() {
   const { t } = useTranslation('confirmInfo')
   const { t: tCommon } = useTranslation('common')
   const router = useRouter()
   const currentState = getState()
   const updateAddress = useUpdateAddress()
-  const { validationResult, enteredAddress, setAddress, clearValidationResult } = useAddressFlow()
+  const {
+    validationResult,
+    enteredAddress,
+    setAddress,
+    clearValidationResult,
+    continuePath,
+    formPath
+  } = useAddressFlow()
   const [submitError, setSubmitError] = useState<string | null>(null)
 
   const isAbbreviated = validationResult?.reason === 'abbreviated' && currentState === 'dc'
@@ -59,12 +64,12 @@ export function SuggestedAddress() {
     }
 
     flushSync(() => setAddress(selectedAddress))
-    router.push(DEFAULT_REDIRECT)
+    router.push(continuePath)
   }
 
   function handleBack() {
     clearValidationResult()
-    router.push('/profile/address')
+    router.push(formPath)
   }
 
   // Use abbreviated copy for DC 30-char abbreviation, suggested copy otherwise

--- a/src/SEBT.Portal.Web/src/features/address/context/AddressFlowContext.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/context/AddressFlowContext.tsx
@@ -5,6 +5,9 @@ import { createContext, useCallback, useContext, useMemo, useState } from 'react
 
 import type { AddressUpdateResponse, UpdateAddressRequest } from '../api/schema'
 
+const DEFAULT_FORM_PATH = '/profile/address'
+const DEFAULT_CONTINUE_PATH = '/profile/address/replacement-cards'
+
 interface AddressFlowContextValue {
   /** The address submitted by the user. Null until form submission. */
   address: UpdateAddressRequest | null
@@ -20,6 +23,12 @@ interface AddressFlowContextValue {
   setValidationResult: (result: AddressUpdateResponse, entered: UpdateAddressRequest) => void
   /** Clear validation state (e.g. when navigating back to the address form). */
   clearValidationResult: () => void
+  /** Path to return to when user edits address from suggestion/not-found pages. */
+  formPath: string
+  /** Path to continue to after an address is accepted. */
+  continuePath: string
+  /** Update the active address-flow navigation targets. */
+  setNavigationTargets: (targets: { formPath: string; continuePath: string }) => void
 }
 
 const AddressFlowContext = createContext<AddressFlowContextValue | undefined>(undefined)
@@ -28,6 +37,8 @@ export function AddressFlowProvider({ children }: { children: ReactNode }) {
   const [address, setAddressState] = useState<UpdateAddressRequest | null>(null)
   const [validationResult, setValidationResultState] = useState<AddressUpdateResponse | null>(null)
   const [enteredAddress, setEnteredAddressState] = useState<UpdateAddressRequest | null>(null)
+  const [formPath, setFormPath] = useState(DEFAULT_FORM_PATH)
+  const [continuePath, setContinuePath] = useState(DEFAULT_CONTINUE_PATH)
 
   const setAddress = useCallback((addr: UpdateAddressRequest) => {
     setAddressState(addr)
@@ -50,6 +61,14 @@ export function AddressFlowProvider({ children }: { children: ReactNode }) {
     setEnteredAddressState(null)
   }, [])
 
+  const setNavigationTargets = useCallback(
+    (targets: { formPath: string; continuePath: string }) => {
+      setFormPath(targets.formPath)
+      setContinuePath(targets.continuePath)
+    },
+    []
+  )
+
   const value = useMemo<AddressFlowContextValue>(
     () => ({
       address,
@@ -58,7 +77,10 @@ export function AddressFlowProvider({ children }: { children: ReactNode }) {
       validationResult,
       enteredAddress,
       setValidationResult,
-      clearValidationResult
+      clearValidationResult,
+      formPath,
+      continuePath,
+      setNavigationTargets
     }),
     [
       address,
@@ -67,7 +89,10 @@ export function AddressFlowProvider({ children }: { children: ReactNode }) {
       validationResult,
       enteredAddress,
       setValidationResult,
-      clearValidationResult
+      clearValidationResult,
+      formPath,
+      continuePath,
+      setNavigationTargets
     ]
   )
 


### PR DESCRIPTION
#### 🔗 Jira ticket

[DC-325](https://codeforamerica.atlassian.net/browse/DC-325)

#### ✍️ Description

This branch fixes the DC mailing-address update flow when validation returns a suggested address, when the user lands on address not found, and when persisting the address after a successful update.

1. Persist suggested address before continuing (DC connector path)  
   On the suggested-address step, choosing the suggested line calls the address update mutation and only navigates forward after a successful `valid` response, so the replacement-card flow does not continue on unstored data.

2. Preserve caller redirect targets  
   `AddressFlowContext` exposes configurable `formPath` / `continuePath` (with defaults). `AddressForm` sets these from the current pathname and `redirect` query param where applicable. `SuggestedAddress` and `AddressNotFound` navigate using those paths instead of hard-coded `/profile/address` routes.

3. Normalized address on success  
   **API**: `PUT` household address responses include optional `normalizedAddress` when validation succeeds. `HouseholdController` maps it from the validation result.  
   **Web**: Types and mutation `onSuccess` align with the new field; the UI prefers normalized values when mapping into flow context after submit; `invalidateQueries` is awaited on success so navigation does not race stale cache.

Tests: Updates/additions for `SuggestedAddress`, `AddressNotFound`, `AddressForm`, integration coverage for normalized payload behavior; MSW `handlers` adjusted as needed.


https://github.com/user-attachments/assets/4f16b472-ca61-4e58-a9c6-107d16de2770



#### 🔗 Links to related PRs

N/A

---

#### ✅ Completion tasks

- [x] Added relevant tests  
- [x] Meets acceptance criteria in ticket *(confirm on DC-325)*  
- [ ] Configuration changes:  (N/A)
  - [ ] If new environment variables are added, update in Tofu  
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager  
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig  
  - [ ] If appsetttings are changed, update in AWS AppConfig  



[DC-325]: https://codeforamerica.atlassian.net/browse/DC-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ