### PR TITLE
DC-359 Update: Show suggestion screen when Smarty has a suggestion

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
@@ -90,7 +90,8 @@ public class HouseholdController : ControllerBase
             StreetAddress2 = request.StreetAddress2,
             City = request.City,
             State = request.State,
-            PostalCode = request.PostalCode
+            PostalCode = request.PostalCode,
+            AcceptEnteredAddress = request.AcceptEnteredAddress ?? false
         };
 
         var result = await commandHandler.Handle(command, cancellationToken);

--- a/src/SEBT.Portal.Api/Models/Household/UpdateAddressRequest.cs
+++ b/src/SEBT.Portal.Api/Models/Household/UpdateAddressRequest.cs
@@ -26,4 +26,9 @@ public record UpdateAddressRequest
     [Required(ErrorMessage = "Postal code is required.")]
     [RegularExpression(@"^\d{5}(-\d{4})?$", ErrorMessage = "Postal code must be a valid 5- or 9-digit ZIP code.")]
     public required string PostalCode { get; init; }
+
+    /// <summary>
+    /// Persist the submitted address even when verification suggests an alternative (user chose entered address).
+    /// </summary>
+    public bool? AcceptEnteredAddress { get; init; }
 }

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommand.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommand.cs
@@ -37,7 +37,7 @@ public class UpdateAddressCommand : ICommand<AddressValidationResult>
     /// <summary>
     /// When true and address verification produced a normalized suggestion, persist the command fields
     /// (what the user entered) instead of returning another suggestion. Used after the user explicitly
-    /// chooses “address you entered” on the suggestion screen.
+    /// chooses "address you entered" on the suggestion screen.
     /// </summary>
     public bool AcceptEnteredAddress { get; init; }
 }

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommand.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommand.cs
@@ -33,4 +33,11 @@ public class UpdateAddressCommand : ICommand<AddressValidationResult>
     [Required(ErrorMessage = "Postal code is required.")]
     [RegularExpression(@"^\d{5}(-\d{4})?$", ErrorMessage = "Postal code must be a valid 5- or 9-digit ZIP code.")]
     public required string PostalCode { get; init; }
+
+    /// <summary>
+    /// When true and address verification produced a normalized suggestion, persist the command fields
+    /// (what the user entered) instead of returning another suggestion. Used after the user explicitly
+    /// chooses “address you entered” on the suggestion screen.
+    /// </summary>
+    public bool AcceptEnteredAddress { get; init; }
 }

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -88,18 +88,28 @@ public class UpdateAddressCommandHandler(
 
         // Smarty's USPS-long canonical street can exceed DC's connector limit while the user's typed
         // street still fits. Abbreviated suggestions must not loop forever when the user explicitly
-        // chooses "address you entered" — validate and persist those lines instead.
-        var abbreviatedOnlyBlocksPersist =
-            command.AcceptEnteredAddress
-            && !stateValidationOnNormalized.IsValid
-            && stateValidationOnNormalized.Reason == "abbreviated";
-
-        if (!stateValidationOnNormalized.IsValid && !abbreviatedOnlyBlocksPersist)
+        // chooses "address you entered" - validate and persist those lines instead.
+        var abbreviatedOnlyBlocksPersist = false;
+        if (!stateValidationOnNormalized.IsValid)
         {
-            logger.LogInformation(
-                "Address failed state-specific validation: {Reason}",
-                stateValidationOnNormalized.Reason);
-            return Result<AddressValidationResult>.Success(stateValidationOnNormalized);
+            // Only abbreviated-normalization mismatch may proceed; entered lines are validated below before persist.
+            if (stateValidationOnNormalized.Reason != "abbreviated")
+            {
+                logger.LogInformation(
+                    "Address failed state-specific validation: {Reason}",
+                    stateValidationOnNormalized.Reason);
+                return Result<AddressValidationResult>.Success(stateValidationOnNormalized);
+            }
+
+            if (!command.AcceptEnteredAddress)
+            {
+                logger.LogInformation(
+                    "Address failed state-specific validation: {Reason}",
+                    stateValidationOnNormalized.Reason);
+                return Result<AddressValidationResult>.Success(stateValidationOnNormalized);
+            }
+
+            abbreviatedOnlyBlocksPersist = true;
         }
 
         Address persistAddress = normalizedAddress!;
@@ -147,7 +157,7 @@ public class UpdateAddressCommandHandler(
             return Result<AddressValidationResult>.Unauthorized("Unable to identify user from token.");
         }
 
-        // Never log raw address fields — PII policy.
+        // Never log raw address fields - PII policy.
         // Extract enum name to a local to break CodeQL taint chain (identifier is tainted via .Value).
         var identifierKind = identifier.Type.ToString();
 

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -91,6 +91,23 @@ public class UpdateAddressCommandHandler(
             return Result<AddressValidationResult>.Success(stateValidation);
         }
 
+        // If Smarty returned a canonical address that differs from what the user entered,
+        // route through the suggestion flow so the user can explicitly confirm which one to use.
+        var requestedAddress = new Address
+        {
+            StreetAddress1 = command.StreetAddress1,
+            StreetAddress2 = command.StreetAddress2,
+            City = command.City,
+            State = command.State,
+            PostalCode = command.PostalCode
+        };
+        if (!AddressesEquivalent(requestedAddress, normalizedAddress!))
+        {
+            logger.LogInformation("Address normalization produced a suggested alternative");
+            return Result<AddressValidationResult>.Success(
+                AddressValidationResult.Suggestion(normalizedAddress!, "suggested"));
+        }
+
         var identifier = await resolver.ResolveAsync(command.User, cancellationToken);
         if (identifier == null)
         {
@@ -214,5 +231,21 @@ public class UpdateAddressCommandHandler(
                 DependencyFailedReason.ConnectionFailed,
                 "Address update service is temporarily unavailable.");
         }
+    }
+
+    private static bool AddressesEquivalent(Address left, Address right)
+    {
+        return StringFieldEquals(left.StreetAddress1, right.StreetAddress1)
+            && StringFieldEquals(left.StreetAddress2, right.StreetAddress2)
+            && StringFieldEquals(left.City, right.City)
+            && StringFieldEquals(left.State, right.State)
+            && StringFieldEquals(left.PostalCode, right.PostalCode);
+    }
+
+    private static bool StringFieldEquals(string? left, string? right)
+    {
+        var normalizedLeft = string.IsNullOrWhiteSpace(left) ? null : left.Trim();
+        var normalizedRight = string.IsNullOrWhiteSpace(right) ? null : right.Trim();
+        return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -83,18 +83,57 @@ public class UpdateAddressCommandHandler(
 
         // Run state-specific address checks (blocked addresses, DC abbreviations, 30-char limit)
         // after Smarty normalization so we validate the canonical form.
-        var stateValidation = await addressValidationService.ValidateAsync(
+        var stateValidationOnNormalized = await addressValidationService.ValidateAsync(
             normalizedAddress!, cancellationToken);
-        if (!stateValidation.IsValid)
+
+        // Smarty's USPS-long canonical street can exceed DC's connector limit while the user's typed
+        // street still fits. Abbreviated suggestions must not loop forever when the user explicitly
+        // chooses "address you entered" — validate and persist those lines instead.
+        var abbreviatedOnlyBlocksPersist =
+            command.AcceptEnteredAddress
+            && !stateValidationOnNormalized.IsValid
+            && stateValidationOnNormalized.Reason == "abbreviated";
+
+        if (!stateValidationOnNormalized.IsValid && !abbreviatedOnlyBlocksPersist)
         {
             logger.LogInformation(
                 "Address failed state-specific validation: {Reason}",
-                stateValidation.Reason);
-            return Result<AddressValidationResult>.Success(stateValidation);
+                stateValidationOnNormalized.Reason);
+            return Result<AddressValidationResult>.Success(stateValidationOnNormalized);
         }
 
-        // Use WasCorrected from validation (Smarty compares input vs normalized via AddressNormalizationHelper.AddressesEqualLoose).
-        if (normalizationCorrectedAddress)
+        Address persistAddress = normalizedAddress!;
+
+        var enteredAddressModel = new Address
+        {
+            StreetAddress1 = command.StreetAddress1.Trim(),
+            StreetAddress2 = string.IsNullOrWhiteSpace(command.StreetAddress2)
+                ? null
+                : command.StreetAddress2.Trim(),
+            City = command.City.Trim(),
+            State = command.State.Trim(),
+            PostalCode = command.PostalCode.Trim()
+        };
+
+        if (command.AcceptEnteredAddress)
+        {
+            var enteredStateValidation =
+                await addressValidationService.ValidateAsync(enteredAddressModel, cancellationToken);
+            if (!enteredStateValidation.IsValid)
+            {
+                logger.LogInformation(
+                    "User-opted entered address failed state-specific validation: {Reason}",
+                    enteredStateValidation.Reason);
+                return Result<AddressValidationResult>.Success(enteredStateValidation);
+            }
+
+            persistAddress = enteredAddressModel;
+            logger.LogInformation(
+                abbreviatedOnlyBlocksPersist
+                    ? "Persisting user-entered address after opting out of abbreviated connector form"
+                    : "Persisting user-entered address after opting out of normalization suggestion");
+        }
+        else if (normalizationCorrectedAddress)
         {
             logger.LogInformation("Address normalization produced a suggested alternative");
             return Result<AddressValidationResult>.Success(
@@ -175,14 +214,14 @@ public class UpdateAddressCommandHandler(
             }
         }
 
-        // Use the normalized address from validation for the state connector call.
+        // Use the persisted address (normalized or user-entered when opted in) for the state connector call.
         var pluginAddress = new PluginAddress
         {
-            StreetAddress1 = normalizedAddress!.StreetAddress1,
-            StreetAddress2 = normalizedAddress.StreetAddress2,
-            City = normalizedAddress.City,
-            State = normalizedAddress.State,
-            PostalCode = normalizedAddress.PostalCode
+            StreetAddress1 = persistAddress.StreetAddress1,
+            StreetAddress2 = persistAddress.StreetAddress2,
+            City = persistAddress.City,
+            State = persistAddress.State,
+            PostalCode = persistAddress.PostalCode
         };
 
         var updateRequest = new PluginAddressUpdateRequest
@@ -199,7 +238,7 @@ public class UpdateAddressCommandHandler(
             {
                 logger.LogInformation("Address update completed for household identifier kind {Kind}", identifierKind);
                 return Result<AddressValidationResult>.Success(
-                    AddressValidationResult.Valid(normalizedAddress));
+                    AddressValidationResult.Valid(persistAddress));
             }
 
             if (updateResult.IsPolicyRejection)

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -53,6 +53,7 @@ public class UpdateAddressCommandHandler(
 
         var addressOutcome = await addressUpdateService.ValidateAndNormalizeAsync(addressRequest, cancellationToken);
         Address? normalizedAddress = null;
+        var normalizationCorrectedAddress = false;
         switch (addressOutcome)
         {
             case ValidationFailedResult<AddressUpdateSuccess> addressValidationFailed:
@@ -72,6 +73,7 @@ public class UpdateAddressCommandHandler(
                 return Result<AddressValidationResult>.DependencyFailed(addressDependencyFailed.Reason, addressDependencyFailed.Message);
             case SuccessResult<AddressUpdateSuccess> success:
                 normalizedAddress = success.Value.NormalizedAddress;
+                normalizationCorrectedAddress = success.Value.WasCorrected;
                 break;
             default:
                 return Result<AddressValidationResult>.DependencyFailed(
@@ -91,17 +93,8 @@ public class UpdateAddressCommandHandler(
             return Result<AddressValidationResult>.Success(stateValidation);
         }
 
-        // If Smarty returned a canonical address that differs from what the user entered,
-        // route through the suggestion flow so the user can explicitly confirm which one to use.
-        var requestedAddress = new Address
-        {
-            StreetAddress1 = command.StreetAddress1,
-            StreetAddress2 = command.StreetAddress2,
-            City = command.City,
-            State = command.State,
-            PostalCode = command.PostalCode
-        };
-        if (!AddressesEquivalent(requestedAddress, normalizedAddress!))
+        // Use WasCorrected from validation (Smarty compares input vs normalized via AddressNormalizationHelper.AddressesEqualLoose).
+        if (normalizationCorrectedAddress)
         {
             logger.LogInformation("Address normalization produced a suggested alternative");
             return Result<AddressValidationResult>.Success(
@@ -231,21 +224,5 @@ public class UpdateAddressCommandHandler(
                 DependencyFailedReason.ConnectionFailed,
                 "Address update service is temporarily unavailable.");
         }
-    }
-
-    private static bool AddressesEquivalent(Address left, Address right)
-    {
-        return StringFieldEquals(left.StreetAddress1, right.StreetAddress1)
-            && StringFieldEquals(left.StreetAddress2, right.StreetAddress2)
-            && StringFieldEquals(left.City, right.City)
-            && StringFieldEquals(left.State, right.State)
-            && StringFieldEquals(left.PostalCode, right.PostalCode);
-    }
-
-    private static bool StringFieldEquals(string? left, string? right)
-    {
-        var normalizedLeft = string.IsNullOrWhiteSpace(left) ? null : left.Trim();
-        var normalizedRight = string.IsNullOrWhiteSpace(right) ? null : right.Trim();
-        return string.Equals(normalizedLeft, normalizedRight, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/SEBT.Portal.Web/src/features/address/api/schema.ts
+++ b/src/SEBT.Portal.Web/src/features/address/api/schema.ts
@@ -27,7 +27,9 @@ export const UpdateAddressRequestSchema = z.object({
   postalCode: z
     .string()
     .min(1, 'Postal code is required.')
-    .refine(isValidZip, 'Postal code must be a valid 5- or 9-digit ZIP code.')
+    .refine(isValidZip, 'Postal code must be a valid 5- or 9-digit ZIP code.'),
+  /** When true, API persists these fields even if Smarty suggested a correction. */
+  acceptEnteredAddress: z.boolean().optional()
 })
 
 export type UpdateAddressRequest = z.infer<typeof UpdateAddressRequestSchema>

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
@@ -215,7 +215,30 @@ describe('SuggestedAddress', () => {
     })
   })
 
-  it('calls setAddress with entered address when "Address you entered" is selected', async () => {
+  it('calls API with acceptEnteredAddress when "Address you entered" is selected', async () => {
+    server.use(
+      http.put('/api/household/address', async ({ request }) => {
+        const body = (await request.json()) as UpdateAddressRequest
+        expect(body.acceptEnteredAddress).toBe(true)
+        expect(body).toMatchObject({
+          streetAddress1: '123 Martin Luther King Jr Ave NW',
+          city: 'Washington',
+          state: 'District of Columbia',
+          postalCode: '20001'
+        })
+        return HttpResponse.json({
+          status: 'valid',
+          normalizedAddress: {
+            streetAddress1: body.streetAddress1,
+            streetAddress2: body.streetAddress2 ?? null,
+            city: body.city,
+            state: body.state,
+            postalCode: body.postalCode
+          }
+        })
+      })
+    )
+
     const { user } = renderSuggestedAddress()
 
     const enteredRadio = screen.getByRole('radio', { name: /address you entered/i })
@@ -224,7 +247,9 @@ describe('SuggestedAddress', () => {
     const continueButton = screen.getByRole('button', { name: /continue/i })
     await user.click(continueButton)
 
-    expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
+    })
   })
 
   it('navigates using context continuePath when configured', async () => {

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.test.tsx
@@ -293,6 +293,40 @@ describe('SuggestedAddress', () => {
     })
   })
 
+  it('continues when API returns suggestion after selecting suggested address', async () => {
+    server.use(
+      http.put('/api/household/address', () =>
+        HttpResponse.json({
+          status: 'suggestion',
+          reason: 'suggested',
+          suggestedAddress: {
+            streetAddress1: '123 MLK JR AVE NW',
+            streetAddress2: null,
+            city: 'WASHINGTON',
+            state: 'DC',
+            postalCode: '20001-0001'
+          }
+        })
+      )
+    )
+
+    const { user } = renderSuggestedAddress(mockSuggestionResult, mockEntered, {
+      includeInspector: true
+    })
+
+    const continueButton = screen.getByRole('button', { name: /continue/i })
+    await user.click(continueButton)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('has-address')).toHaveTextContent('yes')
+      const contextData = JSON.parse(screen.getByTestId('address-json').textContent ?? '{}')
+      expect(contextData.streetAddress1).toBe('123 MLK JR AVE NW')
+      expect(contextData.city).toBe('WASHINGTON')
+      expect(contextData.postalCode).toBe('20001-0001')
+      expect(mockPush).toHaveBeenCalledWith('/profile/address/replacement-cards')
+    })
+  })
+
   it('shows an error and stays on the page when persisting the suggested address fails', async () => {
     server.use(
       http.put('/api/household/address', () =>

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
@@ -64,35 +64,40 @@ export function SuggestedAddress() {
       return
     }
 
-    if (selection === 'suggested') {
-      setSubmitError(null)
+    setSubmitError(null)
 
-      try {
-        const result = await updateAddress.mutateAsync(selectedAddress)
-        if (result.status !== 'valid' && result.status !== 'suggestion') {
-          setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
-          return
-        }
-        const normalized = toUpdateAddressRequestOrNull(result.normalizedAddress)
-        if (normalized) {
-          flushSync(() => setAddress(normalized))
-          router.push(continuePath)
-          return
-        }
-        const suggested = toUpdateAddressRequestOrNull(result.suggestedAddress)
-        if (suggested) {
-          flushSync(() => setAddress(suggested))
-          router.push(continuePath)
-          return
-        }
-      } catch {
+    try {
+      const payload =
+        selection === 'entered'
+          ? { ...selectedAddress, acceptEnteredAddress: true }
+          : selectedAddress
+
+      const result = await updateAddress.mutateAsync(payload)
+
+      if (result.status !== 'valid' && result.status !== 'suggestion') {
         setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
         return
       }
-    }
 
-    flushSync(() => setAddress(selectedAddress))
-    router.push(continuePath)
+      const normalized = toUpdateAddressRequestOrNull(result.normalizedAddress)
+      if (normalized) {
+        flushSync(() => setAddress(normalized))
+        router.push(continuePath)
+        return
+      }
+
+      const suggested = toUpdateAddressRequestOrNull(result.suggestedAddress)
+      if (suggested) {
+        flushSync(() => setAddress(suggested))
+        router.push(continuePath)
+        return
+      }
+
+      flushSync(() => setAddress(selectedAddress))
+      router.push(continuePath)
+    } catch {
+      setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
+    }
   }
 
   function handleBack() {

--- a/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/SuggestedAddress/SuggestedAddress.tsx
@@ -69,13 +69,19 @@ export function SuggestedAddress() {
 
       try {
         const result = await updateAddress.mutateAsync(selectedAddress)
-        if (result.status !== 'valid') {
+        if (result.status !== 'valid' && result.status !== 'suggestion') {
           setSubmitError(t('addressUpdateError', 'Something went wrong. Please try again.'))
           return
         }
         const normalized = toUpdateAddressRequestOrNull(result.normalizedAddress)
         if (normalized) {
           flushSync(() => setAddress(normalized))
+          router.push(continuePath)
+          return
+        }
+        const suggested = toUpdateAddressRequestOrNull(result.suggestedAddress)
+        if (suggested) {
+          flushSync(() => setAddress(suggested))
           router.push(continuePath)
           return
         }

--- a/test/SEBT.Portal.Tests/Unit/Api/Models/Household/UpdateAddressRequestJsonTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Api/Models/Household/UpdateAddressRequestJsonTests.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using SEBT.Portal.Api.Models.Household;
+using Xunit;
+
+namespace SEBT.Portal.Tests.Unit.Api.Models.Household;
+
+public class UpdateAddressRequestJsonTests
+{
+    [Fact]
+    public void Deserialize_Web_defaults_Map_acceptEnteredAddress_To_AcceptEnteredAddress()
+    {
+        var json =
+            """{"streetAddress1":"2207 Orchard Creek Drive","city":"Newman","state":"CA","postalCode":"95360-2424","acceptEnteredAddress":true}""";
+
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        var dto = JsonSerializer.Deserialize<UpdateAddressRequest>(json, options);
+
+        Assert.NotNull(dto);
+        Assert.True(dto.AcceptEnteredAddress);
+        Assert.Equal("2207 Orchard Creek Drive", dto.StreetAddress1);
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
@@ -788,6 +788,268 @@ public class UpdateAddressCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_PersistsEnteredAddress_WhenAcceptEnteredAddressAndSmartySuggestedCorrection()
+    {
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "2400 MLK JR Ave SE",
+                            City = "Washington",
+                            State = "DC",
+                            PostalCode = "20020"
+                        },
+                        WasCorrected = true,
+                        IsGeneralDelivery = false
+                    })));
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = "2400 Martin Luther King Jr Ave SE",
+            City = "Washington",
+            State = "DC",
+            PostalCode = "20020",
+            AcceptEnteredAddress = true
+        };
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<AddressValidationResult>>(result);
+        Assert.True(success.Value.IsValid);
+        Assert.Equal("2400 Martin Luther King Jr Ave SE", success.Value.NormalizedAddress?.StreetAddress1);
+
+        await _stateAddressUpdateService.Received(1).UpdateAddressAsync(
+            Arg.Is<AddressUpdateRequest>(r =>
+                r.Address.StreetAddress1 == "2400 Martin Luther King Jr Ave SE"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PersistsEnteredStreet_WithDrive_WhenAcceptEnteredAddressTrue_AndSmartyCorrectedToDr()
+    {
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "2207 Orchard Creek Dr",
+                            City = "Newman",
+                            State = "CA",
+                            PostalCode = "95360-2424"
+                        },
+                        WasCorrected = true,
+                        IsGeneralDelivery = false
+                    })));
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = "2207 Orchard Creek Drive",
+            City = "Newman",
+            State = "CA",
+            PostalCode = "95360-2424",
+            AcceptEnteredAddress = true
+        };
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await _stateAddressUpdateService.Received(1).UpdateAddressAsync(
+            Arg.Is<AddressUpdateRequest>(r =>
+                r.Address.StreetAddress1 == "2207 Orchard Creek Drive"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PersistsNormalizedStreet_WithDr_WhenAcceptEnteredAddressFalse_AndSmartyWasCorrectedFalse()
+    {
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "2207 Orchard Creek Dr",
+                            City = "Newman",
+                            State = "CA",
+                            PostalCode = "95360-2424"
+                        },
+                        WasCorrected = false,
+                        IsGeneralDelivery = false
+                    })));
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = "2207 Orchard Creek Drive",
+            City = "Newman",
+            State = "CA",
+            PostalCode = "95360-2424",
+            AcceptEnteredAddress = false
+        };
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await _stateAddressUpdateService.Received(1).UpdateAddressAsync(
+            Arg.Is<AddressUpdateRequest>(r =>
+                r.Address.StreetAddress1 == "2207 Orchard Creek Dr"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PersistsEnteredAddress_WhenAcceptEnteredAddressAndSmartyCanonicalFailsDcAbbreviationRule()
+    {
+        // USPS-normalized street exceeds DC connector width → abbreviated 422 on first submit.
+        // Second submit with AcceptEnteredAddress must not re-return that suggestion; persist typed street.
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "2207 Orchard Creek Drive Suite Building North Wing A",
+                            City = "Newman",
+                            State = "CA",
+                            PostalCode = "95360-2424"
+                        },
+                        WasCorrected = false,
+                        IsGeneralDelivery = false
+                    })));
+
+        _addressValidationService
+            .ValidateAsync(Arg.Any<Address>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                var addr = call.Arg<Address>();
+                if ((addr.StreetAddress1?.Length ?? 0) > 30)
+                {
+                    return Task.FromResult(
+                        AddressValidationResult.Suggestion(
+                            new Address
+                            {
+                                StreetAddress1 = "2207 Orchard Crk Dr STE B",
+                                City = addr.City,
+                                State = addr.State,
+                                PostalCode = addr.PostalCode
+                            },
+                            "abbreviated"));
+                }
+
+                return Task.FromResult(AddressValidationResult.Valid());
+            });
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = "2207 Orchard Creek Drive",
+            City = "Newman",
+            State = "CA",
+            PostalCode = "95360-2424",
+            AcceptEnteredAddress = true
+        };
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<AddressValidationResult>>(result);
+        Assert.True(success.Value.IsValid);
+        Assert.Equal("2207 Orchard Creek Drive", success.Value.NormalizedAddress?.StreetAddress1);
+
+        await _stateAddressUpdateService.Received(1).UpdateAddressAsync(
+            Arg.Is<AddressUpdateRequest>(r =>
+                r.Address.StreetAddress1 == "2207 Orchard Creek Drive"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsInvalid_WhenAcceptEnteredAddressButEnteredFailsStateValidation()
+    {
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "SHORT",
+                            City = "Washington",
+                            State = "DC",
+                            PostalCode = "20001"
+                        },
+                        WasCorrected = true,
+                        IsGeneralDelivery = false
+                    })));
+
+        var callCount = 0;
+        _addressValidationService
+            .ValidateAsync(Arg.Any<Address>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                return Task.FromResult(
+                    callCount == 1
+                        ? AddressValidationResult.Valid()
+                        : AddressValidationResult.Invalid(
+                            "Enter a street address shorter than 30 characters.",
+                            "too_long"));
+            });
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = new string('X', 35),
+            City = "Washington",
+            State = "DC",
+            PostalCode = "20001",
+            AcceptEnteredAddress = true
+        };
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<AddressValidationResult>>(result);
+        Assert.False(success.Value.IsValid);
+        Assert.Equal("too_long", success.Value.Reason);
+        await _stateAddressUpdateService.DidNotReceive()
+            .UpdateAddressAsync(Arg.Any<AddressUpdateRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_DoesNotReturnSuggestion_WhenDifferenceIsOnlyCase()
     {
         _addressUpdateService
@@ -803,7 +1065,6 @@ public class UpdateAddressCommandHandlerTests
                             State = "dc",
                             PostalCode = "20001"
                         },
-                        // Matches Smarty: AddressesEqualLoose treats case-only / ZIP-format-only differences as not corrected.
                         WasCorrected = false,
                         IsGeneralDelivery = false
                     })));

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
@@ -55,7 +55,7 @@ public class UpdateAddressCommandHandlerTests
                         {
                             StreetAddress1 = "123 Main St NW",
                             City = "Washington",
-                            State = "DC",
+                            State = "District of Columbia",
                             PostalCode = "20001"
                         },
                         WasCorrected = false,
@@ -708,7 +708,7 @@ public class UpdateAddressCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_UsesNormalizedAddressForStateConnector()
+    public async Task Handle_ReturnsSuggestion_WhenSmartyNormalizesAddressForStateConnector()
     {
         var normalizedAddress = new Address
         {
@@ -735,14 +735,97 @@ public class UpdateAddressCommandHandlerTests
         SetupResolverReturnsEmail();
         SetupHouseholdWithCases();
 
-        await handler.Handle(command, CancellationToken.None);
+        var result = await handler.Handle(command, CancellationToken.None);
 
-        await _stateAddressUpdateService.Received(1).UpdateAddressAsync(
-            Arg.Is<AddressUpdateRequest>(r =>
-                r.Address.StreetAddress1 == "123 MAIN ST NW" &&
-                r.Address.City == "WASHINGTON" &&
-                r.Address.State == "DC" &&
-                r.Address.PostalCode == "20001-0001"),
-            Arg.Any<CancellationToken>());
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<AddressValidationResult>>(result);
+        Assert.False(success.Value.IsValid);
+        Assert.Equal("suggested", success.Value.Reason);
+        Assert.Equal("123 MAIN ST NW", success.Value.SuggestedAddress?.StreetAddress1);
+        await _stateAddressUpdateService.DidNotReceive()
+            .UpdateAddressAsync(Arg.Any<AddressUpdateRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsSuggestion_WhenSmartyNormalizedAddressDiffersFromInput()
+    {
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "2400 MLK JR Ave SE",
+                            City = "Washington",
+                            State = "DC",
+                            PostalCode = "20020"
+                        },
+                        WasCorrected = true,
+                        IsGeneralDelivery = false
+                    })));
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = "2400 Martin Luther King Jr Ave SE",
+            City = "Washington",
+            State = "DC",
+            PostalCode = "20020"
+        };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<AddressValidationResult>>(result);
+        Assert.False(success.Value.IsValid);
+        Assert.Equal("suggested", success.Value.Reason);
+        Assert.Equal("2400 MLK JR Ave SE", success.Value.SuggestedAddress?.StreetAddress1);
+        await _stateAddressUpdateService.DidNotReceive()
+            .UpdateAddressAsync(Arg.Any<AddressUpdateRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotReturnSuggestion_WhenDifferenceIsOnlyCase()
+    {
+        _addressUpdateService
+            .ValidateAndNormalizeAsync(Arg.Any<AddressUpdateOperationRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AddressUpdateSuccess>.Success(
+                    new AddressUpdateSuccess
+                    {
+                        NormalizedAddress = new Address
+                        {
+                            StreetAddress1 = "123 MAIN ST NW",
+                            City = "WASHINGTON",
+                            State = "dc",
+                            PostalCode = "20001"
+                        },
+                        WasCorrected = true,
+                        IsGeneralDelivery = false
+                    })));
+
+        var handler = CreateHandler();
+        var command = new UpdateAddressCommand
+        {
+            User = CreateUser("user@example.com"),
+            StreetAddress1 = "123 Main St NW",
+            City = "Washington",
+            State = "DC",
+            PostalCode = "20001"
+        };
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        var success = Assert.IsType<SuccessResult<AddressValidationResult>>(result);
+        Assert.True(success.Value.IsValid);
+        await _stateAddressUpdateService.Received(1)
+            .UpdateAddressAsync(Arg.Any<AddressUpdateRequest>(), Arg.Any<CancellationToken>());
     }
 }

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
@@ -803,7 +803,8 @@ public class UpdateAddressCommandHandlerTests
                             State = "dc",
                             PostalCode = "20001"
                         },
-                        WasCorrected = true,
+                        // Matches Smarty: AddressesEqualLoose treats case-only / ZIP-format-only differences as not corrected.
+                        WasCorrected = false,
                         IsGeneralDelivery = false
                     })));
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/c45f9135-f0f5-4773-9de0-b5435e167508


#### 🔗 Jira ticket

[DC-359](https://codeforamerica.atlassian.net/browse/DC-359)

#### ✍️ Description

This work improves the mailing address update flow when Smarty returns a normalized address that meaningfully differs from what the user typed.

Backend (`UpdateAddressCommandHandler`)

- After Smarty/state validation, compare the requested address to the normalized address (trim + case-insensitive per field).
- If they are not equivalent, return `AddressValidationResult.Suggestion` with reason `suggested` so the client can route to the suggestion UI (not only the DC 30-character abbreviation path).
- Case-only differences do not trigger a suggestion.
- Unchanged behavior for paths that already returned suggestion/invalid from state-specific validation.

Frontend (`SuggestedAddress`)

- When the user chooses Suggested address, treat API responses with `status: "valid"` or `status: "suggestion"` as success for navigation (covers cases where a second normalization still returns suggestion).
- Prefer `normalizedAddress` from the response when present; otherwise fall back to `suggestedAddress` before updating flow context and continuing.

Tests

- `UpdateAddressCommandHandlerTests`: coverage for suggestion when normalization differs, no suggestion when only casing differs, and adjustment of expectations where normalization previously proceeded without suggestion.
- `SuggestedAddress.test.tsx`: new test for continuation when the API returns `suggestion` after accepting the suggested address.

#### 🔗 Links to related PRs

[DC-connector](https://github.com/codeforamerica/sebt-self-service-portal-dc-connector/pull/35)

#### ✅ Completion tasks

- [x] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsettings are changed, update in AWS AppConfig

Suggested QA

1. DC user with `canUpdateAddress`, enter an address Smarty will normalize (e.g. long MLK street name -> abbreviated). 
3. Confirm `422` with `status: "suggestion"` on first submit and suggestion screen appears.
4. Choose suggested vs entered and confirm downstream screens and `PUT /api/household/address` behavior match product expectations (including when backend returns `valid` vs another `suggestion`).

[DC-359]: https://codeforamerica.atlassian.net/browse/DC-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ