### PR TITLE
DC-377(Bug): Socure ID proofed users - the status should be IAL1+

### DIFF
--- a/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/JwtTokenService.cs
@@ -212,7 +212,7 @@ public class JwtTokenService : ILocalLoginTokenService, IOidcTokenService, ISess
             .ToDictionary(c => c.Type, c => c.Value, StringComparer.OrdinalIgnoreCase);
 
         // Resolve IAL: use whichever is higher between the existing session claim
-        // and the DB value. This lets the post-DocV elevation (DB=IAL2, claim=IAL1)
+        // and the DB value. This lets the post-DocV elevation (DB=IAL1plus, claim=IAL1)
         // take effect on refresh, without ever allowing a stale or admin-edited DB
         // downgrade to supersede a current claim (defense-in-depth).
         var existingIalClaim = existingClaims.GetValueOrDefault(JwtClaimTypes.Ial);

--- a/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
@@ -233,13 +233,13 @@ public class ProcessWebhookCommandHandler(
         }
 
         user.IdProofingStatus = IdProofingStatus.Completed;
-        user.IalLevel = UserIalLevel.IAL2;
+        user.IalLevel = UserIalLevel.IAL1plus;
         user.IdProofingCompletedAt = DateTime.UtcNow;
 
         await userRepository.UpdateUserAsync(user, cancellationToken);
 
         logger.LogInformation(
-            "User {UserId} proofing status updated to Completed, IAL2 after document verification",
+            "User {UserId} proofing status updated to Completed, IAL1plus after document verification",
             userId);
     }
 }

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -302,7 +302,7 @@ public class SubmitIdProofingCommandHandler(
                 // Single save: attempt count + proofing completion together
                 return await CompleteProofingAndRespond(
                     user,
-                    UserIalLevel.IAL2,
+                    UserIalLevel.IAL1plus,
                     cancellationToken,
                     "Socure ACCEPT (no DocV required)");
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.test.tsx
@@ -386,7 +386,7 @@ describe('DocVerifyPage', () => {
       })
 
       // Refresh must be awaited before navigation so the dashboard's first
-      // fetches carry the rotated JWT with IAL2.
+      // fetches carry the rotated JWT with IAL1+.
       expect(callOrder).toEqual(['refresh', 'navigate'])
     })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/doc-verify/DocVerifyPage.tsx
@@ -158,7 +158,7 @@ export function DocVerifyPage({ contactLink }: DocVerifyPageProps) {
     trackEvent(AnalyticsEvents.IDV_FINAL_RESULT)
     clearChallengeContext()
 
-    // DC-296: the webhook just bumped the user to IAL2 server-side. Await a
+    // DC-296: the webhook just bumped the user to IAL1+ server-side. Await a
     // token refresh so the rotated HttpOnly cookie is in place before we
     // navigate. Otherwise the dashboard's first fetches race the refresh and
     // hit the IAL guard with the stale IAL1 JWT. Swallow failures so we never

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcEnrollmentCheckIntegrationTests.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcEnrollmentCheckIntegrationTests.cs
@@ -14,6 +14,8 @@ namespace SEBT.Portal.Tests.Integration.PluginIntegration;
 /// These tests require:
 /// - DC plugin DLLs built into plugins-dc/ (with all transitive dependencies)
 /// - Docker running (for the MSSQL Testcontainer)
+/// - <c>DCConnector:CheckEligibilityProcName</c> pointing at the fixture stub (<c>dbo.sp_CheckEligibility</c>),
+///   matching production behavior where the proc name has no default.
 ///
 /// Tests skip gracefully when plugin DLLs are not present or can't be loaded.
 /// </summary>
@@ -45,7 +47,9 @@ public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseF
                     pluginDir: "plugins-dc",
                     configOverrides: new Dictionary<string, string>
                     {
-                        ["DCConnector:ConnectionString"] = dcDatabase.ConnectionString
+                        ["DCConnector:ConnectionString"] = dcDatabase.ConnectionString,
+                        // Required by DcEnrollmentCheckService (no default); must match dbo.sp_CheckEligibility in DcSourceDatabaseFixture.
+                        ["DCConnector:CheckEligibilityProcName"] = "dbo.sp_CheckEligibility"
                     });
 
                 using (var scope = factory.Services.CreateScope())

--- a/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/SessionRefreshTokenServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Infrastructure/Services/SessionRefreshTokenServiceTests.cs
@@ -136,17 +136,17 @@ public class SessionRefreshTokenServiceTests : JwtTokenServiceTestBase
 
     // --- DocV elevation flow ---
 
-    // Critical scenario from the DocV webhook bug: DB has been updated to IAL2/Completed
+    // Critical scenario from the DocV webhook bug: DB has been updated to IAL1+/Completed
     // after a successful DocV webhook, but the current session JWT still carries the pre-
     // DocV ial=1/NotStarted claims. Refresh must adopt the elevated DB state, not the stale
     // claims, so the user can access the IAL1plus-gated dashboard.
     [Fact]
-    public void ElevatesFromIal1NotStartedToIal2Completed_WhenDbHasPostDocVState()
+    public void ElevatesFromIal1NotStartedToIal1PlusCompleted_WhenDbHasPostDocVState()
     {
         var completedAt = new DateTime(2026, 4, 24, 17, 2, 31, DateTimeKind.Utc);
         var user = new User
         {
-            IalLevel = UserIalLevel.IAL2,
+            IalLevel = UserIalLevel.IAL1plus,
             IdProofingStatus = IdProofingStatus.Completed,
             IdProofingCompletedAt = completedAt,
             Email = "user@example.com"
@@ -159,7 +159,7 @@ public class SessionRefreshTokenServiceTests : JwtTokenServiceTestBase
         var token = Service.GenerateForSessionRefresh(user, principal);
 
         var jwt = ReadJwt(token);
-        Assert.Equal("2", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
+        Assert.Equal("1plus", jwt.Claims.First(c => c.Type == JwtClaimTypes.Ial).Value);
         Assert.Equal(
             ((int)IdProofingStatus.Completed).ToString(),
             jwt.Claims.First(c => c.Type == JwtClaimTypes.IdProofingStatus).Value);
@@ -230,7 +230,7 @@ public class SessionRefreshTokenServiceTests : JwtTokenServiceTestBase
         var completedAt = new DateTime(2026, 4, 24, 10, 30, 0, DateTimeKind.Utc);
         var user = new User
         {
-            IalLevel = UserIalLevel.IAL2,
+            IalLevel = UserIalLevel.IAL1plus,
             IdProofingStatus = IdProofingStatus.Completed,
             IdProofingCompletedAt = completedAt,
             Email = "user@example.com"

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ProcessWebhookCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/ProcessWebhookCommandHandlerTests.cs
@@ -207,11 +207,11 @@ public class ProcessWebhookCommandHandlerTests
                 && c.SocureEventId == "evt-123"),
                 Arg.Any<CancellationToken>());
 
-        // User should be updated to Completed + IAL2
+        // User should be updated to Completed + IAL1plus
         await userRepository.Received(1)
             .UpdateUserAsync(Arg.Is<User>(u =>
                 u.IdProofingStatus == IdProofingStatus.Completed
-                && u.IalLevel == UserIalLevel.IAL2),
+                && u.IalLevel == UserIalLevel.IAL1plus),
                 Arg.Any<CancellationToken>());
     }
 
@@ -510,7 +510,7 @@ public class ProcessWebhookCommandHandlerTests
         await userRepository.Received(1)
             .UpdateUserAsync(Arg.Is<User>(u =>
                 u.IdProofingStatus == IdProofingStatus.Completed
-                && u.IalLevel == UserIalLevel.IAL2),
+                && u.IalLevel == UserIalLevel.IAL1plus),
                 Arg.Any<CancellationToken>());
     }
 
@@ -539,7 +539,7 @@ public class ProcessWebhookCommandHandlerTests
             .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
-    // --- Latent-bug fix: DI-rejected workflow with DocV "accept" must NOT grant IAL2 ---
+    // --- Latent-bug fix: DI-rejected workflow with DocV "accept" must NOT grant IAL1plus ---
 
     [Fact]
     public async Task HandleAsync_EvaluationCompleted_WorkflowRejectButDocvAccept_TransitionsToRejected()
@@ -570,7 +570,7 @@ public class ProcessWebhookCommandHandlerTests
                 && c.OffboardingReason == "docVerificationFailed"),
                 Arg.Any<CancellationToken>());
 
-        // Critical: user must NOT be updated to IAL2
+        // Critical: user must NOT be updated to completed proofing / elevated IAL
         await userRepository.DidNotReceive()
             .UpdateUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -720,7 +720,7 @@ public class SubmitIdProofingCommandHandlerTests
         await handler.Handle(command, CancellationToken.None);
 
         Assert.Equal(IdProofingStatus.Completed, user.IdProofingStatus);
-        Assert.Equal(UserIalLevel.IAL2, user.IalLevel);
+        Assert.Equal(UserIalLevel.IAL1plus, user.IalLevel);
         Assert.NotNull(user.IdProofingCompletedAt);
     }
 


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-377](https://codeforamerica.atlassian.net/browse/DC-377)

#### ✍️ Description

Socure / DocV ID proofing → IAL1+ (not IAL2)  
DC users who complete identity proofing via the in-app Socure flow were persisting `UserIalLevel.IAL2`.  We need to change to this IAL1+ since IAL2 is too high.

- `SubmitIdProofingCommandHandler` — When Socure returns `IdProofingOutcome.Matched`, completion now sets `UserIalLevel.IAL1plus` instead of `IAL2`.
- `ProcessWebhookCommandHandler` — When DocV completes successfully, the user is now updated to `IAL1plus` instead of `IAL2`; log message updated accordingly.
- `JwtTokenService` — Comment-only fix describing post-DocV refresh elevation (DB = IAL1+, stale claim = IAL1).

OIDC  
No changes to OIDC verification claim translation or OIDC login JWT behavior; Colorado / IdP flows are unchanged.

Tests & frontend notes  
- Unit tests updated for submit proofing, webhook proofing, and session refresh (DocV elevation scenario expects `ial` claim `1plus`).  
- `DocVerifyPage` / test comments updated to refer to IAL1+ after webhook completion.

DC enrollment check integration test  
`DcEnrollmentCheckService` requires `DCConnector:CheckEligibilityProcName` (no default). The portal integration test only supplied the connection string, so the plugin threw and the API returned 503. The test harness now sets `dbo.sp_CheckEligibility` to match `DcSourceDatabaseFixture`'s stub proc; class XML docs updated.

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks

- [x] Added relevant tests  
- [ ] Meets acceptance criteria in ticket  
- [x] Configuration changes:  
  - [ ] If new environment variables are added, update in Tofu  
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager  
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig  
  - [ ] If appsetttings are changed, update in AWS AppConfig  

#### Testing instructions (for ticket / reviewers)

1. `pnpm api:test` — full backend suite (includes fixed DC enrollment integration test when `plugins-dc` + Docker are present).  
2. `cd src/SEBT.Portal.Web && pnpm exec vitest run src/features/auth/components/doc-verify/DocVerifyPage.test.tsx` — DocV page tests.  
3. Manual DC path (optional): complete Socure match without DocV and with DocV; confirm DB / JWT reflect IAL1+ (`ial` / `1plus`) not reserved IAL2 for these flows.


[DC-377]: https://codeforamerica.atlassian.net/browse/DC-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ