### PR TITLE
DC-409 - P0 - Enrollment Checker apply CTA points at PEAK regardless of build state 

### DIFF
--- a/src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.test.ts
+++ b/src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.test.ts
@@ -2,46 +2,40 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getApplyHref } from './applyHref'
 
-let mockState = 'co'
-vi.mock('@sebt/design-system', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@sebt/design-system')>()
-  return { ...actual, getState: () => mockState }
-})
-
 afterEach(() => {
-  mockState = 'co'
+  vi.unstubAllEnvs()
 })
 
 describe('getApplyHref', () => {
-  it('returns the CO PEAK starting-page URL with English language param when locale is en', () => {
-    mockState = 'co'
+  it('returns the PEAK starting-page URL with English language param when locale is en', () => {
     expect(getApplyHref('en')).toBe(
       'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
     )
   })
 
-  it('returns the CO PEAK starting-page URL with Spanish language param when locale is es', () => {
-    mockState = 'co'
+  it('returns the PEAK starting-page URL with Spanish language param when locale is es', () => {
     expect(getApplyHref('es')).toBe(
-      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=es_US'
+      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=es'
     )
   })
 
-  it('falls back to en_US for an unknown locale on CO', () => {
-    mockState = 'co'
+  it('falls back to en_US for an unknown locale', () => {
     expect(getApplyHref('fr')).toBe(
       'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
     )
   })
 
-  it('returns /apply when state is dc, regardless of locale', () => {
-    mockState = 'dc'
-    expect(getApplyHref('en')).toBe('/apply')
-    expect(getApplyHref('es')).toBe('/apply')
+  it('returns the PEAK URL when NEXT_PUBLIC_STATE is empty', () => {
+    vi.stubEnv('NEXT_PUBLIC_STATE', '')
+    expect(getApplyHref('en')).toBe(
+      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
+    )
   })
 
-  it('falls back to /apply for an unknown state', () => {
-    mockState = 'xx'
-    expect(getApplyHref('en')).toBe('/apply')
+  it('returns the PEAK URL when NEXT_PUBLIC_STATE is dc', () => {
+    vi.stubEnv('NEXT_PUBLIC_STATE', 'dc')
+    expect(getApplyHref('en')).toBe(
+      'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page?language=en_US'
+    )
   })
 })

--- a/src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.ts
+++ b/src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.ts
@@ -1,11 +1,9 @@
-import { getState } from '@sebt/design-system'
-
 // Duplicated from src/SEBT.Portal.Web/src/lib/applyHref.ts. Portal.Web and
 // EnrollmentChecker.Web are separate pnpm workspace members and can't import
 // each other's src/lib internals; the proper home for this is
 // packages/design-system/src/lib/ so both apps consume one copy. Consolidating
-// is a pure refactor (move file, update 4 import sites, relocate the existing
-// test, swap two vi.mock targets) and should happen in its own change.
+// is a pure refactor (move file, update import sites, relocate the existing
+// test, swap vi.mock targets) and should happen in its own change.
 
 // Lives in code (not via the CSV-driven `applyOnlineLink` translation) because
 // the source-of-truth Google Sheet still points at the legacy
@@ -17,13 +15,10 @@ const PEAK_APPLY_URL = 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-
 // Unknown locales fall back to en_US.
 const PEAK_LANG_BY_LOCALE: Record<string, string> = {
   en: 'en_US',
-  es: 'es_US'
+  es: 'es'
 }
 
 export function getApplyHref(locale: string): string {
-  if (getState() === 'co') {
-    const lang = PEAK_LANG_BY_LOCALE[locale] ?? 'en_US'
-    return `${PEAK_APPLY_URL}?language=${lang}`
-  }
-  return '/apply'
+  const lang = PEAK_LANG_BY_LOCALE[locale] ?? 'en_US'
+  return `${PEAK_APPLY_URL}?language=${lang}`
 }


### PR DESCRIPTION
## PR Description

#### 🔗 Jira ticket
[DC-409](https://codeforamerica.atlassian.net/browse/DC-409)

#### ✍️ Description
The Enrollment Checker results page CTA "Continue your application" is broken in production: it renders `href="/apply"`, which the browser resolves to `https://sebt.cbms.cdhs.state.co.us/apply` (the CBMS-hosted origin) and 404s. The CTA is now produced unconditionally, so it points at the PEAK starting page regardless of how the build was configured. The Spanish locale param is corrected from `es_US` to `es` to match PEAK's URL convention.

#### 🔗 Links to related PRs
- N/A

#### ✅ Completion tasks
- [x] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---
### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.ts` | `getApplyHref()` | Low | Low | Low | URL helper, removed state gate |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.ts` | `PEAK_LANG_BY_LOCALE` | Low | Low | Low | `es` param changed from `es_US` |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/lib/applyHref.test.ts` | test suite | Low | Low | Low | New regression cases for empty/dc env |


[DC-409]: https://codeforamerica.atlassian.net/browse/DC-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ