### PR TITLE
DC-403: point DC apply CTA at sunbucks.dc.gov application form

### DIFF
--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -157,7 +157,10 @@ describe('DashboardContent', () => {
       expect(screen.getByRole('alert')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('link', { name: /apply/i })).toHaveAttribute('href', '/apply')
+    expect(screen.getByRole('link', { name: /apply/i })).toHaveAttribute(
+      'href',
+      'https://forms.sunbucks.dc.gov/s3/AppUpdate2026'
+    )
   })
 
   it('renders UserProfileCard in empty state when userProfile available', async () => {

--- a/src/SEBT.Portal.Web/src/features/household/components/EmptyState/EmptyState.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EmptyState/EmptyState.test.tsx
@@ -15,6 +15,6 @@ describe('EmptyState', () => {
     render(<EmptyState />)
 
     const link = screen.getByRole('link')
-    expect(link).toHaveAttribute('href', '/apply')
+    expect(link).toHaveAttribute('href', 'https://forms.sunbucks.dc.gov/s3/AppUpdate2026')
   })
 })

--- a/src/SEBT.Portal.Web/src/lib/applyHref.test.ts
+++ b/src/SEBT.Portal.Web/src/lib/applyHref.test.ts
@@ -34,10 +34,10 @@ describe('getApplyHref', () => {
     )
   })
 
-  it('returns /apply when state is dc, regardless of locale', () => {
+  it('returns the DC application form URL when state is dc, regardless of locale', () => {
     mockState = 'dc'
-    expect(getApplyHref('en')).toBe('/apply')
-    expect(getApplyHref('es')).toBe('/apply')
+    expect(getApplyHref('en')).toBe('https://forms.sunbucks.dc.gov/s3/AppUpdate2026')
+    expect(getApplyHref('es')).toBe('https://forms.sunbucks.dc.gov/s3/AppUpdate2026')
   })
 
   it('falls back to /apply for an unknown state', () => {

--- a/src/SEBT.Portal.Web/src/lib/applyHref.ts
+++ b/src/SEBT.Portal.Web/src/lib/applyHref.ts
@@ -1,10 +1,12 @@
 import { getState } from '@sebt/design-system'
 
 // Lives in code (not via the CSV-driven `applyOnlineLink` translation) because
-// the source-of-truth Google Sheet still points at the legacy
-// `/SEBT/s/?language=en_US` URL.
+// the source-of-truth Google Sheet still points at the legacy CO
+// `/SEBT/s/?language=en_US` URL, and DC's apply form lives at a separate
+// state-hosted survey URL with no language variant exposed today.
 
 const PEAK_APPLY_URL = 'https://peak.my.site.com/SEBT/s/apply-for-sebt-starting-page'
+const DC_APPLY_URL = 'https://forms.sunbucks.dc.gov/s3/AppUpdate2026'
 
 // Map i18next locale codes to the language param PEAK expects on its URL.
 // Unknown locales fall back to en_US.
@@ -14,9 +16,13 @@ const PEAK_LANG_BY_LOCALE: Record<string, string> = {
 }
 
 export function getApplyHref(locale: string): string {
-  if (getState() === 'co') {
+  const state = getState()
+  if (state === 'co') {
     const lang = PEAK_LANG_BY_LOCALE[locale] ?? 'en_US'
     return `${PEAK_APPLY_URL}?language=${lang}`
+  }
+  if (state === 'dc') {
+    return DC_APPLY_URL
   }
   return '/apply'
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-403

#### ✍️ Description

Routes the DC portal's "submit a DC SUN Bucks application." CTA (in the Enrolled Children section and in the empty-state alert) to the external DC application form:

`https://forms.sunbucks.dc.gov/s3/AppUpdate2026`

Previously the DC branch of `getApplyHref` returned `/apply`, which is not a real route in the DC portal — the link was effectively broken. The CO branch (PEAK URL with locale) is unchanged. The unknown-state fallback remains `/apply` so a misconfigured deployment lands on a portal-internal 404 rather than misrouting users to a state-specific form.

Tests updated:
- `applyHref.test.ts` — DC test now expects the new external URL.
- `EmptyState.test.tsx` and `DashboardContent.test.tsx` — `href` assertions point at the new URL.

Web suite: 781 passing / 9 skipped.

#### 🔗 Links to related PRs
N/A (single-repo change)

#### ✅ Completion tasks

- [x] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig