### PR TITLE
DC-356 security: add packageSourceMapping and NuGetAudit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,26 @@
+<Project>
+
+  <!--
+    Repository-wide MSBuild defaults. Applied to every .csproj below this directory
+    via MSBuild's automatic import of Directory.Build.props.
+
+    NuGet vulnerability auditing: enabled by default in .NET 8+, but we set it
+    explicitly so the policy is discoverable in source rather than relying on
+    SDK defaults. Audit results surface as NU190x warnings during `dotnet restore`;
+    promoting them to errors causes restore (and therefore build/CI) to fail on
+    any known CVE in direct or transitive dependencies.
+
+      NU1901 = low      NU1902 = moderate
+      NU1903 = high     NU1904 = critical
+
+    Without lockfiles, this is our primary defense against silently picking up
+    a vulnerable transitive package on a fresh restore.
+  -->
+  <PropertyGroup>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>moderate</NuGetAuditLevel>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="local-plugins" value="%HOME%/nuget-store" />
+  </packageSources>
+
+  <!--
+    Pins package -> source resolution to defend against dependency confusion.
+    Any package under the SEBT.* namespace must come from the local source only;
+    everything else from nuget.org. Keeping this pattern broad means a future
+    internal package (e.g. SEBT.Portal.Kernel) is covered automatically and
+    cannot be shadowed by a same-named package pushed to nuget.org.
+    See: https://learn.microsoft.com/nuget/consume-packages/package-source-mapping
+  -->
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="local-plugins">
+      <package pattern="SEBT.*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-356

#### ✍️ Description
Adds the following NuGet security measures:
- `packageSourceMapping` to prevent internal package squatting in the public repo
- `NuGetAudit` vulnerability scanning for direct and transitive dependencies

NOTE: this does not negate the need for dependency **lockfiles** to prevent unwanted packages from being installed, but this will be addressed in a separate PR.

#### 🔗 Links to related PRs
<!-- If applicable, include links to dependent or related PRs in this or other repos  -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
