### PR TITLE
DC-449 - hide Amharic from CO language selector

### DIFF
--- a/packages/design-system/src/lib/i18n.test.ts
+++ b/packages/design-system/src/lib/i18n.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { supportedLanguages } from './i18n'
+import { getState, getStateConfig } from './state'
+
+describe('i18n — supportedLanguages export', () => {
+  it('matches the current state config', () => {
+    expect(supportedLanguages).toEqual(getStateConfig(getState()).supportedLanguages)
+  })
+
+  it('is the readonly list of language codes, not the whole config object', () => {
+    expect(Array.isArray(supportedLanguages)).toBe(true)
+    expect(supportedLanguages.every((code) => typeof code === 'string')).toBe(true)
+  })
+})

--- a/packages/design-system/src/lib/i18n.ts
+++ b/packages/design-system/src/lib/i18n.ts
@@ -29,9 +29,15 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
-// Supported languages
-export const supportedLanguages = ['en', 'es', 'am'] as const
-export type SupportedLanguage = (typeof supportedLanguages)[number]
+import { getState, getStateConfig, type SupportedLanguage } from './state'
+
+export type { SupportedLanguage }
+
+// Languages offered in the current deployment, resolved from the per-state
+// config in `state.ts`. The `SupportedLanguage` type stays the full union so
+// `languageNames` and `languageTranslationKeys` keep covering every label.
+export const supportedLanguages: readonly SupportedLanguage[] =
+  getStateConfig(getState()).supportedLanguages
 
 /** Map of state code → i18next resource bundle (language → namespace → key → value) */
 export type StateResources = Record<

--- a/packages/design-system/src/lib/state.test.ts
+++ b/packages/design-system/src/lib/state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { getStateConfig } from './state'
+
+describe('getStateConfig — supportedLanguages', () => {
+  it('omits Amharic from the CO config', () => {
+    expect(getStateConfig('co').supportedLanguages).not.toContain('am')
+  })
+
+  it('exposes only English and Spanish for CO', () => {
+    expect(getStateConfig('co').supportedLanguages).toEqual(['en', 'es'])
+  })
+
+  it('includes Amharic in the DC config', () => {
+    expect(getStateConfig('dc').supportedLanguages).toContain('am')
+  })
+
+  it('exposes English, Spanish, and Amharic for DC', () => {
+    expect(getStateConfig('dc').supportedLanguages).toEqual(['en', 'es', 'am'])
+  })
+})

--- a/packages/design-system/src/lib/state.ts
+++ b/packages/design-system/src/lib/state.ts
@@ -9,6 +9,15 @@
 /** Supported state codes — add new states here */
 export type StateCode = 'dc' | 'co'
 
+/**
+ * Full set of language codes the design system knows how to render labels for.
+ * The runtime list of languages offered to a user is per-state (see
+ * `StateConfig.supportedLanguages`), but `languageNames` and
+ * `languageTranslationKeys` cover every member of this union so a state that
+ * offers a given language always has its native label available.
+ */
+export type SupportedLanguage = 'en' | 'es' | 'am'
+
 export interface StateConfig {
   /** Full display name (e.g., 'District of Columbia') */
   name: string
@@ -16,6 +25,8 @@ export interface StateConfig {
   programName: string
   /** Alt text for the state seal image in the footer */
   sealAlt: string
+  /** Languages offered in this state's UI (drives the LanguageSelector and `?lang=` validation) */
+  supportedLanguages: readonly SupportedLanguage[]
   /** Extra CSS classes appended to the mobile language selector button */
   languageSelectorClass?: string
   /** Extra CSS classes appended to the mobile language submenu */
@@ -35,6 +46,7 @@ const stateConfigs: Record<StateCode, StateConfig> = {
     name: 'District of Columbia',
     programName: 'DC SUN Bucks',
     sealAlt: 'Government of the District of Columbia - Muriel Bowser, Mayor',
+    supportedLanguages: ['en', 'es', 'am'],
     actionButtonBg: 'bg-secondary',
     actionButtonText: 'text-ink'
   },
@@ -42,6 +54,7 @@ const stateConfigs: Record<StateCode, StateConfig> = {
     name: 'Colorado',
     programName: 'Summer EBT',
     sealAlt: 'Colorado Official State Web Portal',
+    supportedLanguages: ['en', 'es'],
     languageSelectorClass: 'border-primary radius-md text-primary',
     languageSubmenuClass: 'bg-primary-dark',
     actionButtonBg: 'bg-primary',


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-449](https://codeforamerica.atlassian.net/browse/DC-449)

#### ✍️ Description
Hide Amharic from the LanguageSelector in Colorado deployments while preserving all three languages (English, Español, አማርኛ) for DC. The list of languages offered to a user is now a per-state value on `StateConfig`, and the design-system's `supportedLanguages` export is derived from the current state's config at module load. CO renders the desktop nav, the mobile accordion, and the `?lang=am` URL guard with English and Español only; DC is unchanged.

#### 🔗 Links to related PRs
- None.

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

[DC-449]: https://codeforamerica.atlassian.net/browse/DC-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ