### PR TITLE
DC-448 fix: bypass AuthGuard for id-proofing off-boarding 

### DIFF
--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/layout.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/layout.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockUsePathname = vi.fn<() => string>()
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname()
+}))
+
+vi.mock('@/features/auth', () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="auth-guard">{children}</div>
+  )
+}))
+
+import IdProofingLayout from './layout'
+
+function renderAt(pathname: string) {
+  mockUsePathname.mockReturnValue(pathname)
+  return render(
+    <IdProofingLayout>
+      <span data-testid="child">child</span>
+    </IdProofingLayout>
+  )
+}
+
+describe('IdProofingLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('wraps id-proofing pages in AuthGuard', () => {
+    renderAt('/login/id-proofing')
+    expect(screen.getByTestId('auth-guard')).toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+
+  it('renders off-boarding without AuthGuard so users who lost their session during OIDC step-up still see the failure screen', () => {
+    renderAt('/login/id-proofing/off-boarding')
+    expect(screen.queryByTestId('auth-guard')).not.toBeInTheDocument()
+    expect(screen.getByTestId('child')).toBeInTheDocument()
+  })
+})

--- a/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/layout.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/login/id-proofing/layout.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { AuthGuard } from '@/features/auth'
+import { usePathname } from 'next/navigation'
 import type { ReactNode } from 'react'
 
 interface IdProofingLayoutProps {
@@ -8,10 +9,14 @@ interface IdProofingLayoutProps {
 }
 
 /**
- * Protects all id-proofing routes (/login/id-proofing/*).
- * Users must be authenticated (via OTP or OIDC) before entering the
- * identity-proofing flow. Unauthenticated visitors are redirected to /login.
+ * Protects all id-proofing routes (/login/id-proofing/*) except off-boarding,
+ * which must remain reachable when the OIDC step-up round-trip loses the
+ * portal session.
  */
 export default function IdProofingLayout({ children }: IdProofingLayoutProps) {
+  const pathname = usePathname()
+  if (pathname.startsWith('/login/id-proofing/off-boarding')) {
+    return <>{children}</>
+  }
   return <AuthGuard>{children}</AuthGuard>
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-448](https://codeforamerica.atlassian.net/browse/DC-448) — P1: in CO, declining consent on step-up takes you to an error screen and then logs you out.

#### ✍️ Description
When a CO user declines consent on the PingOne / Socure step-up flow, PingOne redirects them back to `/callback?error=…`. The callback page correctly forwards to `/login/id-proofing/off-boarding?reason=oidcCallbackError`, where the off-boarding page already renders the "We're sorry, we aren't able to show your Summer EBT information" copy that matches the [Step Up Failure Figma](https://www.figma.com/) (title, body, Back + Contact us buttons — design verified against the current `stepUpFailure` namespace and `OffBoardingContent` component).

The bug is upstream of the page itself. `/login/id-proofing/*` is wrapped in `IdProofingLayout`, which gates every child route with `AuthGuard`. The OIDC round-trip to PingOne can lose the portal session (cross-site cookie age, SameSite refusal on the inbound redirect, IdP-side `prompt=login` + step-up declining the new auth event). When that happens, `AuthGuard` sees `isAuthenticated === false` on the off-boarding page and bounces the user to `/login` — which produces exactly the "logs you out + ends up on a 404-ish screen" experience the ticket describes.

Fix: the off-boarding route is the terminal failure screen for the step-up round-trip. It must remain reachable regardless of session state. This PR adds a path-based bypass in `IdProofingLayout` so off-boarding renders without `AuthGuard`. The page itself already null-safes `session?.isCoLoaded`, so it works with or without a session.

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig


[DC-448]: https://codeforamerica.atlassian.net/browse/DC-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ