### PR TITLE
DC-460 Portal-side exact-match filter for CO enrollment check candidates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ We're colleagues working together. Neither of us is afraid to admit we don't kno
 - **Locale JSON files are generated — NEVER hand-edit them.** They are produced by `packages/design-system/content/scripts/generate-locales.js` from CSV exports in `packages/design-system/content/states/`. To add or change content: update the source Google Sheet, re-export the CSV, and re-run the generator (run `pnpm copy:generate` from within `src/SEBT.Portal.Web/` or `src/SEBT.EnrollmentChecker.Web/`). This also runs automatically via the `predev` and `prebuild` hooks. If a key is missing, note it as a content gap to resolve in the spreadsheet — do not add it directly to the JSON.
 
 ### Code style
-- C#: 4-space indent, Allman brace style (braces on own line), nullable reference types enabled (see `.editorconfig`)
+- C#: 4-space indent, Allman brace style (braces on own line), nullable reference types enabled (see `.editorconfig`). Always use braces for control-flow bodies (`if`, `else`, `for`, `foreach`, `while`) even when the body is a single line.
 - Frontend: TypeScript (not JavaScript). ESLint + Prettier with organize-imports plugin
 - Unix line endings (LF) enforced project-wide
 

--- a/src/SEBT.EnrollmentChecker.Web/src/lib/env.ts
+++ b/src/SEBT.EnrollmentChecker.Web/src/lib/env.ts
@@ -1,6 +1,14 @@
 import { createEnv } from '@t3-oss/env-nextjs'
 import { z } from 'zod'
 
+// z.coerce.boolean() uses Boolean() which treats any non-empty string as true,
+// so "false" would coerce to true. This handles the common env var string values.
+const boolEnv = (defaultValue = false) =>
+  z.preprocess(
+    (val) => (val === 'false' || val === '0' ? false : Boolean(val)),
+    z.boolean().optional().default(defaultValue)
+  )
+
 export const env = createEnv({
   server: {
     NODE_ENV: z.enum(['development', 'test', 'production']).optional(),
@@ -10,9 +18,9 @@ export const env = createEnv({
     NEXT_PUBLIC_STATE: z.enum(['dc', 'co']),
     NEXT_PUBLIC_BASE_PATH: z.string().optional().default(''),
     NEXT_PUBLIC_API_BASE_URL: z.string().url().optional(),
-    NEXT_PUBLIC_SHOW_SCHOOL_FIELD: z.coerce.boolean().default(false),
-    NEXT_PUBLIC_CHECKER_ENABLED: z.coerce.boolean().default(true),
-    NEXT_PUBLIC_BOT_PROTECTION_ENABLED: z.coerce.boolean().default(false),
+    NEXT_PUBLIC_SHOW_SCHOOL_FIELD: boolEnv(false),
+    NEXT_PUBLIC_CHECKER_ENABLED: boolEnv(true),
+    NEXT_PUBLIC_BOT_PROTECTION_ENABLED: boolEnv(false),
     NEXT_PUBLIC_PORTAL_URL: z.string().url(),
     NEXT_PUBLIC_APPLICATION_URL: z.string().url(),
     NEXT_PUBLIC_GA_ID: z.string().regex(/^G-/).optional()

--- a/src/SEBT.Portal.Core/AppSettings/FeatureFlags.cs
+++ b/src/SEBT.Portal.Core/AppSettings/FeatureFlags.cs
@@ -1,0 +1,17 @@
+namespace SEBT.Portal.Core.AppSettings;
+
+/// <summary>
+/// Constants for feature flag names used across the portal.
+/// Names must contain only alphanumeric characters and underscores to satisfy both
+/// the FeatureFlagQueryService validator and AWS AppConfig naming requirements.
+/// </summary>
+public static class FeatureFlags
+{
+    /// <summary>
+    /// When enabled, the portal drops enrollment check candidates (Match/PossibleMatch)
+    /// where neither the date of birth nor the full name (first + last) exactly matches
+    /// what was submitted. Defaults to true for CO via appsettings.co.json.
+    /// </summary>
+    public const string EnrollmentCheckRequiresAtLeastOneExactMatchedField =
+        "enrollment_check_requires_at_least_one_exact_matched_field";
+}

--- a/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
@@ -77,6 +77,32 @@ public class CheckEnrollmentCommandHandler(
             result = new EnrollmentCheckResult { Results = filtered, ResponseMessage = result.ResponseMessage };
         }
 
+        // Replace connector-returned identity fields with submitted values so no state-system
+        // PII is ever surfaced to the UI, regardless of flag state.
+        var submittedById = request.Children.ToDictionary(c => c.CheckId);
+        result = new EnrollmentCheckResult
+        {
+            Results = result.Results.Select(r =>
+            {
+                if (!submittedById.TryGetValue(r.CheckId, out var submitted))
+                    return r;
+
+                return new ChildCheckResult
+                {
+                    CheckId = r.CheckId,
+                    FirstName = submitted.FirstName,
+                    LastName = submitted.LastName,
+                    DateOfBirth = submitted.DateOfBirth,
+                    Status = r.Status,
+                    MatchConfidence = r.MatchConfidence,
+                    StatusMessage = r.StatusMessage,
+                    SchoolName = r.SchoolName,
+                    EligibilityType = r.EligibilityType
+                };
+            }).ToList(),
+            ResponseMessage = result.ResponseMessage
+        };
+
         // Log de-identified submission (fire and forget, don't fail the request)
         try
         {

--- a/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
@@ -1,6 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.EnrollmentCheck;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Kernel;
@@ -13,7 +15,8 @@ namespace SEBT.Portal.UseCases.EnrollmentCheck;
 public class CheckEnrollmentCommandHandler(
     IEnrollmentCheckService enrollmentCheckService,
     IEnrollmentCheckSubmissionLogger submissionLogger,
-    ILogger<CheckEnrollmentCommandHandler> logger)
+    ILogger<CheckEnrollmentCommandHandler> logger,
+    IFeatureManager featureManager)
     : ICommandHandler<CheckEnrollmentCommand, EnrollmentCheckResult>
 {
     public async Task<Result<EnrollmentCheckResult>> Handle(
@@ -58,6 +61,20 @@ public class CheckEnrollmentCommandHandler(
             return Result<EnrollmentCheckResult>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "Enrollment check service is temporarily unavailable.");
+        }
+
+        if (await featureManager.IsEnabledAsync(FeatureFlags.EnrollmentCheckRequiresAtLeastOneExactMatchedField))
+        {
+            var beforeCount = result.Results.Count;
+            var filtered = EnrollmentCheckResultFilter.Filter(request.Children, result.Results);
+            var droppedCount = beforeCount - filtered.Count;
+
+            if (droppedCount > 0)
+                logger.LogWarning(
+                    "Enrollment check filter dropped {DroppedCount} of {TotalCount} candidates — neither DOB nor full name matched the submission",
+                    droppedCount, beforeCount);
+
+            result = new EnrollmentCheckResult { Results = filtered, ResponseMessage = result.ResponseMessage };
         }
 
         // Log de-identified submission (fire and forget, don't fail the request)

--- a/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
@@ -65,61 +65,12 @@ public class CheckEnrollmentCommandHandler(
 
         if (await featureManager.IsEnabledAsync(FeatureFlags.EnrollmentCheckRequiresAtLeastOneExactMatchedField))
         {
-            var beforeCount = result.Results.Count;
-            var filtered = EnrollmentCheckResultFilter.Filter(request.Children, result.Results);
-            var droppedCount = beforeCount - filtered.Count;
-
-            if (droppedCount > 0)
-                logger.LogWarning(
-                    "Enrollment check filter dropped {DroppedCount} of {TotalCount} candidates — neither DOB nor full name matched the submission",
-                    droppedCount, beforeCount);
-
-            // For any submitted child with no surviving candidate, insert a NonMatch so the
-            // response always contains one result per submitted child.
-            var survivingIds = filtered.Select(r => r.CheckId).ToHashSet();
-            var synthetic = request.Children
-                .Where(c => !survivingIds.Contains(c.CheckId))
-                .Select(c => new ChildCheckResult
-                {
-                    CheckId = c.CheckId,
-                    FirstName = c.FirstName,
-                    LastName = c.LastName,
-                    DateOfBirth = c.DateOfBirth,
-                    Status = EnrollmentStatus.NonMatch
-                });
-
-            result = new EnrollmentCheckResult
-            {
-                Results = [.. filtered, .. synthetic],
-                ResponseMessage = result.ResponseMessage
-            };
+            result = ApplyExactMatchFilter(request.Children, result);
         }
 
         // Replace connector-returned identity fields with submitted values so no state-system
         // PII is ever surfaced to the UI, regardless of flag state.
-        var submittedById = request.Children.ToDictionary(c => c.CheckId);
-        result = new EnrollmentCheckResult
-        {
-            Results = result.Results.Select(r =>
-            {
-                if (!submittedById.TryGetValue(r.CheckId, out var submitted))
-                    return r;
-
-                return new ChildCheckResult
-                {
-                    CheckId = r.CheckId,
-                    FirstName = submitted.FirstName,
-                    LastName = submitted.LastName,
-                    DateOfBirth = submitted.DateOfBirth,
-                    Status = r.Status,
-                    MatchConfidence = r.MatchConfidence,
-                    StatusMessage = r.StatusMessage,
-                    SchoolName = r.SchoolName,
-                    EligibilityType = r.EligibilityType
-                };
-            }).ToList(),
-            ResponseMessage = result.ResponseMessage
-        };
+        result = ReplaceWithSubmittedIdentity(request.Children, result);
 
         // Log de-identified submission (fire and forget, don't fail the request)
         try
@@ -149,10 +100,77 @@ public class CheckEnrollmentCommandHandler(
         return Result<EnrollmentCheckResult>.Success(result);
     }
 
+    private EnrollmentCheckResult ApplyExactMatchFilter(IList<ChildCheckRequest> requestChildren, EnrollmentCheckResult result)
+    {
+        var beforeCount = result.Results.Count;
+        var filtered = EnrollmentCheckResultFilter.Filter(requestChildren, result.Results);
+        var droppedCount = beforeCount - filtered.Count;
+
+        if (droppedCount > 0)
+        {
+            logger.LogWarning(
+                "Enrollment check filter dropped {DroppedCount} of {TotalCount} candidates — neither DOB nor full name matched the submission",
+                droppedCount, beforeCount);
+        }
+
+        // For any submitted child with no surviving candidate, insert a NonMatch so the
+        // response always contains one result per submitted child.
+        var survivingIds = filtered.Select(r => r.CheckId).ToHashSet();
+        var synthetic = requestChildren
+            .Where(c => !survivingIds.Contains(c.CheckId))
+            .Select(c => new ChildCheckResult
+            {
+                CheckId = c.CheckId,
+                FirstName = c.FirstName,
+                LastName = c.LastName,
+                DateOfBirth = c.DateOfBirth,
+                Status = EnrollmentStatus.NonMatch
+            });
+
+        return new EnrollmentCheckResult
+        {
+            Results = [.. filtered, .. synthetic],
+            ResponseMessage = result.ResponseMessage
+        };
+    }
+
+    private static EnrollmentCheckResult ReplaceWithSubmittedIdentity(
+        IList<ChildCheckRequest> requestChildren,
+        EnrollmentCheckResult result)
+    {
+        var submittedById = requestChildren.ToDictionary(c => c.CheckId);
+        return new EnrollmentCheckResult
+        {
+            Results = result.Results.Select(r =>
+            {
+                if (!submittedById.TryGetValue(r.CheckId, out var submitted))
+                {
+                    return r;
+                }
+
+                return new ChildCheckResult
+                {
+                    CheckId = r.CheckId,
+                    FirstName = submitted.FirstName,
+                    LastName = submitted.LastName,
+                    DateOfBirth = submitted.DateOfBirth,
+                    Status = r.Status,
+                    MatchConfidence = r.MatchConfidence,
+                    StatusMessage = r.StatusMessage,
+                    SchoolName = r.SchoolName,
+                    EligibilityType = r.EligibilityType
+                };
+            }).ToList(),
+            ResponseMessage = result.ResponseMessage
+        };
+    }
+
     private static string? HashIpAddress(string? ipAddress)
     {
         if (string.IsNullOrWhiteSpace(ipAddress))
+        {
             return null;
+        }
 
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(ipAddress));
         return Convert.ToHexString(bytes).ToLowerInvariant();

--- a/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
@@ -74,7 +74,25 @@ public class CheckEnrollmentCommandHandler(
                     "Enrollment check filter dropped {DroppedCount} of {TotalCount} candidates — neither DOB nor full name matched the submission",
                     droppedCount, beforeCount);
 
-            result = new EnrollmentCheckResult { Results = filtered, ResponseMessage = result.ResponseMessage };
+            // For any submitted child with no surviving candidate, insert a NonMatch so the
+            // response always contains one result per submitted child.
+            var survivingIds = filtered.Select(r => r.CheckId).ToHashSet();
+            var synthetic = request.Children
+                .Where(c => !survivingIds.Contains(c.CheckId))
+                .Select(c => new ChildCheckResult
+                {
+                    CheckId = c.CheckId,
+                    FirstName = c.FirstName,
+                    LastName = c.LastName,
+                    DateOfBirth = c.DateOfBirth,
+                    Status = EnrollmentStatus.NonMatch
+                });
+
+            result = new EnrollmentCheckResult
+            {
+                Results = [.. filtered, .. synthetic],
+                ResponseMessage = result.ResponseMessage
+            };
         }
 
         // Replace connector-returned identity fields with submitted values so no state-system

--- a/src/SEBT.Portal.UseCases/EnrollmentCheck/EnrollmentCheckResultFilter.cs
+++ b/src/SEBT.Portal.UseCases/EnrollmentCheck/EnrollmentCheckResultFilter.cs
@@ -1,0 +1,52 @@
+using SEBT.Portal.StatesPlugins.Interfaces.Models.EnrollmentCheck;
+
+namespace SEBT.Portal.UseCases.EnrollmentCheck;
+
+/// <summary>
+/// Portal-side filter for enrollment check results. When enabled via the
+/// <c>enrollment_check_requires_at_least_one_exact_matched_field</c> feature flag, drops
+/// Match/PossibleMatch candidates where neither the date of birth nor the full name
+/// (first + last) is an exact match against the submitted request. This guards against
+/// false positives from CBMS fuzzy-matching, regardless of the connector's confidence score.
+/// </summary>
+public static class EnrollmentCheckResultFilter
+{
+    /// <summary>
+    /// Filters <paramref name="results"/> against the original <paramref name="requests"/>,
+    /// removing any Match or PossibleMatch entry where the birth year does not match, or where
+    /// the year matches but neither the full DOB nor the full name (first + last, case-insensitive)
+    /// is an exact match. Error and NonMatch results pass through unchanged.
+    /// Results whose CheckId has no corresponding request are kept (defensive).
+    /// </summary>
+    public static IList<ChildCheckResult> Filter(
+        IList<ChildCheckRequest> requests,
+        IList<ChildCheckResult> results)
+    {
+        var requestsByCheckId = requests.ToDictionary(r => r.CheckId);
+
+        return results
+            .Where(result => PassesFilter(result, requestsByCheckId))
+            .ToList();
+    }
+
+    private static bool PassesFilter(
+        ChildCheckResult result,
+        Dictionary<Guid, ChildCheckRequest> requestsByCheckId)
+    {
+        if (result.Status is EnrollmentStatus.Error or EnrollmentStatus.NonMatch)
+            return true;
+
+        if (!requestsByCheckId.TryGetValue(result.CheckId, out var request))
+            return true;
+
+        if (result.DateOfBirth.Year != request.DateOfBirth.Year)
+            return false;
+
+        var dobMatches = result.DateOfBirth == request.DateOfBirth;
+        var nameMatches =
+            string.Equals(result.FirstName, request.FirstName, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(result.LastName, request.LastName, StringComparison.OrdinalIgnoreCase);
+
+        return dobMatches || nameMatches;
+    }
+}

--- a/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
+++ b/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
@@ -23,6 +23,7 @@
     <ItemGroup>
       <PackageReference Include="DistributedLock.Core" Version="1.0.9" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+      <PackageReference Include="Microsoft.FeatureManagement" Version="3.3.0" />
     </ItemGroup>
 
   <!-- State connector as sibling repo only. Sibling under parent of portal, or CI path. -->

--- a/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/CheckEnrollmentCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/CheckEnrollmentCommandHandlerTests.cs
@@ -181,6 +181,54 @@ public class CheckEnrollmentCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_AlwaysReplacesConnectorNameAndDobWithSubmittedValues()
+    {
+        // The connector now returns CBMS values (not submitted ones). The handler must
+        // replace FirstName/LastName/DateOfBirth with the submitted values before
+        // returning to the API — regardless of flag state — so no state-system PII
+        // is ever surfaced to the UI.
+        _featureManager
+            .IsEnabledAsync(FeatureFlags.EnrollmentCheckRequiresAtLeastOneExactMatchedField)
+            .Returns(false);
+
+        var handler = CreateHandler();
+        var command = new CheckEnrollmentCommand
+        {
+            Children =
+            [
+                new() { FirstName = "Jane", LastName = "Doe", DateOfBirth = new DateOnly(2015, 3, 12) }
+            ],
+            IpAddress = "127.0.0.1"
+        };
+
+        // Connector returns CBMS-normalized values — different name, different month/day
+        _enrollmentCheckService
+            .CheckEnrollmentAsync(Arg.Any<EnrollmentCheckRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new EnrollmentCheckResult
+            {
+                Results =
+                [
+                    new()
+                    {
+                        CheckId = call.Arg<EnrollmentCheckRequest>().Children[0].CheckId,
+                        FirstName = "JANE",
+                        LastName = "DOE",
+                        DateOfBirth = new DateOnly(2015, 3, 12),
+                        Status = EnrollmentStatus.Match
+                    }
+                ]
+            });
+
+        var result = await handler.Handle(command);
+
+        Assert.True(result.IsSuccess);
+        var returned = Assert.Single(result.Value.Results);
+        Assert.Equal("Jane", returned.FirstName);
+        Assert.Equal("Doe", returned.LastName);
+        Assert.Equal(new DateOnly(2015, 3, 12), returned.DateOfBirth);
+    }
+
+    [Fact]
     public async Task Handle_WhenExactMatchFlagEnabled_DropsResultWithNoExactMatch()
     {
         _featureManager

--- a/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/CheckEnrollmentCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/CheckEnrollmentCommandHandlerTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.StatesPlugins.Interfaces;
 using SEBT.Portal.StatesPlugins.Interfaces.Models.EnrollmentCheck;
@@ -13,9 +15,10 @@ public class CheckEnrollmentCommandHandlerTests
     private readonly IEnrollmentCheckService _enrollmentCheckService = Substitute.For<IEnrollmentCheckService>();
     private readonly IEnrollmentCheckSubmissionLogger _submissionLogger = Substitute.For<IEnrollmentCheckSubmissionLogger>();
     private readonly ILogger<CheckEnrollmentCommandHandler> _logger = Substitute.For<ILogger<CheckEnrollmentCommandHandler>>();
+    private readonly IFeatureManager _featureManager = Substitute.For<IFeatureManager>();
 
     private CheckEnrollmentCommandHandler CreateHandler() =>
-        new(_enrollmentCheckService, _submissionLogger, _logger);
+        new(_enrollmentCheckService, _submissionLogger, _logger, _featureManager);
 
     [Fact]
     public async Task Handle_WhenNoChildren_ReturnsValidationFailed()
@@ -175,5 +178,87 @@ public class CheckEnrollmentCommandHandlerTests
 
         Assert.False(result.IsSuccess);
         Assert.IsType<Portal.Kernel.Results.DependencyFailedResult<EnrollmentCheckResult>>(result);
+    }
+
+    [Fact]
+    public async Task Handle_WhenExactMatchFlagEnabled_DropsResultWithNoExactMatch()
+    {
+        _featureManager
+            .IsEnabledAsync(FeatureFlags.EnrollmentCheckRequiresAtLeastOneExactMatchedField)
+            .Returns(true);
+
+        var handler = CreateHandler();
+        var command = new CheckEnrollmentCommand
+        {
+            Children =
+            [
+                new() { FirstName = "Jane", LastName = "Doe", DateOfBirth = new DateOnly(2015, 3, 12) }
+            ],
+            IpAddress = "127.0.0.1"
+        };
+
+        // Connector returns a candidate whose name and DOB don't match the submission
+        _enrollmentCheckService
+            .CheckEnrollmentAsync(Arg.Any<EnrollmentCheckRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new EnrollmentCheckResult
+            {
+                Results =
+                [
+                    new()
+                    {
+                        CheckId = call.Arg<EnrollmentCheckRequest>().Children[0].CheckId,
+                        FirstName = "Robert",
+                        LastName = "Smith",
+                        DateOfBirth = new DateOnly(2010, 6, 1),
+                        Status = EnrollmentStatus.PossibleMatch
+                    }
+                ]
+            });
+
+        var result = await handler.Handle(command);
+
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.Value.Results);
+    }
+
+    [Fact]
+    public async Task Handle_WhenExactMatchFlagDisabled_KeepsResultRegardlessOfMatch()
+    {
+        _featureManager
+            .IsEnabledAsync(FeatureFlags.EnrollmentCheckRequiresAtLeastOneExactMatchedField)
+            .Returns(false);
+
+        var handler = CreateHandler();
+        var command = new CheckEnrollmentCommand
+        {
+            Children =
+            [
+                new() { FirstName = "Jane", LastName = "Doe", DateOfBirth = new DateOnly(2015, 3, 12) }
+            ],
+            IpAddress = "127.0.0.1"
+        };
+
+        // Same non-matching candidate as above — should be kept because flag is off
+        _enrollmentCheckService
+            .CheckEnrollmentAsync(Arg.Any<EnrollmentCheckRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new EnrollmentCheckResult
+            {
+                Results =
+                [
+                    new()
+                    {
+                        CheckId = call.Arg<EnrollmentCheckRequest>().Children[0].CheckId,
+                        FirstName = "Robert",
+                        LastName = "Smith",
+                        DateOfBirth = new DateOnly(2010, 6, 1),
+                        Status = EnrollmentStatus.PossibleMatch
+                    }
+                ]
+            });
+
+        var result = await handler.Handle(command);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value.Results);
     }
 }

--- a/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/CheckEnrollmentCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/CheckEnrollmentCommandHandlerTests.cs
@@ -229,6 +229,51 @@ public class CheckEnrollmentCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenAllCandidatesDroppedByFilter_InsertsSyntheticNonMatch()
+    {
+        _featureManager
+            .IsEnabledAsync(FeatureFlags.EnrollmentCheckRequiresAtLeastOneExactMatchedField)
+            .Returns(true);
+
+        var handler = CreateHandler();
+        var command = new CheckEnrollmentCommand
+        {
+            Children =
+            [
+                new() { FirstName = "Jane", LastName = "Doe", DateOfBirth = new DateOnly(2015, 3, 12) }
+            ],
+            IpAddress = "127.0.0.1"
+        };
+
+        // Connector returns a candidate with a wrong year — filter drops it, leaving no result for this child
+        _enrollmentCheckService
+            .CheckEnrollmentAsync(Arg.Any<EnrollmentCheckRequest>(), Arg.Any<CancellationToken>())
+            .Returns(call => new EnrollmentCheckResult
+            {
+                Results =
+                [
+                    new()
+                    {
+                        CheckId = call.Arg<EnrollmentCheckRequest>().Children[0].CheckId,
+                        FirstName = "Jane",
+                        LastName = "Doe",
+                        DateOfBirth = new DateOnly(2014, 3, 12),
+                        Status = EnrollmentStatus.Match
+                    }
+                ]
+            });
+
+        var result = await handler.Handle(command);
+
+        Assert.True(result.IsSuccess);
+        var returned = Assert.Single(result.Value.Results);
+        Assert.Equal(EnrollmentStatus.NonMatch, returned.Status);
+        Assert.Equal("Jane", returned.FirstName);
+        Assert.Equal("Doe", returned.LastName);
+        Assert.Equal(new DateOnly(2015, 3, 12), returned.DateOfBirth);
+    }
+
+    [Fact]
     public async Task Handle_WhenExactMatchFlagEnabled_DropsResultWithNoExactMatch()
     {
         _featureManager
@@ -266,7 +311,8 @@ public class CheckEnrollmentCommandHandlerTests
         var result = await handler.Handle(command);
 
         Assert.True(result.IsSuccess);
-        Assert.Empty(result.Value.Results);
+        var returned = Assert.Single(result.Value.Results);
+        Assert.Equal(EnrollmentStatus.NonMatch, returned.Status);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/EnrollmentCheckResultFilterTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/EnrollmentCheck/EnrollmentCheckResultFilterTests.cs
@@ -1,0 +1,188 @@
+using SEBT.Portal.StatesPlugins.Interfaces.Models.EnrollmentCheck;
+using SEBT.Portal.UseCases.EnrollmentCheck;
+
+namespace SEBT.Portal.Tests.Unit.UseCases.EnrollmentCheck;
+
+public class EnrollmentCheckResultFilterTests
+{
+    private static readonly Guid CheckId = Guid.NewGuid();
+
+    private static ChildCheckRequest MakeRequest(
+        string firstName = "Jane",
+        string lastName = "Doe",
+        DateOnly? dob = null) =>
+        new()
+        {
+            CheckId = CheckId,
+            FirstName = firstName,
+            LastName = lastName,
+            DateOfBirth = dob ?? new DateOnly(2015, 3, 12)
+        };
+
+    private static ChildCheckResult MakeResult(
+        string firstName = "Jane",
+        string lastName = "Doe",
+        DateOnly? dob = null,
+        EnrollmentStatus status = EnrollmentStatus.Match) =>
+        new()
+        {
+            CheckId = CheckId,
+            FirstName = firstName,
+            LastName = lastName,
+            DateOfBirth = dob ?? new DateOnly(2015, 3, 12),
+            Status = status
+        };
+
+    [Fact]
+    public void Filter_WhenDobMatchesExactly_KeepsResult()
+    {
+        var request = MakeRequest(firstName: "Janet", lastName: "Smith");
+        var result = MakeResult(firstName: "Janet", lastName: "Smith");
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Single(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenFullNameMatchesCaseInsensitively_KeepsResult()
+    {
+        // Names match (case-insensitive), birth year matches, but month/day differ — name combo + year is enough
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2000, 6, 6));
+        var result = MakeResult(firstName: "jane", lastName: "doe", dob: new DateOnly(2000, 1, 1));
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Single(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenNameMatchesButBirthYearDiffers_DropsResult()
+    {
+        // Full name matches but birth year is wrong — year is always required
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2000, 6, 6));
+        var result = MakeResult(firstName: "Jane", lastName: "Doe", dob: new DateOnly(1999, 6, 6));
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenDobMatchesButNamesAreDifferent_KeepsResult()
+    {
+        // DOB matches (default on both), names differ — DOB alone is enough
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe");
+        var result = MakeResult(firstName: "Janet", lastName: "Smith");
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Single(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenNeitherDobNorNameMatches_DropsResult()
+    {
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2015, 3, 12));
+        var result = MakeResult(firstName: "Robert", lastName: "Smith", dob: new DateOnly(2010, 6, 1));
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenOnlyFirstNameMatches_DropsResult()
+    {
+        // First name matches, last name does not, DOB does not — full combo required
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2015, 3, 12));
+        var result = MakeResult(firstName: "Jane", lastName: "Smith", dob: new DateOnly(2010, 6, 1));
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenOnlyLastNameMatches_DropsResult()
+    {
+        // Last name matches, first name does not, DOB does not — full combo required
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2015, 3, 12));
+        var result = MakeResult(firstName: "Robert", lastName: "Doe", dob: new DateOnly(2010, 6, 1));
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenResultStatusIsError_KeepsRegardlessOfMatch()
+    {
+        // Errors aren't candidates; don't filter them
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2015, 3, 12));
+        var result = MakeResult(firstName: "Robert", lastName: "Smith", dob: new DateOnly(2010, 6, 1),
+            status: EnrollmentStatus.Error);
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Single(filtered);
+    }
+
+    [Fact]
+    public void Filter_WhenResultStatusIsNonMatch_KeepsRegardlessOfMatch()
+    {
+        // NonMatch results are already non-matches; no need to filter further
+        var request = MakeRequest(firstName: "Jane", lastName: "Doe", dob: new DateOnly(2015, 3, 12));
+        var result = MakeResult(firstName: "Robert", lastName: "Smith", dob: new DateOnly(2010, 6, 1),
+            status: EnrollmentStatus.NonMatch);
+
+        var filtered = EnrollmentCheckResultFilter.Filter([request], [result]);
+
+        Assert.Single(filtered);
+    }
+
+    [Fact]
+    public void Filter_WithEmptyResults_ReturnsEmpty()
+    {
+        var filtered = EnrollmentCheckResultFilter.Filter([], []);
+
+        Assert.Empty(filtered);
+    }
+
+    [Fact]
+    public void Filter_WithMixedResults_KeepsOnlyPassingOnes()
+    {
+        var matchingCheckId = Guid.NewGuid();
+        var nonMatchingCheckId = Guid.NewGuid();
+        var dob = new DateOnly(2015, 3, 12);
+
+        var requests = new List<ChildCheckRequest>
+        {
+            new() { CheckId = matchingCheckId, FirstName = "Jane", LastName = "Doe", DateOfBirth = dob },
+            new() { CheckId = nonMatchingCheckId, FirstName = "Jane", LastName = "Doe", DateOfBirth = dob }
+        };
+        var results = new List<ChildCheckResult>
+        {
+            // DOB matches → kept
+            new() { CheckId = matchingCheckId, FirstName = "Janet", LastName = "Smith", DateOfBirth = dob, Status = EnrollmentStatus.Match },
+            // Neither matches → dropped
+            new() { CheckId = nonMatchingCheckId, FirstName = "Robert", LastName = "Jones", DateOfBirth = new DateOnly(2010, 1, 1), Status = EnrollmentStatus.PossibleMatch }
+        };
+
+        var filtered = EnrollmentCheckResultFilter.Filter(requests, results);
+
+        Assert.Single(filtered);
+        Assert.Equal(matchingCheckId, filtered[0].CheckId);
+    }
+
+    [Fact]
+    public void Filter_WhenResultHasNoCorrespondingRequest_KeepsResult()
+    {
+        // Defensive: an unrecognized CheckId should not be silently dropped
+        var result = MakeResult();
+
+        var filtered = EnrollmentCheckResultFilter.Filter([], [result]);
+
+        Assert.Single(filtered);
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-460

#### ✍️ Description

Two changes that work together:

**Filter** (`enrollment_check_requires_at_least_one_exact_matched_field`, default `true` for CO): drops a Match/PossibleMatch result unless the birth year matches *and* either the full DOB or full name (case-insensitive) also matches. Error/NonMatch pass through. If all candidates are dropped for a child, a synthetic NonMatch is returned so the response always has one result per submitted child.

**PII boundary** (always-on): the handler replaces `FirstName`/`LastName`/`DateOfBirth` in every result with the submitted values before returning to the API, so no CBMS-normalized data (e.g. `JANE DOE`) ever surfaces to the UI.

The CO connector ([PR #40](https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/40)) is updated to return real CBMS values instead of echoing submitted values — this is what makes the filter non-trivial, and what requires the PII boundary.

#### 🔗 Links to related PRs

- CO connector: https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/40

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

> **Note:** CO connector PR must merge first. Feature flag `enrollment_check_requires_at_least_one_exact_matched_field: true` must be set in AWS AppConfig for CO dev + prod.