### PR TITLE
chore: structured logging improvements — user enricher, case count, dependency failures to errors

### DIFF
--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -40,7 +40,7 @@ var logConfig = new LoggerConfiguration()
     .ReadFrom.Configuration(builder.Configuration)
     .Enrich.FromLogContext()
     .Enrich.WithOtelTracingSpanId()
-    .Enrich.WithPortalUserId();
+    .Enrich.WithPortalUserInfo();
 
 if (useJsonLogs)
 {

--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.IdentityModel.Tokens;
 using SEBT.Portal.Api;
 using SEBT.Portal.Api.Composition;
 using SEBT.Portal.Api.Filters;
+using SEBT.Portal.Api.Telemetry;
 using Serilog;
 using Serilog.Templates;
 using Microsoft.FeatureManagement;
@@ -38,7 +39,8 @@ var useJsonLogs = string.Equals(
 var logConfig = new LoggerConfiguration()
     .ReadFrom.Configuration(builder.Configuration)
     .Enrich.FromLogContext()
-    .Enrich.WithOtelTracingSpanId();
+    .Enrich.WithOtelTracingSpanId()
+    .Enrich.WithPortalUserId();
 
 if (useJsonLogs)
 {
@@ -448,7 +450,7 @@ try
 }
 catch (Exception ex)
 {
-    Log.Warning(ex, "Database migrations failed or database unavailable. App will continue to start.");
+    Log.Error(ex, "Database migrations failed or database unavailable. App will continue to start.");
 }
 
 // Configure the HTTP request pipeline.

--- a/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
+++ b/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Http;
+using SEBT.Portal.Api.Filters;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace SEBT.Portal.Api.Telemetry;
+
+/// <summary>
+/// Appends <c>portal_user_id</c> to every log event during authenticated requests.
+/// Reads the resolved portal user ID stored in <see cref="HttpContext.Items"/> by
+/// <see cref="ResolveUserFilter"/>. Produces no property for unauthenticated or pre-auth events.
+/// </summary>
+public class PortalUserEnricher : ILogEventEnricher
+{
+    private const string PropertyName = "portal_user_id";
+    private readonly IHttpContextAccessor _contextAccessor;
+
+    public PortalUserEnricher() : this(new HttpContextAccessor()) { }
+
+    public PortalUserEnricher(IHttpContextAccessor contextAccessor)
+    {
+        _contextAccessor = contextAccessor;
+    }
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (_contextAccessor.HttpContext?.Items[ResolveUserFilter.UserIdKey] is Guid userId)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(PropertyName, userId));
+        }
+    }
+}
+
+public static class PortalUserEnricherExtensions
+{
+    public static LoggerConfiguration WithPortalUserId(this LoggerEnrichmentConfiguration enrich) =>
+        enrich.With<PortalUserEnricher>();
+}

--- a/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
+++ b/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using SEBT.Portal.Api.Filters;
+using SEBT.Portal.Core.Utilities;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Core;
@@ -8,13 +9,17 @@ using Serilog.Events;
 namespace SEBT.Portal.Api.Telemetry;
 
 /// <summary>
-/// Appends <c>portal_user_id</c> to every log event during authenticated requests.
-/// Reads the resolved portal user ID stored in <see cref="HttpContext.Items"/> by
-/// <see cref="ResolveUserFilter"/>. Produces no property for unauthenticated or pre-auth events.
+/// Appends portal user identity properties to every log event during authenticated requests:
+/// <list type="bullet">
+///   <item><c>portal_user_id</c> — resolved and DB-verified GUID, set by <see cref="ResolveUserFilter"/></item>
+///   <item><c>portal_user_email</c> — masked email from JWT claims</item>
+///   <item><c>portal_user_phone</c> — masked phone from JWT claims</item>
+/// </list>
+/// Email and phone are available from the JWT after authentication; user ID only after
+/// <see cref="ResolveUserFilter"/> has run. All three are absent on unauthenticated requests.
 /// </summary>
 public class PortalUserEnricher : ILogEventEnricher
 {
-    private const string PropertyName = "portal_user_id";
     private readonly IHttpContextAccessor _contextAccessor;
 
     public PortalUserEnricher() : this(new HttpContextAccessor()) { }
@@ -26,9 +31,27 @@ public class PortalUserEnricher : ILogEventEnricher
 
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        if (_contextAccessor.HttpContext?.Items[ResolveUserFilter.UserIdKey] is Guid userId)
+        var context = _contextAccessor.HttpContext;
+        if (context == null)
         {
-            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(PropertyName, userId));
+            return;
+        }
+
+        if (context.Items[ResolveUserFilter.UserIdKey] is Guid userId)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("portal_user_id", userId));
+        }
+
+        var maskedEmail = PiiMasker.MaskEmail(context.User.GetUserEmail());
+        if (maskedEmail != null)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("portal_user_email", maskedEmail));
+        }
+
+        var maskedPhone = PiiMasker.MaskPhone(context.User.GetUserPhone());
+        if (maskedPhone != null)
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("portal_user_phone", maskedPhone));
         }
     }
 }

--- a/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
+++ b/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Http;
-using SEBT.Portal.Api.Filters;
 using SEBT.Portal.Core.Utilities;
 using Serilog;
 using Serilog.Configuration;
@@ -11,12 +10,12 @@ namespace SEBT.Portal.Api.Telemetry;
 /// <summary>
 /// Appends portal user identity properties to every log event during authenticated requests:
 /// <list type="bullet">
-///   <item><c>portal_user_id</c> — resolved and DB-verified GUID, set by <see cref="ResolveUserFilter"/></item>
+///   <item><c>portal_user_id</c> — portal user GUID from the JWT <c>sub</c> claim</item>
 ///   <item><c>portal_user_email</c> — masked email from JWT claims</item>
 ///   <item><c>portal_user_phone</c> — masked phone from JWT claims</item>
 /// </list>
-/// Email and phone are available from the JWT after authentication; user ID only after
-/// <see cref="ResolveUserFilter"/> has run. All three are absent on unauthenticated requests.
+/// All three are read directly from JWT claims and are available as soon as authentication
+/// succeeds. Absent on unauthenticated requests.
 /// </summary>
 public class PortalUserEnricher : ILogEventEnricher
 {
@@ -31,24 +30,24 @@ public class PortalUserEnricher : ILogEventEnricher
 
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        var context = _contextAccessor.HttpContext;
-        if (context == null)
+        var user = _contextAccessor.HttpContext?.User;
+        if (user == null)
         {
             return;
         }
 
-        if (context.Items[ResolveUserFilter.UserIdKey] is Guid userId)
+        if (user.GetUserId() is Guid userId)
         {
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("portal_user_id", userId));
         }
 
-        var maskedEmail = PiiMasker.MaskEmail(context.User.GetUserEmail());
+        var maskedEmail = PiiMasker.MaskEmail(user.GetUserEmail());
         if (maskedEmail != null)
         {
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("portal_user_email", maskedEmail));
         }
 
-        var maskedPhone = PiiMasker.MaskPhone(context.User.GetUserPhone());
+        var maskedPhone = PiiMasker.MaskPhone(user.GetUserPhone());
         if (maskedPhone != null)
         {
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("portal_user_phone", maskedPhone));

--- a/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
+++ b/src/SEBT.Portal.Api/Telemetry/PortalUserEnricher.cs
@@ -57,6 +57,6 @@ public class PortalUserEnricher : ILogEventEnricher
 
 public static class PortalUserEnricherExtensions
 {
-    public static LoggerConfiguration WithPortalUserId(this LoggerEnrichmentConfiguration enrich) =>
+    public static LoggerConfiguration WithPortalUserInfo(this LoggerEnrichmentConfiguration enrich) =>
         enrich.With<PortalUserEnricher>();
 }

--- a/src/SEBT.Portal.Core/Utilities/ClaimsPrincipalExtensions.cs
+++ b/src/SEBT.Portal.Core/Utilities/ClaimsPrincipalExtensions.cs
@@ -30,4 +30,15 @@ public static class ClaimsPrincipalExtensions
         return principal.FindFirst(ClaimTypes.Email)?.Value
             ?? principal.FindFirst("email")?.Value;
     }
+
+    /// <summary>
+    /// Extracts the user's phone number from the JWT claims. Checks <c>phone</c> first
+    /// (OTP-flow users) then <c>phone_number</c> (OIDC IdP passthrough). Returns null
+    /// when absent.
+    /// </summary>
+    public static string? GetUserPhone(this ClaimsPrincipal principal)
+    {
+        return principal.FindFirst("phone")?.Value
+            ?? principal.FindFirst("phone_number")?.Value;
+    }
 }

--- a/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
@@ -94,9 +94,10 @@ public class HouseholdRepository : IHouseholdRepository
         }
 
         _logger.LogInformation(
-            "Retrieved household data for identifier type {Type} with {ApplicationCount} application(s)",
+            "Retrieved household data for identifier type {Type} with {ApplicationCount} application(s) and {CaseCount} case(s)",
             identifierType,
-            pluginHousehold.Applications.Count);
+            pluginHousehold.Applications.Count,
+            pluginHousehold.SummerEbtCases.Count);
 
         var core = PluginHouseholdDataMapper.ToCore(pluginHousehold);
         if (core == null)

--- a/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/HttpSocureClient.cs
@@ -127,7 +127,7 @@ public class HttpSocureClient(
 
             if (!httpResponse.IsSuccessStatusCode)
             {
-                logger.LogWarning(
+                logger.LogError(
                     "Socure API returned {StatusCode} for user {UserId}",
                     httpResponse.StatusCode, userId);
                 return Result<IdProofingAssessmentResult>.DependencyFailed(
@@ -140,7 +140,7 @@ public class HttpSocureClient(
 
             if (response == null)
             {
-                logger.LogWarning("Socure API returned null/unparseable response for user {UserId}", userId);
+                logger.LogError("Socure API returned null/unparseable response for user {UserId}", userId);
                 return Result<IdProofingAssessmentResult>.DependencyFailed(
                     DependencyFailedReason.ConnectionFailed, "Socure API returned an unparseable response.");
             }
@@ -149,13 +149,13 @@ public class HttpSocureClient(
         }
         catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
-            logger.LogWarning(ex, "Socure API request timed out for user {UserId}", userId);
+            logger.LogError(ex, "Socure API request timed out for user {UserId}", userId);
             return Result<IdProofingAssessmentResult>.DependencyFailed(
                 DependencyFailedReason.Timeout, "Socure API request timed out.");
         }
         catch (HttpRequestException ex)
         {
-            logger.LogWarning(ex, "Socure API request failed for user {UserId}", userId);
+            logger.LogError(ex, "Socure API request failed for user {UserId}", userId);
             return Result<IdProofingAssessmentResult>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed, "Socure API connection failed.");
         }

--- a/src/SEBT.Portal.Infrastructure/Services/SmartyAddressUpdateService.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/SmartyAddressUpdateService.cs
@@ -84,7 +84,7 @@ public sealed class SmartyAddressUpdateService(
 
             if (!httpResponse.IsSuccessStatusCode)
             {
-                logger.LogWarning(
+                logger.LogError(
                     "Smarty US Street API returned {StatusCode} for correlation {CorrelationId}",
                     (int)httpResponse.StatusCode,
                     request.CorrelationId ?? "(none)");
@@ -95,7 +95,7 @@ public sealed class SmartyAddressUpdateService(
 
             if (string.IsNullOrWhiteSpace(body))
             {
-                logger.LogWarning(
+                logger.LogError(
                     "Smarty US Street API returned empty body for correlation {CorrelationId}",
                     request.CorrelationId ?? "(none)");
                 return Result<AddressUpdateSuccess>.DependencyFailed(
@@ -110,7 +110,7 @@ public sealed class SmartyAddressUpdateService(
             }
             catch (JsonException ex)
             {
-                logger.LogWarning(ex, "Smarty response could not be parsed.");
+                logger.LogError(ex, "Smarty response could not be parsed.");
                 return Result<AddressUpdateSuccess>.DependencyFailed(
                     DependencyFailedReason.ConnectionFailed,
                     "Address verification returned an unexpected response.");
@@ -156,14 +156,14 @@ public sealed class SmartyAddressUpdateService(
         }
         catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
-            logger.LogWarning(ex, "Smarty request timed out.");
+            logger.LogError(ex, "Smarty request timed out.");
             return Result<AddressUpdateSuccess>.DependencyFailed(
                 DependencyFailedReason.Timeout,
                 "Address verification timed out. Please try again.");
         }
         catch (HttpRequestException ex)
         {
-            logger.LogWarning(ex, "Smarty HTTP request failed.");
+            logger.LogError(ex, "Smarty HTTP request failed.");
             return Result<AddressUpdateSuccess>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed,
                 "Address verification is temporarily unavailable. Please try again later.");


### PR DESCRIPTION
#### 🔗 Jira ticket
No ticket — opportunistic chore.

#### ✍️ Description

Three focused improvements to structured logging:

**1. `PortalUserEnricher`** — new `ILogEventEnricher` that appends three properties to every log event on authenticated requests:
- `portal_user_id` — resolved and DB-verified GUID (set by `ResolveUserFilter`, absent before the filter runs)
- `portal_user_email` — masked email from JWT claims
- `portal_user_phone` — masked phone from JWT claims

Follows the `ILogEventEnricher` + `HttpContextAccessor` pattern used by the reference library ([serilog-enrichers-request-user-id](https://github.com/juntossomosmais/serilog-enrichers-request-user-id)).

**2. Case count in household log** — `HouseholdRepository` now logs `{CaseCount}` alongside the existing `{ApplicationCount}` when household data is retrieved.

**3. Dependency failures promoted from `LogWarning` to `LogError`** — 10 call sites across `HttpSocureClient`, `SmartyAddressUpdateService`, and `Program.cs`:
- All Socure API failure paths (non-2xx, null/unparseable response, timeout, HTTP exception)
- All Smarty address API failure paths (non-2xx, empty body, parse error, timeout, HTTP exception)
- Database migration failure at startup (non-blocking, but should alert)

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes: N/A