### PR TITLE
DC-463 - Colorado Socure stepup back button

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -147,7 +147,7 @@ public class OidcController(
             logger.LogInformation(
                 "OIDC Authorize: step-up short-circuited (reason=already_ial1plus, StateCode={StateCode})",
                 stateCode);
-            return Redirect(safeReturnUrl ?? "/dashboard");
+            return LocalRedirect(safeReturnUrl ?? "/dashboard");
         }
 
         var clientId = stepUp ? config["Oidc:StepUp:ClientId"] : config["Oidc:ClientId"];
@@ -502,14 +502,13 @@ public class OidcController(
     private const int MaxStepUpReturnUrlLength = 4096;
 
     /// <summary>
-    /// Mirrors the frontend's <c>hasIal1Plus(session) && isIdProofingCompletionFresh(session)</c>:
-    /// the portal JWT has an <c>ial</c> claim of "1plus" or "2" and an unexpired
+    /// Mirrors the frontend's <c>hasIal1Plus(session) &amp;&amp; isIdProofingCompletionFresh(session)</c>:
+    /// the portal JWT carries at least <see cref="UserIalLevel.IAL1plus"/> and an unexpired
     /// <c>id_proofing_expires_at</c> Unix-seconds claim.
     /// </summary>
     private static bool HasFreshIal1Plus(ClaimsPrincipal user)
     {
-        var ial = user.FindFirst(JwtClaimTypes.Ial)?.Value;
-        if (ial != "1plus" && ial != "2")
+        if (user.GetIalLevel() < UserIalLevel.IAL1plus)
             return false;
 
         var expiresAtClaim = user.FindFirst(JwtClaimTypes.IdProofingExpiresAt)?.Value;

--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -139,6 +139,17 @@ public class OidcController(
             }
         }
 
+        // Skip the IdP round-trip (and the cost of another Socure call) when the caller
+        // is already step-up complete. Catches browser-back navigation that lands back
+        // on this endpoint after a successful step-up.
+        if (stepUp && HasFreshIal1Plus(HttpContext.User))
+        {
+            logger.LogInformation(
+                "OIDC Authorize: step-up short-circuited (reason=already_ial1plus, StateCode={StateCode})",
+                stateCode);
+            return Redirect(safeReturnUrl ?? "/dashboard");
+        }
+
         var clientId = stepUp ? config["Oidc:StepUp:ClientId"] : config["Oidc:ClientId"];
         var redirectUri = stepUp
             ? (config["Oidc:StepUp:RedirectUri"] ?? config["Oidc:CallbackRedirectUri"])
@@ -489,6 +500,24 @@ public class OidcController(
     }
 
     private const int MaxStepUpReturnUrlLength = 4096;
+
+    /// <summary>
+    /// Mirrors the frontend's <c>hasIal1Plus(session) && isIdProofingCompletionFresh(session)</c>:
+    /// the portal JWT has an <c>ial</c> claim of "1plus" or "2" and an unexpired
+    /// <c>id_proofing_expires_at</c> Unix-seconds claim.
+    /// </summary>
+    private static bool HasFreshIal1Plus(ClaimsPrincipal user)
+    {
+        var ial = user.FindFirst(JwtClaimTypes.Ial)?.Value;
+        if (ial != "1plus" && ial != "2")
+            return false;
+
+        var expiresAtClaim = user.FindFirst(JwtClaimTypes.IdProofingExpiresAt)?.Value;
+        if (!long.TryParse(expiresAtClaim, out var expiresAtUnix))
+            return false;
+
+        return DateTimeOffset.FromUnixTimeSeconds(expiresAtUnix) > DateTimeOffset.UtcNow;
+    }
 
     /// <summary>
     /// Step-up post-login navigation: only same-document relative paths (for example <c>/profile/address</c>).

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
@@ -32,7 +32,11 @@ vi.mock('next/navigation', () => ({
 }))
 
 // Mock @/features/auth without loading the barrel (barrel pulls IalGuard → @/env and breaks Vitest).
-const { mockLogin } = vi.hoisted(() => ({ mockLogin: vi.fn() }))
+// `sessionState` is mutable so individual tests can simulate an already-authenticated visitor.
+const { mockLogin, sessionState } = vi.hoisted(() => ({
+  mockLogin: vi.fn(),
+  sessionState: { current: null as Record<string, unknown> | null }
+}))
 vi.mock('@/features/auth', async () => {
   const api = await vi.importActual<typeof import('@/features/auth/api')>('@/features/auth/api')
   return {
@@ -40,8 +44,8 @@ vi.mock('@/features/auth', async () => {
     useAuth: () => ({
       login: mockLogin,
       logout: vi.fn(),
-      isAuthenticated: false,
-      session: null,
+      isAuthenticated: sessionState.current !== null,
+      session: sessionState.current,
       isLoading: false
     })
   }
@@ -81,6 +85,7 @@ import CallbackPage from './page'
 describe('CallbackPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    sessionState.current = null
     // Default: URL has code and state
     Object.defineProperty(window, 'location', {
       value: {
@@ -276,6 +281,33 @@ describe('CallbackPage', () => {
       await waitFor(() => {
         expect(mockReplace).toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
       })
+    })
+  })
+
+  describe('back-button re-entry after successful login', () => {
+    it('skips the code exchange and redirects to /dashboard when the visitor is already authenticated', async () => {
+      sessionState.current = { ial: '1plus', idProofingExpiresAt: 9999999999 }
+      const callbackSpy = vi.fn()
+      const completeLoginSpy = vi.fn()
+      server.use(
+        http.post('/api/auth/oidc/callback', () => {
+          callbackSpy()
+          return HttpResponse.json({ callbackToken: 'should-not-be-issued' })
+        }),
+        http.post('/api/auth/oidc/complete-login', () => {
+          completeLoginSpy()
+          return HttpResponse.json({})
+        })
+      )
+
+      render(<CallbackPage />)
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/dashboard')
+      })
+      expect(callbackSpy).not.toHaveBeenCalled()
+      expect(completeLoginSpy).not.toHaveBeenCalled()
+      expect(mockReplace).not.toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
@@ -8,6 +8,7 @@ import {
   OidcCallbackTokenResponseSchema,
   OidcCompleteLoginResponseSchema
 } from '@/features/auth/api/oidc'
+import { hasIal1Plus, isIdProofingCompletionFresh } from '@/lib/jwt'
 import { getState } from '@sebt/design-system'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef } from 'react'
@@ -28,7 +29,7 @@ import { useTranslation } from 'react-i18next'
  */
 export default function CallbackPage() {
   const router = useRouter()
-  const { login } = useAuth()
+  const { session, login } = useAuth()
   const { t } = useTranslation('login')
   const { t: tProcessing } = useTranslation('step-upProcessing')
   const exchangeStartedRef = useRef(false)
@@ -51,6 +52,15 @@ export default function CallbackPage() {
     }
 
     if (exchangeStartedRef.current) return
+
+    // Back-button re-entry after a successful step-up: the visitor already has IAL1+
+    // and a fresh proofing window. Re-running the exchange here would burn the
+    // single-use code and bounce them to off-boarding.
+    if (hasIal1Plus(session) && isIdProofingCompletionFresh(session)) {
+      router.replace('/dashboard')
+      return
+    }
+
     exchangeStartedRef.current = true
 
     let cancelled = false
@@ -89,9 +99,8 @@ export default function CallbackPage() {
     run()
     return () => {
       cancelled = true
-      exchangeStartedRef.current = false
     }
-  }, [login, router])
+  }, [session, login, router])
 
   if (isCO) {
     return (

--- a/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
@@ -823,6 +823,165 @@ public class OidcControllerTests
         Assert.DoesNotContain("code_verifier", redirect.Url);
     }
 
+    /// <summary>
+    /// DC-463: when the user already has IAL1+ with a fresh expiry, hitting Authorize with
+    /// stepUp=true must short-circuit — no PingOne redirect, no new pre-auth session, and
+    /// therefore no second Socure call. The user is redirected to the sanitized returnUrl.
+    /// </summary>
+    [Fact]
+    public async Task Authorize_WhenStepUpAndUserAlreadyIal1Plus_ShortCircuitsToReturnUrl()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: "/cards/replace",
+            exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/cards/replace", redirect.Url);
+
+        await _sessionStore.DidNotReceive().CreateAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+        await exchangeService.DidNotReceive().GetDiscoveryConfigAsync(
+            Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Authorize_WhenStepUpAndUserAlreadyIal2_ShortCircuits()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "2", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: "/profile/address",
+            exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/profile/address", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Authorize_WhenStepUpAndIal1Plus_WithNoReturnUrl_ShortCircuitsToDashboard()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: null, exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/dashboard", redirect.Url);
+    }
+
+    /// <summary>
+    /// An open-redirect returnUrl is sanitized to null. Short-circuit must still fall back
+    /// to a safe relative path rather than echoing the unsafe value.
+    /// </summary>
+    [Fact]
+    public async Task Authorize_WhenStepUpAndIal1Plus_WithUnsafeReturnUrl_ShortCircuitsToDashboard()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: "https://evil.example/phish",
+            exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal("/dashboard", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Authorize_WhenStepUpAndIal1PlusButExpired_ProceedsToIdp()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddSeconds(-60));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: "/cards/replace",
+            exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith("https://auth.example.com/authorize?", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Authorize_WhenStepUpAndIal1_ProceedsToIdp()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "1", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: "/cards/replace",
+            exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith("https://auth.example.com/authorize?", redirect.Url);
+    }
+
+    [Fact]
+    public async Task Authorize_WhenStepUpAndNoJwt_ProceedsToIdp()
+    {
+        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
+        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        // HttpContext.User is a default unauthenticated principal — no claims set.
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: true, returnUrl: "/cards/replace",
+            exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith("https://auth.example.com/authorize?", redirect.Url);
+    }
+
+    /// <summary>
+    /// Normal (non-step-up) login must always proceed to the IdP even if the caller
+    /// happens to have IAL1+ already. The guard is scoped to <c>stepUp=true</c> only.
+    /// </summary>
+    [Fact]
+    public async Task Authorize_WhenNotStepUpAndUserAlreadyIal1Plus_StillProceedsToIdp()
+    {
+        _config["Oidc:ClientId"].Returns("test-client-id");
+        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
+        SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+
+        var result = await _controller.Authorize(
+            CoStateKey, stepUp: false, exchangeService: exchangeService);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith("https://auth.example.com/authorize?", redirect.Url);
+    }
+
+    private static void SetUser(OidcController controller, string ial, DateTimeOffset idProofingExpiresAt)
+    {
+        var identity = new ClaimsIdentity(
+            [
+                new Claim(JwtClaimTypes.Ial, ial),
+                new Claim(
+                    JwtClaimTypes.IdProofingExpiresAt,
+                    idProofingExpiresAt.ToUnixTimeSeconds().ToString())
+            ],
+            authenticationType: "Test");
+        controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(identity);
+    }
+
     #endregion
 
 }

--- a/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
@@ -840,7 +840,7 @@ public class OidcControllerTests
             CoStateKey, stepUp: true, returnUrl: "/cards/replace",
             exchangeService: exchangeService);
 
-        var redirect = Assert.IsType<RedirectResult>(result);
+        var redirect = Assert.IsType<LocalRedirectResult>(result);
         Assert.Equal("/cards/replace", redirect.Url);
 
         await _sessionStore.DidNotReceive().CreateAsync(
@@ -863,7 +863,7 @@ public class OidcControllerTests
             CoStateKey, stepUp: true, returnUrl: "/profile/address",
             exchangeService: exchangeService);
 
-        var redirect = Assert.IsType<RedirectResult>(result);
+        var redirect = Assert.IsType<LocalRedirectResult>(result);
         Assert.Equal("/profile/address", redirect.Url);
     }
 
@@ -878,7 +878,7 @@ public class OidcControllerTests
         var result = await _controller.Authorize(
             CoStateKey, stepUp: true, returnUrl: null, exchangeService: exchangeService);
 
-        var redirect = Assert.IsType<RedirectResult>(result);
+        var redirect = Assert.IsType<LocalRedirectResult>(result);
         Assert.Equal("/dashboard", redirect.Url);
     }
 
@@ -898,7 +898,7 @@ public class OidcControllerTests
             CoStateKey, stepUp: true, returnUrl: "https://evil.example/phish",
             exchangeService: exchangeService);
 
-        var redirect = Assert.IsType<RedirectResult>(result);
+        var redirect = Assert.IsType<LocalRedirectResult>(result);
         Assert.Equal("/dashboard", redirect.Url);
     }
 


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-463](https://codeforamerica.atlassian.net/browse/DC-463?atlOrigin=eyJpIjoiMzM4MDRkMDlmNWRhNGUxOWIwYTRmYjVkOWViNThlZTkiLCJwIjoiaiJ9)

#### ✍️ Description
In Colorado, completing Socure step-up once should not trigger a second Socure call when the user clicks back. This adds two guards: a server-side short-circuit on `GET /api/auth/oidc/{state}/authorize` that redirects to the sanitized `returnUrl` (or `/dashboard`) when the caller already has `ial=1plus`/`2` with a fresh `id_proofing_expires_at`, and a client-side guard in `/callback` that skips the code exchange when the visitor is already step-up complete (which previously bounced them to off-boarding on re-entry).

#### 🔗 Links to related PRs
- _none — single-repo change_

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

_(No config or env-var changes in this PR.)_

---

## Triage analysis

- **Branch:** `fix/DC-463-co-socure-stepup-back-button` -> `main`
- **Risk Level:** Medium

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs` | `Authorize` short-circuit + `HasFreshIal1Plus` | High | Low | Low | reads JWT claims, controls IdP redirect |
| 🟡 | `src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx` | `useEffect` re-entry guard | Med | Med | Low | session check + cleanup change |
| 🟢 | `test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs` | new Authorize tests | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx` | new re-entry test | Low | Low | Low | |

[DC-463]: https://codeforamerica.atlassian.net/browse/DC-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ