### PR TITLE
DC-466 Update logging for datadog reserved attributes

### DIFF
--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -50,7 +50,7 @@ var logConfig = new LoggerConfiguration()
 if (useJsonLogs)
 {
     logConfig.WriteTo.Console(new ExpressionTemplate(
-        "{ {date: @t, service: 'sebt-portal-api', status: @l, message: @m, exception: @x, ..@p} }\n"));
+        "{ {date: @t, timestamp: @t, status: @l, level: @l, message: @m, exception: @x, ..@p} }\n"));
 }
 else
 {

--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -30,8 +30,13 @@ var builder = WebApplication.CreateBuilder(args);
 // Configure Serilog early so that configuration providers can log.
 // Console sink is configured in code (not appsettings) so we can use
 // human-readable text locally and structured JSON in deployed environments.
-// The JSON format uses field names that Datadog auto-recognizes (level,
-// message, timestamp) so log severity maps correctly without custom pipelines.
+// Field names match Datadog's reserved attributes (`date`, `status`, `service`,
+// `message`) so they are auto-recognized without configuring a per-service
+// log pipeline. Without these names the Forwarder Lambda falls back to the
+// CloudWatch event time for the timeline and tags the log with
+// `service:cloudwatch`. The literal service value must match the OTEL
+// ServiceName constant in OpenTelemetrySetup so traces and logs correlate
+// under the same service in Datadog.
 // Set LOG_FORMAT=json in ECS task definitions to enable structured output.
 var useJsonLogs = string.Equals(
     Environment.GetEnvironmentVariable("LOG_FORMAT"), "json", StringComparison.OrdinalIgnoreCase);
@@ -45,7 +50,7 @@ var logConfig = new LoggerConfiguration()
 if (useJsonLogs)
 {
     logConfig.WriteTo.Console(new ExpressionTemplate(
-        "{ {timestamp: @t, level: @l, message: @m, exception: @x, ..@p} }\n"));
+        "{ {date: @t, service: 'sebt-portal-api', status: @l, message: @m, exception: @x, ..@p} }\n"));
 }
 else
 {

--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -30,7 +30,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Configure Serilog early so that configuration providers can log.
 // Console sink is configured in code (not appsettings) so we can use
 // human-readable text locally and structured JSON in deployed environments.
-// Field names match Datadog's reserved attributes (`date`, `status`, `service`,
+// Field names match Datadog's reserved attributes (`date`, `status`,
 // `message`) so they are auto-recognized without configuring a per-service
 // log pipeline. Without these names the Forwarder Lambda falls back to the
 // CloudWatch event time for the timeline and tags the log with


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-466

#### ✍️ Description
- Updates Logger Config to include field names that match Datadog's reserved attributes `date` and `status`. This fixes an issue where the primary date column in Datadog is showing the CloudWatch forwarding event time rather than the actual timestamp from Serilog.
- These fields were added rather than replaced, so as to not break any existing DD filters/dashboards that may rely on the previous names

