### PR TITLE
fix: scope FeatureFlagsProvider to authenticated layout (DC-448 follow-up)

### DIFF
--- a/src/SEBT.Portal.Web/src/app/(authenticated)/layout.tsx
+++ b/src/SEBT.Portal.Web/src/app/(authenticated)/layout.tsx
@@ -1,5 +1,7 @@
+import { BetaBanner } from '@/components/BetaBanner'
 import { AuthGuard, TokenRefresher } from '@/features/auth'
 import { UserDataSync } from '@/hooks/useUserDataSync'
+import { FeatureFlagsProvider } from '@/providers'
 import type { ReactNode } from 'react'
 
 interface AuthenticatedLayoutProps {
@@ -9,9 +11,12 @@ interface AuthenticatedLayoutProps {
 export default function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
   return (
     <AuthGuard>
-      <TokenRefresher />
-      <UserDataSync />
-      {children}
+      <FeatureFlagsProvider>
+        <TokenRefresher />
+        <UserDataSync />
+        <BetaBanner />
+        {children}
+      </FeatureFlagsProvider>
     </AuthGuard>
   )
 }

--- a/src/SEBT.Portal.Web/src/app/layout.tsx
+++ b/src/SEBT.Portal.Web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import { AmplitudeAnalytics } from '@/components/AmplitudeAnalytics'
-import { BetaBanner } from '@/components/BetaBanner'
 import { MixpanelAnalytics } from '@/components/MixpanelAnalytics'
 import { SiteImproveAnalytics } from '@/components/SiteImproveAnalytics'
 import { primaryFont } from '@/design/fonts'
@@ -8,7 +7,6 @@ import {
   AuthProvider,
   AxeProvider,
   DataLayerProvider,
-  FeatureFlagsProvider,
   I18nProvider,
   QueryProvider
 } from '@/providers'
@@ -113,23 +111,21 @@ export default async function RootLayout({
         >
           <QueryProvider>
             <AuthProvider>
-              <FeatureFlagsProvider>
-                <I18nProvider>
-                  <SkipNav />
-                  <AxeProvider>
-                    {/* Portal target for page-level alerts rendered above the header.
-                        Currently used by AddressForm (30-char street address error).
-                        If a second consumer appears, refactor to a SiteAlertContext so
-                        child components call setSiteAlert() instead of using createPortal directly. */}
-                    <div id="site-alerts" />
-                    <BetaBanner />
-                    <Header state={state} />
-                    <main id="main-content">{children}</main>
-                    <HelpSection state={state} />
-                    <Footer state={state} />
-                  </AxeProvider>
-                </I18nProvider>
-              </FeatureFlagsProvider>
+              <I18nProvider>
+                <SkipNav />
+                <AxeProvider>
+                  {/* Portal target for page-level alerts rendered above the header.
+                      Currently used by AddressForm (30-char street address error).
+                      If a second consumer appears, refactor to a SiteAlertContext so
+                      child components call setSiteAlert() instead of using createPortal directly. */}
+                  <div id="site-alerts" />
+                  {/* FeatureFlagsProvider lives in (authenticated) so public routes don't fire /features. */}
+                  <Header state={state} />
+                  <main id="main-content">{children}</main>
+                  <HelpSection state={state} />
+                  <Footer state={state} />
+                </AxeProvider>
+              </I18nProvider>
             </AuthProvider>
           </QueryProvider>
         </DataLayerProvider>


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-448](https://codeforamerica.atlassian.net/browse/DC-448) — P1: in CO, declining consent on step-up takes you to an error screen and then logs you out.

#### ✍️ Description
Follow-up to PR #320. The `AuthGuard` bypass landed correctly but the POC retest surfaced a second mechanism kicking users off the off-boarding route.

**Why the previous fix was incomplete.** `FeatureFlagsProvider` lived in the root `layout.tsx`, so it mounted on every route — including public ones (`/callback`, `/login/*`, `/login/id-proofing/off-boarding`). On mount it fires `GET /api/features`. The OIDC round-trip leaves the user's JWT cookie stale; on the next request, JwtBearer's `OnTokenValidated` session-lifetime check calls `context.Fail()` and the response goes back as **401**. `apiFetch` has a global "401 means session is dead → `window.location.replace('/login')`" rule with one exception for `/auth/status` (the bootstrap probe). `/features` wasn't on that list, so the user was hard-redirected to `/login` after `router.replace` brought them to off-boarding — they never saw the failure screen.

**Fix.** Move `FeatureFlagsProvider` out of the root layout and into `(authenticated)/layout.tsx`, alongside `AuthGuard`, `TokenRefresher`, and `UserDataSync`. The provider's only public-route consumer was `BetaBanner`, which moved with it.

- Public routes (`/callback`, `/login`, off-boarding) **never call `/features`** → no 401 cascade, off-boarding renders.
- Authenticated routes still call `/features` exactly as today. `AuthGuard` runs above the provider, so a `/features` 401 in that tree genuinely means the session just died mid-render — the existing `apiFetch` redirect is correct in that case.
- `useFeatureFlag` already returns `false` when used outside the provider, so the rearrangement is fail-safe: any future stray render of a flag-gated component outside the authenticated tree degrades to "feature off" rather than throwing.

The alternative fix (adding `/features` to the `apiFetch` bootstrap-probe list) was discarded because it would have introduced a flash-of-hidden-UI window on dead-session dashboard loads — every flag temporarily reads `false`, which is safe for today's flag set but a hazard if a future flag is added that defaults to a "show sensitive thing" state.

**Trade-off worth flagging:** `BetaBanner` is now scoped to authenticated routes. The login page no longer shows it. The banner exists to announce in-beta features, which only matter once a user is signed in — product should confirm this is acceptable before promoting beyond dev.

#### 🔗 Links to related PRs
- #320 (the original AuthGuard bypass, also for DC-448)

#### ✅ Completion tasks

- [x] Added relevant tests — _existing 804-test suite still passes; provider move is structural and exercised end-to-end by route tests_
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

[DC-448]: https://codeforamerica.atlassian.net/browse/DC-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ