### PR TITLE
chore: structured logging improvements and error testing endpoints

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Diagnostics/TestErrorController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Diagnostics/TestErrorController.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Kernel;
+using SEBT.Portal.UseCases.Diagnostics;
+
+namespace SEBT.Portal.Api.Controllers.Diagnostics;
+
+/// <summary>
+/// Diagnostic endpoints for validating OTEL tracing, structured logging, and error-handling behavior.
+/// All endpoints are gated by the <c>test_error_endpoints_enabled</c> feature flag (off by default).
+/// Enable in appsettings.Development.json or AWS AppConfig for dev/staging. Do not enable in production.
+/// </summary>
+[ApiController]
+[Route("api/test-error")]
+[AllowAnonymous]
+[Tags("Diagnostics")]
+public class TestErrorController(IFeatureManager featureManager) : ControllerBase
+{
+    private Task<bool> IsEnabled() =>
+        featureManager.IsEnabledAsync(FeatureFlags.TestErrorEndpointsEnabled);
+
+    /// <summary>
+    /// Returns the specified HTTP status code without going through a command handler.
+    /// Useful for testing frontend error-handling branches in isolation.
+    /// </summary>
+    [HttpGet("http/{statusCode:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> HttpStatus([FromRoute] int statusCode)
+    {
+        if (!await IsEnabled()) return NotFound();
+        return StatusCode(statusCode);
+    }
+
+    /// <summary>
+    /// Throws an unhandled <see cref="InvalidOperationException"/> inside <see cref="TestErrorCommandHandler"/>.
+    /// Validates that OTEL spans are marked faulted and the exception is captured in structured logs.
+    /// </summary>
+    [HttpGet("exception")]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> ThrowException(
+        [FromServices] ICommandHandler<TestErrorCommand> handler,
+        CancellationToken cancellationToken)
+    {
+        if (!await IsEnabled()) return NotFound();
+        await handler.Handle(new TestErrorCommand(), cancellationToken);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Simulates a timeout: <see cref="TestErrorCommandHandler"/> delays 30 seconds;
+    /// the controller cancels after 500 ms. Validates that <see cref="OperationCanceledException"/>
+    /// propagates correctly through OTEL spans and structured logging.
+    /// </summary>
+    [HttpGet("exception/timeout")]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> SimulateTimeout(
+        [FromServices] ICommandHandler<TestErrorCommand> handler)
+    {
+        if (!await IsEnabled()) return NotFound();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
+        await handler.Handle(new TestErrorCommand { WithDelay = true }, cts.Token);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Simulates a Smarty transport-level failure. Uses the "Smarty" named <see cref="HttpClient"/>
+    /// (so OTEL produces a correctly-labeled dependency span) but cancels the request immediately
+    /// via a pre-cancelled token — no bytes leave the process.
+    /// </summary>
+    [HttpGet("dependencies/smarty")]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> SimulateSmartyFailure(
+        [FromServices] IHttpClientFactory httpClientFactory)
+    {
+        if (!await IsEnabled()) return NotFound();
+
+        var client = httpClientFactory.CreateClient("Smarty");
+        try
+        {
+            // Pre-cancelled token: HttpClient fails before any socket activity, but the OTEL
+            // HttpClient instrumentation still records the span and marks it as cancelled/error.
+            await client.SendAsync(
+                new HttpRequestMessage(HttpMethod.Post, client.BaseAddress ?? new Uri("https://us-street.api.smartystreets.com/")),
+                new CancellationToken(canceled: true));
+        }
+        catch (OperationCanceledException) { }
+
+        return StatusCode(StatusCodes.Status503ServiceUnavailable, new ProblemDetails
+        {
+            Title = "Address verification service is temporarily unavailable.",
+            Status = StatusCodes.Status503ServiceUnavailable
+        });
+    }
+}

--- a/src/SEBT.Portal.Api/Controllers/Diagnostics/TestErrorController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Diagnostics/TestErrorController.cs
@@ -1,7 +1,11 @@
+using System.Net;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement.Mvc;
 using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Models.AddressUpdate;
+using SEBT.Portal.Infrastructure.Services;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.UseCases.Diagnostics;
 
@@ -60,30 +64,85 @@ public class TestErrorController : ControllerBase
     }
 
     /// <summary>
-    /// Simulates a Smarty transport-level failure. Uses the "Smarty" named <see cref="HttpClient"/>
-    /// (so OTEL produces a correctly-labeled dependency span) but cancels the request immediately
-    /// via a pre-cancelled token — no bytes leave the process.
+    /// Exercises the <see cref="SmartyAddressUpdateService"/> error path for a non-2xx HTTP response.
+    /// Constructs the real service with a fake <see cref="HttpMessageHandler"/> that returns 500,
+    /// so the handler's <c>LogError</c> and <c>DependencyFailed</c> result are exercised without
+    /// any network activity.
     /// </summary>
-    [HttpGet("dependencies/smarty")]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
-    public async Task<IActionResult> SimulateSmartyFailure(
-        [FromServices] IHttpClientFactory httpClientFactory)
+    [HttpGet("dependencies/smarty/http-error")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    public async Task<IActionResult> SimulateSmartyHttpError(
+        [FromServices] IOptionsSnapshot<SmartySettings> smartySettings,
+        [FromServices] IOptionsSnapshot<AddressValidationPolicySettings> policySettings,
+        [FromServices] ILogger<SmartyAddressUpdateService> logger,
+        CancellationToken cancellationToken)
     {
-        var client = httpClientFactory.CreateClient("Smarty");
-        try
-        {
-            // Pre-cancelled token: HttpClient fails before any socket activity, but the OTEL
-            // HttpClient instrumentation still records the span and marks it as cancelled/error.
-            await client.SendAsync(
-                new HttpRequestMessage(HttpMethod.Post, client.BaseAddress ?? new Uri("https://us-street.api.smartystreets.com/")),
-                new CancellationToken(canceled: true));
-        }
-        catch (OperationCanceledException) { }
+        await InvokeSmartyService(
+            new FixedResponseHandler(HttpStatusCode.InternalServerError),
+            smartySettings, policySettings, logger, cancellationToken);
 
-        return StatusCode(StatusCodes.Status503ServiceUnavailable, new ProblemDetails
+        return Accepted();
+    }
+
+    /// <summary>
+    /// Exercises the <see cref="SmartyAddressUpdateService"/> error path for a transport-level failure
+    /// (e.g. firewall block, DNS failure). The fake handler throws <see cref="HttpRequestException"/>,
+    /// which the service catches and logs at <c>Error</c>.
+    /// </summary>
+    [HttpGet("dependencies/smarty/transport-failure")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    public async Task<IActionResult> SimulateSmartyTransportFailure(
+        [FromServices] IOptionsSnapshot<SmartySettings> smartySettings,
+        [FromServices] IOptionsSnapshot<AddressValidationPolicySettings> policySettings,
+        [FromServices] ILogger<SmartyAddressUpdateService> logger,
+        CancellationToken cancellationToken)
+    {
+        await InvokeSmartyService(
+            new FixedResponseHandler(transportFailure: true),
+            smartySettings, policySettings, logger, cancellationToken);
+
+        return Accepted();
+    }
+
+    private static Task InvokeSmartyService(
+        FixedResponseHandler handler,
+        IOptionsSnapshot<SmartySettings> smartySettings,
+        IOptionsSnapshot<AddressValidationPolicySettings> policySettings,
+        ILogger<SmartyAddressUpdateService> logger,
+        CancellationToken cancellationToken)
+    {
+        var client = new HttpClient(handler)
         {
-            Title = "Address verification service is temporarily unavailable.",
-            Status = StatusCodes.Status503ServiceUnavailable
-        });
+            BaseAddress = new Uri("https://us-street.api.smartystreets.com/")
+        };
+        var factory = new SingleClientFactory(client);
+        var service = new SmartyAddressUpdateService(factory, smartySettings, policySettings, logger);
+
+        return service.ValidateAndNormalizeAsync(new AddressUpdateOperationRequest
+        {
+            StreetAddress1 = "123 Main St",
+            City = "Denver",
+            State = "CO",
+            PostalCode = "80203"
+        }, cancellationToken);
+    }
+
+    private sealed class FixedResponseHandler(
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        bool transportFailure = false) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (transportFailure)
+                throw new HttpRequestException("Simulated transport failure: connection refused.");
+
+            return Task.FromResult(new HttpResponseMessage(statusCode));
+        }
+    }
+
+    private sealed class SingleClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => client;
     }
 }

--- a/src/SEBT.Portal.Api/Controllers/Diagnostics/TestErrorController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Diagnostics/TestErrorController.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.Mvc;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.UseCases.Diagnostics;
@@ -15,21 +15,18 @@ namespace SEBT.Portal.Api.Controllers.Diagnostics;
 [ApiController]
 [Route("api/test-error")]
 [AllowAnonymous]
+[FeatureGate(FeatureFlags.TestErrorEndpointsEnabled)]
 [Tags("Diagnostics")]
-public class TestErrorController(IFeatureManager featureManager) : ControllerBase
+public class TestErrorController : ControllerBase
 {
-    private Task<bool> IsEnabled() =>
-        featureManager.IsEnabledAsync(FeatureFlags.TestErrorEndpointsEnabled);
-
     /// <summary>
     /// Returns the specified HTTP status code without going through a command handler.
     /// Useful for testing frontend error-handling branches in isolation.
     /// </summary>
     [HttpGet("http/{statusCode:int}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> HttpStatus([FromRoute] int statusCode)
+    public IActionResult HttpStatus([FromRoute] int statusCode)
     {
-        if (!await IsEnabled()) return NotFound();
         return StatusCode(statusCode);
     }
 
@@ -43,7 +40,6 @@ public class TestErrorController(IFeatureManager featureManager) : ControllerBas
         [FromServices] ICommandHandler<TestErrorCommand> handler,
         CancellationToken cancellationToken)
     {
-        if (!await IsEnabled()) return NotFound();
         await handler.Handle(new TestErrorCommand(), cancellationToken);
         return Ok();
     }
@@ -58,7 +54,6 @@ public class TestErrorController(IFeatureManager featureManager) : ControllerBas
     public async Task<IActionResult> SimulateTimeout(
         [FromServices] ICommandHandler<TestErrorCommand> handler)
     {
-        if (!await IsEnabled()) return NotFound();
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
         await handler.Handle(new TestErrorCommand { WithDelay = true }, cts.Token);
         return Ok();
@@ -74,8 +69,6 @@ public class TestErrorController(IFeatureManager featureManager) : ControllerBas
     public async Task<IActionResult> SimulateSmartyFailure(
         [FromServices] IHttpClientFactory httpClientFactory)
     {
-        if (!await IsEnabled()) return NotFound();
-
         var client = httpClientFactory.CreateClient("Smarty");
         try
         {

--- a/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
+++ b/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
@@ -97,6 +97,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.3.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -151,6 +151,7 @@
     "MaxStreetAddressLength": 0
   },
   "FeatureManagement": {
+    "test_error_endpoints_enabled": false,
     "email_dob_opt_in": false,
     "show_application_number": true,
     "show_case_number": true,

--- a/src/SEBT.Portal.Core/AppSettings/FeatureFlags.cs
+++ b/src/SEBT.Portal.Core/AppSettings/FeatureFlags.cs
@@ -14,4 +14,11 @@ public static class FeatureFlags
     /// </summary>
     public const string EnrollmentCheckRequiresAtLeastOneExactMatchedField =
         "enrollment_check_requires_at_least_one_exact_matched_field";
+
+    /// <summary>
+    /// When enabled, the diagnostic test-error endpoints under /api/test-error are active.
+    /// Disabled by default; enable in Development or staging via appsettings.Development.json
+    /// or AWS AppConfig. Never enable in production.
+    /// </summary>
+    public const string TestErrorEndpointsEnabled = "test_error_endpoints_enabled";
 }

--- a/src/SEBT.Portal.UseCases/Dependencies.cs
+++ b/src/SEBT.Portal.UseCases/Dependencies.cs
@@ -5,6 +5,7 @@ using SEBT.Portal.Kernel;
 using SEBT.Portal.StatesPlugins.Interfaces.Models.EnrollmentCheck;
 using SEBT.Portal.UseCases.Auth;
 using SEBT.Portal.UseCases.Auth.SessionLifetime;
+using SEBT.Portal.UseCases.Diagnostics;
 using SEBT.Portal.UseCases.EnrollmentCheck;
 using SEBT.Portal.UseCases.Household;
 using SEBT.Portal.UseCases.IdProofing;
@@ -27,6 +28,7 @@ public static class Dependencies
         services.RegisterCommandHandler<CheckEnrollmentCommand, EnrollmentCheckResult, CheckEnrollmentCommandHandler>();
         services.RegisterCommandHandler<UpdateAddressCommand, Core.Services.AddressValidationResult, UpdateAddressCommandHandler>();
         services.RegisterCommandHandler<RequestCardReplacementCommand, RequestCardReplacementCommandHandler>();
+        services.RegisterCommandHandler<TestErrorCommand, TestErrorCommandHandler>();
 
         // SessionLifetimePolicy is invoked by the JWT bearer middleware on every authenticated
         // request. TryAdd lets a host (e.g., tests) substitute a different TimeProvider.

--- a/src/SEBT.Portal.UseCases/Diagnostics/TestErrorCommand.cs
+++ b/src/SEBT.Portal.UseCases/Diagnostics/TestErrorCommand.cs
@@ -1,0 +1,13 @@
+using SEBT.Portal.Kernel;
+
+namespace SEBT.Portal.UseCases.Diagnostics;
+
+public class TestErrorCommand : ICommand
+{
+    /// <summary>
+    /// When true, the handler delays 30 seconds before throwing, simulating a slow dependency.
+    /// The caller is expected to cancel via a short-lived CancellationTokenSource to exercise
+    /// the timeout / OperationCanceledException path in OTEL tracing.
+    /// </summary>
+    public bool WithDelay { get; init; }
+}

--- a/src/SEBT.Portal.UseCases/Diagnostics/TestErrorCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Diagnostics/TestErrorCommandHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Logging;
+using SEBT.Portal.Kernel;
+using SEBT.Portal.Kernel.Results;
+
+namespace SEBT.Portal.UseCases.Diagnostics;
+
+public class TestErrorCommandHandler(ILogger<TestErrorCommandHandler> logger)
+    : ICommandHandler<TestErrorCommand>
+{
+    // Long enough that a 500 ms controller-side timeout reliably fires first.
+    private const int SimulatedDelayMs = 30_000;
+
+    public async Task<Result> Handle(TestErrorCommand command, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation(
+            "TestErrorCommandHandler invoked (WithDelay={WithDelay}) — diagnostic endpoint",
+            command.WithDelay);
+
+        if (command.WithDelay)
+        {
+            // Awaiting Task.Delay with the caller's token produces a realistic OperationCanceledException
+            // through the OTEL span stack when the controller cancels via its short-lived CTS.
+            await Task.Delay(SimulatedDelayMs, cancellationToken);
+        }
+
+        throw new InvalidOperationException(
+            "Test error: simulated unhandled exception for OTEL span and structured logging validation.");
+    }
+}

--- a/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/EnrollmentCheck/CheckEnrollmentCommandHandler.cs
@@ -36,6 +36,8 @@ public class CheckEnrollmentCommandHandler(
                 "Children", $"A maximum of {maxChildren} children can be checked per request.");
         }
 
+        logger.LogInformation("Enrollment check requested for {ChildCount} child(ren)", command.Children.Count);
+
         var request = new EnrollmentCheckRequest
         {
             Children = command.Children.Select(c => new ChildCheckRequest

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -67,7 +67,7 @@ public class UpdateAddressCommandHandler(
                         firstError?.Message ?? "Address could not be verified.",
                         "not-found"));
             case DependencyFailedResult<AddressUpdateSuccess> addressDependencyFailed:
-                logger.LogWarning(
+                logger.LogError(
                     "Address verification dependency failed: {Reason}",
                     addressDependencyFailed.Reason);
                 return Result<AddressValidationResult>.DependencyFailed(addressDependencyFailed.Reason, addressDependencyFailed.Message);

--- a/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ProcessWebhook/ProcessWebhookCommandHandler.cs
@@ -228,7 +228,7 @@ public class ProcessWebhookCommandHandler(
         var user = await userRepository.GetUserByIdAsync(userId, cancellationToken);
         if (user == null)
         {
-            logger.LogWarning("User {UserId} not found when updating proofing status after verification", userId);
+            logger.LogError("User {UserId} not found when updating proofing status after verification — Socure confirmed identity but portal state cannot be updated", userId);
             return;
         }
 

--- a/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs
@@ -137,7 +137,7 @@ public class ResubmitChallengeCommandHandler(
 
         if (!assessmentResult.IsSuccess)
         {
-            logger.LogWarning(
+            logger.LogError(
                 "ResubmitChallenge: docv_stepup assessment failed for user {UserId}",
                 command.UserId);
             if (assessmentResult is DependencyFailedResult<IdProofingAssessmentResult> depFailed)
@@ -153,7 +153,7 @@ public class ResubmitChallengeCommandHandler(
         if (assessment.Outcome != IdProofingOutcome.DocumentVerificationRequired
             || assessment.DocvSession == null)
         {
-            logger.LogWarning(
+            logger.LogError(
                 "ResubmitChallenge: docv_stepup returned unexpected outcome {Outcome} (DocvSession={HasSession}) for user {UserId}",
                 assessment.Outcome, assessment.DocvSession != null, command.UserId);
             return Result<ResubmitChallengeResponse>.PreconditionFailed(

--- a/src/SEBT.Portal.UseCases/IdProofing/StartChallenge/StartChallengeCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/StartChallenge/StartChallengeCommandHandler.cs
@@ -166,7 +166,7 @@ public class StartChallengeCommandHandler(
         }
         catch (NotSupportedException)
         {
-            logger.LogWarning(
+            logger.LogError(
                 "Challenge {ChallengeId} has no stored DocV data and the Socure client does not " +
                 "support on-demand session creation. User {UserId} must re-submit ID proofing.",
                 command.ChallengeId, command.UserId);
@@ -177,7 +177,7 @@ public class StartChallengeCommandHandler(
 
         if (!sessionResult.IsSuccess)
         {
-            logger.LogWarning("Socure DocV session creation failed for user {UserId}", command.UserId);
+            logger.LogError("Socure DocV session creation failed for user {UserId}", command.UserId);
             return Result<StartChallengeResponse>.DependencyFailed(
                 DependencyFailedReason.ConnectionFailed, "Failed to create document verification session.");
         }
@@ -221,7 +221,7 @@ public class StartChallengeCommandHandler(
             || string.IsNullOrWhiteSpace(challenge.ProofingIdType)
             || string.IsNullOrWhiteSpace(challenge.ProofingIdValue))
         {
-            logger.LogWarning(
+            logger.LogError(
                 "Cannot refresh DocV token for challenge {ChallengeId}: missing stored id-proofing inputs",
                 challenge.PublicId);
             return Result<StartChallengeResponse>.PreconditionFailed(
@@ -296,7 +296,7 @@ public class StartChallengeCommandHandler(
 
         if (!assessmentResult.IsSuccess)
         {
-            logger.LogWarning(
+            logger.LogError(
                 "Socure assessment failed during DocV token refresh for user {UserId}",
                 challenge.UserId);
 
@@ -315,7 +315,7 @@ public class StartChallengeCommandHandler(
         if (assessment.Outcome != IdProofingOutcome.DocumentVerificationRequired
             || assessment.DocvSession == null)
         {
-            logger.LogWarning(
+            logger.LogError(
                 "Socure assessment during DocV token refresh returned unexpected outcome {Outcome} for user {UserId}",
                 assessment.Outcome, challenge.UserId);
             return Result<StartChallengeResponse>.PreconditionFailed(

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -179,7 +179,7 @@ public class SubmitIdProofingCommandHandler(
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger.LogWarning(
+                logger.LogError(
                     "DC warehouse IC+DOB match failed ({ExceptionType}) for co-loaded benefit ID verification for user {UserId}",
                     ex.GetType().Name,
                     command.UserId);
@@ -196,7 +196,7 @@ public class SubmitIdProofingCommandHandler(
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                logger.LogWarning(
+                logger.LogError(
                     "Household lookup failed ({ExceptionType}) for co-loaded benefit ID verification for user {UserId}",
                     ex.GetType().Name,
                     command.UserId);
@@ -258,7 +258,7 @@ public class SubmitIdProofingCommandHandler(
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             householdLookupFailed = true;
-            logger.LogWarning(ex,
+            logger.LogError(ex,
                 "Household lookup failed ({ExceptionType}) for user {UserId}, proceeding without name/address/phone from CMS",
                 ex.GetType().Name,
                 command.UserId);
@@ -315,7 +315,7 @@ public class SubmitIdProofingCommandHandler(
 
         if (!assessmentResult.IsSuccess)
         {
-            logger.LogWarning("Socure assessment failed for user {UserId}", command.UserId);
+            logger.LogError("Socure assessment failed for user {UserId}", command.UserId);
 
             if (assessmentResult is DependencyFailedResult<IdProofingAssessmentResult> depFailed)
             {


### PR DESCRIPTION
#### 🔗 Jira ticket
<!-- Add link to the issue -->

#### ✍️ Description

- External dependency failures (Smarty, Socure) promoted from `LogWarning` to `LogError`
- `CheckEnrollmentCommandHandler` logs child count before dispatching to the state connector
- `[FeatureGate]`-gated `/api/test-error/*` endpoints for OTEL span and log validation (flag off by default); Smarty endpoints exercise the real `SmartyAddressUpdateService` via a fake `HttpMessageHandler`

#### 🔗 Links to related PRs

- CO connector: https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/43

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
       - new feature flag for nonprod envs only: `test_error_endpoints_enabled`
  - [ ] If appsetttings are changed, update in AWS AppConfig