### PR TITLE
Add PR labeler action and update PR template

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+feature:
+  - head-branch: ['^(feat|feature)/']
+bugfix:
+  - head-branch: ['^(fix|bugfix|bug|hotfix)/']
+chore:
+  - head-branch: ['^chore/']
+documentation:
+  - head-branch: ['^(docs|doc|documentation)/']
+proof of concept:
+  - head-branch: ['^poc/']
+security:
+  - head-branch: ['^(security|vuln|sec)/']
+infrastructure:
+  - head-branch: ['^(infra|infrastructure)/']
+dependabot:
+  - head-branch: ['^dependabot/']
+refactor:
+  - head-branch: ['^refactor/']

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+---
+title: "[TICKET] <short description>"
+---
+
 #### 🔗 Jira ticket
 <!-- Add link to the issue -->
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false


### PR DESCRIPTION
#### 🔗 Jira ticket
<!-- Add link to the issue -->

#### ✍️ Description
- Updated .github/pull_request_template.md with title: "[TICKET] <short description>" to ensure uniformity for release notes and work smoothly with Jira<>Github integration
- `pr-labeler.yml` runs [actions/labeler@v5](https://github.com/actions/labeler) on PR open/edit/sync/reopen
- `labeler.yml` maps branch names to label

Once this is merged/tested, will open PRs in the other SEBT repos as well


