### PR TITLE
DC-481: chore: bump NuGet packages — minor/patch + safe major upgrades

### DIFF
--- a/scripts/ClearSeededData/ClearSeededData.csproj
+++ b/scripts/ClearSeededData/ClearSeededData.csproj
@@ -7,10 +7,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
+++ b/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
@@ -93,28 +93,27 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.3.0" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.2.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <!-- Required by state connector plugins that use Kiota-generated API clients -->
     <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
   </ItemGroup>

--- a/src/SEBT.Portal.Core/SEBT.Portal.Core.csproj
+++ b/src/SEBT.Portal.Core/SEBT.Portal.Core.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
       <ProjectReference Include="../SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj" />
     </ItemGroup>
 

--- a/src/SEBT.Portal.Infrastructure.Seeding/SEBT.Portal.Infrastructure.Seeding.csproj
+++ b/src/SEBT.Portal.Infrastructure.Seeding/SEBT.Portal.Infrastructure.Seeding.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
+++ b/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
@@ -27,30 +27,23 @@
       <PackageReference Include="DistributedLock.Redis" Version="1.1.1" />
       <PackageReference Include="DistributedLock.SqlServer" Version="1.0.7" />
       <PackageReference Include="MailKit" Version="4.16.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.4.0" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.4" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
       <PackageReference Include="Bogus" Version="35.6.5" />
-      <PackageReference Include="libphonenumber-csharp" Version="9.0.27" />
-      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-      <PackageReference Include="Microsoft.FeatureManagement" Version="3.3.0" />
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
-      <!--
-        Pinned to override the transitive 9.0.0 pulled in by Microsoft.EntityFrameworkCore.Tools →
-        Microsoft.Build.Tasks.Core. 9.0.0 is flagged by NU1903 for CVE-2026-33116 and CVE-2026-26171
-        (DoS). 9.0.15 is the first patched release on the 9.x line. Remove this pin once
-        Microsoft.Build.Tasks.Core updates its transitive dependency.
-      -->
-      <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
+      <PackageReference Include="libphonenumber-csharp" Version="9.0.30" />
+      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     </ItemGroup>
 
   <!-- State connector as sibling repo only. Sibling under parent of portal, or CI path. -->

--- a/src/SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj
+++ b/src/SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
+++ b/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
@@ -22,8 +22,8 @@
 
     <ItemGroup>
       <PackageReference Include="DistributedLock.Core" Version="1.0.9" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-      <PackageReference Include="Microsoft.FeatureManagement" Version="3.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+      <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
     </ItemGroup>
 
   <!-- State connector as sibling repo only. Sibling under parent of portal, or CI path. -->

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcSourceDatabaseFixture.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcSourceDatabaseFixture.cs
@@ -15,8 +15,7 @@ public class DcSourceDatabaseFixture : IAsyncLifetime
 
     public DcSourceDatabaseFixture()
     {
-        _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
             .WithPassword("YourStrong@Passw0rd")
             .Build();
     }

--- a/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -17,25 +17,22 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+        <PackageReference Include="coverlet.collector" Version="10.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" />
-        <PackageReference Include="Microsoft.FeatureManagement" Version="3.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
+        <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
-        <PackageReference Include="Testcontainers.MsSql" Version="4.1.0" />
-        <PackageReference Include="xunit" Version="2.5.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-        <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+        <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+        <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
     </ItemGroup>
 
   <!-- State connector as sibling repo only. Sibling under parent of portal, or CI path. -->

--- a/test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs
@@ -159,7 +159,7 @@ public class MockHouseholdRepositoryTests
         Assert.Equal(email, result!.Email);
         Assert.Equal("8185558438", result.Phone);
         Assert.NotNull(result.SummerEbtCases);
-        var snapCase = Assert.Single(result.SummerEbtCases.Where(c => c.EbtCaseNumber == "SNAP-CO-001"));
+        var snapCase = Assert.Single(result.SummerEbtCases, c => c.EbtCaseNumber == "SNAP-CO-001");
         Assert.True(snapCase.IsCoLoaded);
     }
 

--- a/test/SEBT.Portal.Tests/Unit/Repositories/SqlServerTestFixture.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/SqlServerTestFixture.cs
@@ -15,8 +15,7 @@ public class SqlServerTestFixture : IAsyncLifetime
     public SqlServerTestFixture()
     {
         // Password is hardcoded for test isolation
-        _container = new MsSqlBuilder()
-            .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
             .WithPassword("YourStrong@Passw0rd")
             .Build();
     }


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-481](https://codeforamerica.atlassian.net/browse/DC-481)

#### ✍️ Description
Batch NuGet package upgrades. All confirmed via `dotnet list package --vulnerable --include-transitive` (zero vulnerabilities across all projects including transitive deps).

Notable non-obvious changes:
- **EF Core 10.0.0 → 10.0.8** severs the `Microsoft.Build.Tasks.Core → System.Security.Cryptography.Xml` CVE chain — the explicit `9.0.15` pin is no longer needed and is removed
- **`Microsoft.Data.SqlClient`** explicit reference removed from `Api.csproj` — nothing calls SqlClient APIs directly; transitive floor from DistributedLock.SqlServer + EF Core is sufficient
- **Serilog major bumps** (8→10 for AspNetCore/Settings.Configuration, 6→7 for Sinks.File) are drop-ins; the version numbers track .NET major releases, not breaking changes
- **FeatureManagement 3.3.0 → 4.5.0** — one breaking change in 4.0 (`FeatureTagHelper` direct instantiation) doesn't apply here

Not in this PR: `Microsoft.Kiota.Abstractions` (requires coordinated upgrade across all 4 repos), `Swashbuckle.AspNetCore` (possible future migration to first-party OpenAPI generator?).

[DC-481]: https://codeforamerica.atlassian.net/browse/DC-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ