### PR TITLE
Ignore .lscache files from c# devkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,7 @@ _pkginfo.txt
 *.[Cc]ache
 # but keep track of directories ending in .cache
 !?*.[Cc]ache/
+*.lscache
 
 # Others
 ClientBin/


### PR DESCRIPTION
#### ✍️ Description
Add `.lscache` to gitignore
