### PR TITLE
Fix: Chrome install on CI

### DIFF
--- a/.github/workflows/playwright-e2e.yaml
+++ b/.github/workflows/playwright-e2e.yaml
@@ -136,14 +136,19 @@ jobs:
       - name: Build backend
         run: ./.github/workflows/scripts/build-backend.sh --configuration Release
 
-      - name: Install Chrome for Pa11y
-        run: cd src/SEBT.Portal.Web && pnpm exec puppeteer browsers install chrome
-
       - name: Build frontend for Pa11y
         env:
           STATE: dc
           NEXT_PUBLIC_STATE: dc
-        run: ./.github/workflows/scripts/build-frontend.sh --production
+        run: ./.github/workflows/scripts/build-frontend.sh --production --skip-install
+
+      - name: Cache Puppeteer browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            puppeteer-${{ runner.os }}-
 
       - name: Run Pa11y accessibility tests
         env:
@@ -167,5 +172,16 @@ jobs:
             sleep 2
           done
           curl -sf --max-time 15 http://localhost:3000 > /dev/null || (echo "Server failed to start" && exit 1)
+          echo "Installing Chrome for Pa11y..."
+          cd src/SEBT.Portal.Web
+          CHROME_INSTALL_OUTPUT="$(pnpm exec puppeteer browsers install chrome)"
+          echo "$CHROME_INSTALL_OUTPUT"
+          CHROME_PATH="${CHROME_INSTALL_OUTPUT#* }"
+          if [ -z "$CHROME_PATH" ] || [ "$CHROME_PATH" = "$CHROME_INSTALL_OUTPUT" ] || [ ! -x "$CHROME_PATH" ]; then
+            echo "Chrome install verification failed: puppeteer did not report an executable path"
+            exit 1
+          fi
+          echo "Chrome ready at $CHROME_PATH"
+          cd ../..
           echo "Running Pa11y accessibility tests..."
           pnpm ci:test:a11y

--- a/.github/workflows/playwright-e2e.yaml
+++ b/.github/workflows/playwright-e2e.yaml
@@ -142,13 +142,16 @@ jobs:
           NEXT_PUBLIC_STATE: dc
         run: ./.github/workflows/scripts/build-frontend.sh --production --skip-install
 
-      - name: Cache Puppeteer browsers
+      - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
-          path: ~/.cache/puppeteer
-          key: puppeteer-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            puppeteer-${{ runner.os }}-
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright Chromium for Pa11y
+        run: cd src/SEBT.Portal.Web && pnpm exec playwright install --with-deps chromium
 
       - name: Run Pa11y accessibility tests
         env:
@@ -172,16 +175,11 @@ jobs:
             sleep 2
           done
           curl -sf --max-time 15 http://localhost:3000 > /dev/null || (echo "Server failed to start" && exit 1)
-          echo "Installing Chrome for Pa11y..."
-          cd src/SEBT.Portal.Web
-          CHROME_INSTALL_OUTPUT="$(pnpm exec puppeteer browsers install chrome)"
-          echo "$CHROME_INSTALL_OUTPUT"
-          CHROME_PATH="${CHROME_INSTALL_OUTPUT#* }"
-          if [ -z "$CHROME_PATH" ] || [ "$CHROME_PATH" = "$CHROME_INSTALL_OUTPUT" ] || [ ! -x "$CHROME_PATH" ]; then
-            echo "Chrome install verification failed: puppeteer did not report an executable path"
+          export PUPPETEER_EXECUTABLE_PATH="$(cd src/SEBT.Portal.Web && node -e "const { chromium } = require('@playwright/test'); console.log(chromium.executablePath());")"
+          if [ -z "$PUPPETEER_EXECUTABLE_PATH" ] || [ ! -x "$PUPPETEER_EXECUTABLE_PATH" ]; then
+            echo "Chromium verification failed: Playwright did not report an executable path"
             exit 1
           fi
-          echo "Chrome ready at $CHROME_PATH"
-          cd ../..
+          echo "Pa11y will use Chromium at $PUPPETEER_EXECUTABLE_PATH"
           echo "Running Pa11y accessibility tests..."
           pnpm ci:test:a11y


### PR DESCRIPTION
#### Jira ticket
N/A

#### Description

Pa11y accessibility tests in the Playwright E2E workflow were failing on CI with `Could not find Chrome (ver. 148.0.7778.97)`. This PR just switches the Pa11y job to use Playwright's Chromium install instead

Verified locally with an empty Puppeteer cache and in ACT (Linux container smoke run): Playwright Chromium installs, Pa11y resolves the browser path, and both configured URLs pass.

#### Links to related PRs

N/A

#### Completion tasks

- [ ] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu (none added)
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager (none added)
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig (none added)
  - [x] If appsetttings are changed, update in AWS AppConfig (none changed)

#### Test plan

- [ ] Confirm the Pa11y Accessibility Tests job passes on GitHub Actions
- [ ] Confirm Playwright E2E Tests (dc) and (co) still pass (unchanged E2E job)
- [ ] In CI logs, verify the Pa11y step prints `Pa11y will use Chromium at ...` with a path under `~/.cache/ms-playwright`
- [ ] Optional local ACT smoke (requires Docker):
  ```bash
  act workflow_dispatch -W .github/workflows/act-pa11y-smoke.yaml -j pa11y-chrome-smoke --container-architecture linux/arm64