### PR TITLE
DC-479 Update ISummerEbtCaseService callers for includeCardService param

### DIFF
--- a/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
+++ b/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
@@ -18,6 +18,7 @@ internal sealed class DefaultSummerEbtCaseService : ISummerEbtCaseService
         PiiVisibility piiVisibility,
         IdentityAssuranceLevel identityAssuranceLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult<HouseholdData?>(null);
@@ -29,6 +30,7 @@ internal sealed class DefaultSummerEbtCaseService : ISummerEbtCaseService
         PiiVisibility piiVisibility,
         IdentityAssuranceLevel identityAssuranceLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult<HouseholdData?>(null);
@@ -52,6 +54,7 @@ internal sealed class DefaultSummerEbtCaseService : ISummerEbtCaseService
         PiiVisibility piiVisibility,
         IdentityAssuranceLevel identityAssuranceLevel,
         Guid portalUserId,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult<HouseholdData?>(null);

--- a/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
+++ b/src/SEBT.Portal.Api/Composition/Defaults/DefaultSummerEbtCaseService.cs
@@ -54,7 +54,6 @@ internal sealed class DefaultSummerEbtCaseService : ISummerEbtCaseService
         PiiVisibility piiVisibility,
         IdentityAssuranceLevel identityAssuranceLevel,
         Guid portalUserId,
-        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult<HouseholdData?>(null);

--- a/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
@@ -87,7 +87,7 @@ public class HouseholdRepository : IHouseholdRepository
             pluginPii,
             pluginIal,
             portalUserId,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         if (pluginHousehold == null)
         {
@@ -190,7 +190,7 @@ public class HouseholdRepository : IHouseholdRepository
             pluginPii,
             pluginIal,
             portalUserId,
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         if (pluginHousehold == null)
         {

--- a/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
@@ -190,7 +190,7 @@ public class HouseholdRepository : IHouseholdRepository
             pluginPii,
             pluginIal,
             portalUserId,
-            cancellationToken: cancellationToken);
+            cancellationToken);
 
         if (pluginHousehold == null)
         {

--- a/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
@@ -153,7 +153,6 @@ public class HouseholdRepositoryTests
                 Arg.Any<PluginPiiVisibility>(),
                 PluginIdentityAssuranceLevel.IAL1plus,
                 userId,
-                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
@@ -174,7 +173,6 @@ public class HouseholdRepositoryTests
             Arg.Any<PluginPiiVisibility>(),
             PluginIdentityAssuranceLevel.IAL1plus,
             userId,
-            Arg.Any<bool>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/HouseholdRepositoryTests.cs
@@ -53,6 +53,7 @@ public class HouseholdRepositoryTests
                 Arg.Any<PluginPiiVisibility>(),
                 Arg.Any<PluginIdentityAssuranceLevel>(),
                 portalUserId,
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns((PluginHouseholdData?)null);
 
@@ -64,6 +65,7 @@ public class HouseholdRepositoryTests
             Arg.Any<PluginPiiVisibility>(),
             Arg.Any<PluginIdentityAssuranceLevel>(),
             portalUserId,
+            Arg.Any<bool>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -95,7 +97,7 @@ public class HouseholdRepositoryTests
         };
 
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
         var result = await _repository.GetHouseholdByEmailAsync(email, FullPii, UserIalLevel.IAL1plus);
@@ -151,6 +153,7 @@ public class HouseholdRepositoryTests
                 Arg.Any<PluginPiiVisibility>(),
                 PluginIdentityAssuranceLevel.IAL1plus,
                 userId,
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
@@ -171,6 +174,7 @@ public class HouseholdRepositoryTests
             Arg.Any<PluginPiiVisibility>(),
             PluginIdentityAssuranceLevel.IAL1plus,
             userId,
+            Arg.Any<bool>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -209,7 +213,7 @@ public class HouseholdRepositoryTests
         };
 
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
         var result = await _repository.GetHouseholdByEmailAsync(email, FullPii, UserIalLevel.IAL1plus);
@@ -238,7 +242,7 @@ public class HouseholdRepositoryTests
     public async Task GetHouseholdByEmailAsync_WhenPluginReturnsNull_ReturnsNull()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((PluginHouseholdData?)null);
 
         var result = await _repository.GetHouseholdByEmailAsync("ishouldnotexist@example.com", FullPii, UserIalLevel.IAL1plus);
@@ -253,7 +257,7 @@ public class HouseholdRepositoryTests
 
         Assert.Null(result);
         await _summerEbtCaseService.DidNotReceive()
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -263,40 +267,40 @@ public class HouseholdRepositoryTests
 
         Assert.Null(result);
         await _summerEbtCaseService.DidNotReceive()
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetHouseholdByEmailAsync_NormalizesEmail()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new PluginHouseholdData { Email = "user@example.com", Applications = new List<PluginApplication>() });
 
         await _repository.GetHouseholdByEmailAsync("  USER@EXAMPLE.COM  ", FullPii, UserIalLevel.IAL1plus);
 
         await _summerEbtCaseService.Received(1)
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, "user@example.com", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, "user@example.com", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetHouseholdByEmailAsync_PassesPiiVisibilityToPlugin()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new PluginHouseholdData { Email = "u@e.com", Applications = new List<PluginApplication>() });
 
         await _repository.GetHouseholdByEmailAsync("u@e.com", new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true), UserIalLevel.IAL1plus);
 
         await _summerEbtCaseService.Received(1)
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, "u@e.com", Arg.Is<PluginPiiVisibility>(p => p.IncludeAddress && p.IncludeEmail && p.IncludePhone), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, "u@e.com", Arg.Is<PluginPiiVisibility>(p => p.IncludeAddress && p.IncludeEmail && p.IncludePhone), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetHouseholdByEmailAsync_WhenPiiVisibilityExcludesEmail_ReturnsMaskedEmail()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new PluginHouseholdData { Email = "u@e.com", Phone = "303-555-0100", Applications = new List<PluginApplication>() });
 
         var noEmailPii = new PiiVisibility(IncludeAddress: true, IncludeEmail: false, IncludePhone: true);
@@ -312,7 +316,7 @@ public class HouseholdRepositoryTests
     public async Task GetHouseholdByEmailAsync_WhenPiiExcludesPhone_ReturnsMaskedPhone()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new PluginHouseholdData { Email = "u@e.com", Phone = "303-555-0100", Applications = new List<PluginApplication>() });
 
         var noPhonePii = new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: false);
@@ -327,7 +331,7 @@ public class HouseholdRepositoryTests
     public async Task GetHouseholdByEmailAsync_WhenPiiExcludesAddress_ReturnsMaskedAddress()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new PluginHouseholdData
             {
                 Email = "u@e.com",
@@ -359,7 +363,7 @@ public class HouseholdRepositoryTests
     public async Task GetHouseholdByEmailAsync_WhenPiiVisibilityExcludesAddress_ReturnsMaskedAddressOnFile()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new PluginHouseholdData
             {
                 Email = "u@e.com",
@@ -391,7 +395,7 @@ public class HouseholdRepositoryTests
         var email = "guardian@example.com";
         var pluginData = new PluginHouseholdData { Email = email, Applications = new List<PluginApplication>() };
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
         var result = await _repository.GetHouseholdByIdentifierAsync(
@@ -400,7 +404,7 @@ public class HouseholdRepositoryTests
         Assert.NotNull(result);
         // Plugin always receives full visibility — masking is handled by ApplyPiiVisibility
         await _summerEbtCaseService.Received(1)
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Is<PluginPiiVisibility>(p => p.IncludeAddress && p.IncludeEmail && p.IncludePhone), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Email, email, Arg.Is<PluginPiiVisibility>(p => p.IncludeAddress && p.IncludeEmail && p.IncludePhone), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -409,7 +413,7 @@ public class HouseholdRepositoryTests
         var phone = "8185558439";
         var pluginData = new PluginHouseholdData { Phone = phone, Applications = new List<PluginApplication>() };
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, phone, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, phone, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
         var result = await _repository.GetHouseholdByIdentifierAsync(
@@ -418,7 +422,7 @@ public class HouseholdRepositoryTests
         Assert.NotNull(result);
         Assert.Equal(phone, result.Phone);
         await _summerEbtCaseService.Received(1)
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, phone, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, phone, Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -426,14 +430,14 @@ public class HouseholdRepositoryTests
     {
         var pluginData = new PluginHouseholdData { Phone = "8185558439", Applications = new List<PluginApplication>() };
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, "8185558439", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, "8185558439", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(pluginData);
 
         await _repository.GetHouseholdByIdentifierAsync(
             HouseholdIdentifier.Phone("  8185558439  "), FullPii, UserIalLevel.IAL1plus);
 
         await _summerEbtCaseService.Received(1)
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, "8185558439", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.Phone, "8185558439", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -444,7 +448,7 @@ public class HouseholdRepositoryTests
 
         Assert.Null(result);
         await _summerEbtCaseService.DidNotReceive()
-            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+            .GetHouseholdByIdentifierAsync(Arg.Any<PluginHouseholdIdentifierType>(), Arg.Any<string>(), Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -458,7 +462,7 @@ public class HouseholdRepositoryTests
     public async Task GetHouseholdByIdentifierAsync_WhenPluginReturnsNull_ReturnsNull()
     {
         _summerEbtCaseService
-            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.SnapId, "SNAP123", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .GetHouseholdByIdentifierAsync(PluginHouseholdIdentifierType.SnapId, "SNAP123", Arg.Any<PluginPiiVisibility>(), Arg.Any<PluginIdentityAssuranceLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((PluginHouseholdData?)null);
 
         var result = await _repository.GetHouseholdByIdentifierAsync(


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-479 (will be subsequent PR)

#### ✍️ Description
Tracks the interface change in `sebt-self-service-portal-state-connector`.

- `DefaultSummerEbtCaseService` — adds the new param to its no-op implementations.
- `HouseholdRepository` — two call sites updated to use `cancellationToken:` as a named argument; inserting `bool includeCardService` before `CancellationToken` broke the positional form.

No behavioral change — `includeCardService` defaults to `true` at every call site.

#### 🔗 Links to related PRs
- State connector: codeforamerica/sebt-self-service-portal-state-connector (feature/cbms-ebt-card-service-param)
- DC connector: codeforamerica/sebt-self-service-portal-dc-connector (feature/cbms-ebt-card-service-param)
- [CO connector: codeforamerica/sebt-self-service-portal-co-connector (feature/cbms-ebt-card-service-param)](https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/45)

#### ✅ Completion tasks

- [x] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [x] Configuration changes: none