### PR TITLE
DC-478: tighten spinner spacing and bump thickness

### DIFF
--- a/packages/design-system/design/sass/components/_spinner.scss
+++ b/packages/design-system/design/sass/components/_spinner.scss
@@ -15,7 +15,7 @@ Color follows the per-state primary theme via USWDS tokens.
   display: inline-block;
   width: units(6);
   height: units(6);
-  border: 5px solid color('primary');
+  border: 7px solid color('primary');
   border-bottom-color: transparent;
   border-radius: 50%;
   box-sizing: border-box;

--- a/packages/design-system/src/components/ui/LoadingInterstitial.tsx
+++ b/packages/design-system/src/components/ui/LoadingInterstitial.tsx
@@ -11,10 +11,10 @@ export function LoadingInterstitial({ title, message }: LoadingInterstitialProps
       aria-live="polite"
       aria-busy="true"
     >
-      <div className="text-center margin-bottom-3">
+      <div className="text-center margin-bottom-0">
         <span className="usa-spinner" aria-hidden="true" />
       </div>
-      <h1 className="font-sans-xl text-primary text-center margin-bottom-4">
+      <h1 className="font-sans-xl text-primary text-center margin-top-1 margin-bottom-4">
         {title}
       </h1>
       <div className="border-1px border-primary-light bg-primary-lightest radius-md padding-3 margin-bottom-2">


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-478

#### ✍️ Description
Follow-up tweaks to the spinner introduced in #359, based on visual feedback from comparing to the Figma frame on the live CO loading screen.

- Spinner border bumped from 5px → 7px so the arc reads more solidly at 48px diameter.
- Spacing between the spinner and the "Please wait…" heading collapsed: the wrapper's `margin-bottom-3` is now `margin-bottom-0`, and `margin-top-1` was added to the `<h1>` to override the USWDS default heading top margin (~1.5em). Net effect: ~8px gap instead of the previous ~24px + heading default.

No new tests — existing tests still pass; nothing structurally changed, only utility classes and one border width.

#### 🔗 Links to related PRs
- Original PR: #359 (merged)

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu (none added)
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager (none added)
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig (none added)
  - [x] If appsetttings are changed, update in AWS AppConfig (none changed)