### PR TITLE
DC-479: (CO) Deferred FIS card details for household data calls

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Household/HouseholdController.cs
@@ -41,9 +41,14 @@ public class HouseholdController : ControllerBase
         [FromServices] IQueryHandler<GetHouseholdDataQuery, Core.Models.Household.HouseholdData> queryHandler,
         [FromServices] IIdentifierHasher identifierHasher,
         [FromServices] IConfiguration configuration,
+        [FromQuery] bool includeCardDetails = true,
         CancellationToken cancellationToken = default)
     {
-        var query = new GetHouseholdDataQuery { User = User };
+        var query = new GetHouseholdDataQuery
+        {
+            User = User,
+            IncludeCardDetails = includeCardDetails
+        };
         var result = await queryHandler.Handle(query, cancellationToken);
 
         return result.ToActionResult(

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -150,6 +150,7 @@
     "show_application_number": true,
     "show_case_number": true,
     "show_card_last4": true,
+    "defer_ebt_card_data_loading": false,
     "enable_beta_banner": false,
     "show_contact_preferences": false,
     "AppConfig": {

--- a/src/SEBT.Portal.Core/AppSettings/FeatureFlags.cs
+++ b/src/SEBT.Portal.Core/AppSettings/FeatureFlags.cs
@@ -16,6 +16,12 @@ public static class FeatureFlags
         "enrollment_check_requires_at_least_one_exact_matched_field";
 
     /// <summary>
+    /// When enabled (CO), the dashboard may request household data without CBMS FIS card
+    /// details first, then load card fields in a follow-up request. Defaults to false.
+    /// </summary>
+    public const string DeferEbtCardDataLoading = "defer_ebt_card_data_loading";
+
+    /// <summary>
     /// When enabled, the diagnostic test-error endpoints under /api/test-error are active.
     /// Disabled by default; enable in Development or staging via appsettings.Development.json
     /// or AWS AppConfig. Never enable in production.

--- a/src/SEBT.Portal.Core/Repositories/IHouseholdRepository.cs
+++ b/src/SEBT.Portal.Core/Repositories/IHouseholdRepository.cs
@@ -27,6 +27,7 @@ public interface IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -44,6 +45,7 @@ public interface IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/HouseholdRepository.cs
@@ -34,6 +34,7 @@ public class HouseholdRepository : IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         var pluginType = MapToPluginIdentifierType(identifier.Type);
@@ -49,6 +50,7 @@ public class HouseholdRepository : IHouseholdRepository
             piiVisibility,
             userIalLevel,
             portalUserId,
+            includeCardService,
             cancellationToken);
     }
 
@@ -58,6 +60,7 @@ public class HouseholdRepository : IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId,
+        bool includeCardService,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(piiVisibility);
@@ -87,6 +90,7 @@ public class HouseholdRepository : IHouseholdRepository
             pluginPii,
             pluginIal,
             portalUserId,
+            includeCardService,
             cancellationToken: cancellationToken);
 
         if (pluginHousehold == null)
@@ -130,6 +134,7 @@ public class HouseholdRepository : IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         return GetHouseholdByIdentifierInternalAsync(
@@ -138,6 +143,7 @@ public class HouseholdRepository : IHouseholdRepository
             piiVisibility,
             userIalLevel,
             portalUserId,
+            includeCardService,
             cancellationToken);
     }
 

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -44,6 +44,7 @@ public class MockHouseholdRepository : IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(piiVisibility);
@@ -101,6 +102,7 @@ public class MockHouseholdRepository : IHouseholdRepository
         PiiVisibility piiVisibility,
         UserIalLevel userIalLevel,
         Guid? portalUserId = null,
+        bool includeCardService = true,
         CancellationToken cancellationToken = default)
     {
         return GetHouseholdByIdentifierAsync(
@@ -108,6 +110,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             piiVisibility,
             userIalLevel,
             portalUserId,
+            includeCardService,
             cancellationToken);
     }
 

--- a/src/SEBT.Portal.UseCases/Household/GetHouseholdData/GetHouseholdDataQuery.cs
+++ b/src/SEBT.Portal.UseCases/Household/GetHouseholdData/GetHouseholdDataQuery.cs
@@ -15,4 +15,10 @@ public class GetHouseholdDataQuery : IQuery<Core.Models.Household.HouseholdData>
     /// </summary>
     [Required]
     public required ClaimsPrincipal User { get; init; }
+
+    /// <summary>
+    /// When false, state connectors that support it (CO CBMS) skip the FIS card lookup.
+    /// Honored only when <see cref="FeatureFlags.DeferEbtCardDataLoading"/> is enabled.
+    /// </summary>
+    public bool IncludeCardDetails { get; init; } = true;
 }

--- a/src/SEBT.Portal.UseCases/Household/GetHouseholdData/GetHouseholdDataQueryHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/GetHouseholdData/GetHouseholdDataQueryHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Models.Household;
@@ -24,11 +25,16 @@ public class GetHouseholdDataQueryHandler(
     ICardReplacementRequestRepository cardReplacementRepo,
     IIdentifierHasher identifierHasher,
     CoLoadedCohortFilterSettings coLoadedCohortFilter,
+    IFeatureManager featureManager,
     ILogger<GetHouseholdDataQueryHandler> logger)
     : IQueryHandler<GetHouseholdDataQuery, HouseholdData>
 {
     public async Task<Result<HouseholdData>> Handle(GetHouseholdDataQuery query, CancellationToken cancellationToken = default)
     {
+        var deferCardLoadingEnabled = await featureManager
+            .IsEnabledAsync(FeatureFlags.DeferEbtCardDataLoading)
+            .ConfigureAwait(false);
+        var includeCardService = deferCardLoadingEnabled ? query.IncludeCardDetails : true;
         var identifier = await resolver.ResolveAsync(query.User, cancellationToken);
 
         if (identifier == null)
@@ -55,6 +61,7 @@ public class GetHouseholdDataQueryHandler(
             piiVisibility,
             userIalLevel,
             portalUserId,
+            includeCardService,
             cancellationToken);
 
         if (householdData == null

--- a/src/SEBT.Portal.UseCases/Household/RequestCardReplacement/RequestCardReplacementCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/RequestCardReplacement/RequestCardReplacementCommandHandler.cs
@@ -65,7 +65,7 @@ public class RequestCardReplacementCommandHandler(
             new PiiVisibility(IncludeAddress: false, IncludeEmail: false, IncludePhone: false),
             userIalLevel,
             command.User.GetUserId(),
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         if (household == null)
         {

--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -174,7 +174,7 @@ public class UpdateAddressCommandHandler(
             piiVisibility,
             userIalLevel,
             command.User.GetUserId(),
-            cancellationToken);
+            cancellationToken: cancellationToken);
 
         if (household == null)
         {

--- a/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/ResubmitChallenge/ResubmitChallengeCommandHandler.cs
@@ -101,7 +101,7 @@ public class ResubmitChallengeCommandHandler(
                 new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true),
                 warehouseIal,
                 user.Id,
-                cancellationToken);
+                cancellationToken: cancellationToken);
             if (household?.UserProfile != null)
             {
                 givenName = household.UserProfile.FirstName;

--- a/src/SEBT.Portal.UseCases/IdProofing/StartChallenge/StartChallengeCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/StartChallenge/StartChallengeCommandHandler.cs
@@ -256,7 +256,7 @@ public class StartChallengeCommandHandler(
                 new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true),
                 warehouseIal,
                 user.Id,
-                cancellationToken);
+                cancellationToken: cancellationToken);
             if (household?.UserProfile != null)
             {
                 givenName = household.UserProfile.FirstName;

--- a/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/IdProofing/SubmitIdProofing/SubmitIdProofingCommandHandler.cs
@@ -193,7 +193,7 @@ public class SubmitIdProofingCommandHandler(
                     new PiiVisibility(IncludeAddress: false, IncludeEmail: false, IncludePhone: false),
                     warehouseIalForEmailReads,
                     command.UserId,
-                    cancellationToken);
+                    cancellationToken: cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -245,7 +245,7 @@ public class SubmitIdProofingCommandHandler(
                 new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true),
                 warehouseIalForEmailReads,
                 command.UserId,
-                cancellationToken);
+                cancellationToken: cancellationToken);
             if (householdForSocure?.UserProfile != null)
             {
                 givenName = householdForSocure.UserProfile.FirstName;

--- a/src/SEBT.Portal.Web/src/features/household/api/mergeHouseholdCardDetails.test.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/mergeHouseholdCardDetails.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockSummerEbtCase } from '../testing'
+import { mergeHouseholdCardDetails } from './mergeHouseholdCardDetails'
+import type { HouseholdData } from './schema'
+
+const shellCase = createMockSummerEbtCase({
+  summerEBTCaseID: 'CASE-1',
+  childFirstName: 'A',
+  childLastName: 'B',
+  ebtCardStatus: 'Unknown',
+  ebtCardLastFour: undefined,
+  cardRequestedAt: '2026-01-01T00:00:00Z'
+})
+
+const shell: HouseholdData = {
+  email: 'test@example.com',
+  summerEbtCases: [shellCase],
+  applications: [],
+  coLoadedCohort: 'NonCoLoaded'
+}
+
+const full: HouseholdData = {
+  ...shell,
+  summerEbtCases: [
+    createMockSummerEbtCase({
+      summerEBTCaseID: 'CASE-1',
+      childFirstName: 'A',
+      childLastName: 'B',
+      ebtCardLastFour: '4321',
+      ebtCardStatus: 'Active',
+      ebtCardIssueDate: '2026-06-01T00:00:00Z',
+      ebtCardBalance: 120,
+      cardRequestedAt: '2026-01-01T00:00:00Z'
+    })
+  ]
+}
+
+describe('mergeHouseholdCardDetails', () => {
+  it('merges card fields from full response by case id', () => {
+    const merged = mergeHouseholdCardDetails(shell, full)
+    const mergedCase = merged.summerEbtCases[0]
+
+    expect(mergedCase).toBeDefined()
+    expect(mergedCase!.ebtCardLastFour).toBe('4321')
+    expect(mergedCase!.ebtCardStatus).toBe('Active')
+    expect(mergedCase!.cardRequestedAt).toBe('2026-01-01T00:00:00Z')
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/household/api/mergeHouseholdCardDetails.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/mergeHouseholdCardDetails.ts
@@ -1,0 +1,39 @@
+import type { HouseholdData, SummerEbtCase } from './schema'
+
+function caseKey(summerEbtCase: SummerEbtCase): string {
+  return (
+    summerEbtCase.summerEBTCaseID ??
+    `${summerEbtCase.childFirstName}|${summerEbtCase.childLastName}|${summerEbtCase.childDateOfBirth}`
+  )
+}
+
+/**
+ * Merges card fields from a full household response into the shell response,
+ * preserving portal-hydrated fields (e.g. cardRequestedAt) on the shell cases.
+ */
+export function mergeHouseholdCardDetails(
+  shell: HouseholdData,
+  full: HouseholdData
+): HouseholdData {
+  const fullByKey = new Map(full.summerEbtCases.map((c) => [caseKey(c), c]))
+
+  return {
+    ...shell,
+    summerEbtCases: shell.summerEbtCases.map((shellCase) => {
+      const fullCase = fullByKey.get(caseKey(shellCase))
+      if (!fullCase) {
+        return shellCase
+      }
+
+      return {
+        ...shellCase,
+        ...(fullCase.ebtCardLastFour != null ? { ebtCardLastFour: fullCase.ebtCardLastFour } : {}),
+        ...(fullCase.ebtCardStatus != null ? { ebtCardStatus: fullCase.ebtCardStatus } : {}),
+        ...(fullCase.ebtCardIssueDate != null
+          ? { ebtCardIssueDate: fullCase.ebtCardIssueDate }
+          : {}),
+        ...(fullCase.ebtCardBalance != null ? { ebtCardBalance: fullCase.ebtCardBalance } : {})
+      }
+    })
+  }
+}

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
@@ -342,4 +342,54 @@ describe('useHouseholdData', () => {
       expect(result.current.error).toBeDefined()
     })
   })
+
+  describe('Deferred card details', () => {
+    it('fetches shell then full household when deferCardDetailsOnLoad is true', async () => {
+      vi.useRealTimers()
+      const requests: string[] = []
+      server.use(
+        http.get('/api/household/data', ({ request }) => {
+          const url = new URL(request.url)
+          requests.push(url.searchParams.get('includeCardDetails') ?? 'true')
+          const includeCardDetails = url.searchParams.get('includeCardDetails') !== 'false'
+          const caseData = includeCardDetails
+            ? { ebtCardLastFour: '9999', ebtCardStatus: 'Active' }
+            : { ebtCardStatus: 'Unknown' }
+          return HttpResponse.json({
+            email: 'test@example.com',
+            benefitIssuanceType: 1,
+            summerEbtCases: [
+              {
+                summerEBTCaseID: 'CASE-1',
+                childFirstName: 'Test',
+                childLastName: 'Child',
+                childDateOfBirth: '2015-01-01',
+                householdType: 'SEBT',
+                eligibilityType: 'NSLP',
+                issuanceType: 1,
+                ...caseData
+              }
+            ],
+            applications: [],
+            coLoadedCohort: 0
+          })
+        })
+      )
+
+      const { result } = renderHook(() => useHouseholdData({ deferCardDetailsOnLoad: true }), {
+        wrapper: createWrapper()
+      })
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+
+      await waitFor(() => {
+        expect(result.current.data?.summerEbtCases[0]?.ebtCardLastFour).toBe('9999')
+      })
+
+      expect(requests.filter((r) => r === 'false').length).toBeGreaterThanOrEqual(1)
+      expect(requests.filter((r) => r === 'true').length).toBeGreaterThanOrEqual(1)
+    })
+  })
 })

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -1,17 +1,38 @@
 'use client'
 
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { ApiError, apiFetch } from '@/api'
 
+import { mergeHouseholdCardDetails } from './mergeHouseholdCardDetails'
 import { HouseholdDataSchema, type HouseholdData } from './schema'
 
-async function fetchHouseholdData(): Promise<HouseholdData> {
-  return apiFetch<HouseholdData>('/household/data', {
+async function fetchHouseholdData(includeCardDetails = true): Promise<HouseholdData> {
+  const query = includeCardDetails ? '' : '?includeCardDetails=false'
+  return apiFetch<HouseholdData>(`/household/data${query}`, {
     schema: HouseholdDataSchema
   })
+}
+
+const householdRetry = (failureCount: number, error: Error) => {
+  if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+    return false
+  }
+  return failureCount < 2
+}
+
+const householdRetryDelay = (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 10000)
+
+export interface UseHouseholdDataOptions {
+  /** Whether to auto-redirect on 403 with requiredIal. Defaults to true. */
+  redirectOnInsufficientIal?: boolean
+  /**
+   * When true (CO dashboard with defer_ebt_card_data_loading), loads household
+   * without card details first, then fetches card fields for enrolled children.
+   */
+  deferCardDetailsOnLoad?: boolean
 }
 
 /**
@@ -23,45 +44,71 @@ async function fetchHouseholdData(): Promise<HouseholdData> {
  * below the minimum required by their cases. By default the hook redirects
  * to `/login/id-proofing` and exposes `requiresProofing` so consumers can
  * render a loading state during the redirect.
- *
- * @param options.redirectOnInsufficientIal - Whether to auto-redirect on 403.
- *   Defaults to `true`. Set to `false` to handle the 403 yourself (e.g., show
- *   an inline prompt instead of redirecting).
- * @returns TanStack Query result with household data, plus `requiresProofing` flag
  */
-export function useHouseholdData({ redirectOnInsufficientIal = true } = {}) {
+export function useHouseholdData({
+  redirectOnInsufficientIal = true,
+  deferCardDetailsOnLoad = false
+}: UseHouseholdDataOptions = {}) {
   const router = useRouter()
+  const queryClient = useQueryClient()
 
   const query = useQuery({
     queryKey: ['householdData'],
-    queryFn: fetchHouseholdData,
+    queryFn: () => (deferCardDetailsOnLoad ? fetchHouseholdData(false) : fetchHouseholdData(true)),
     staleTime: 0,
     gcTime: 5 * 60 * 1000, // 5 minutes for back-navigation
     refetchOnWindowFocus: true,
-    retry: (failureCount, error) => {
-      // Don't retry client errors (4xx)
-      if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
-        return false
-      }
-      // Retry server errors up to 2 times
-      return failureCount < 2
-    },
-    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000)
+    retry: householdRetry,
+    retryDelay: householdRetryDelay
   })
 
-  // A 403 with requiredIal in the response body means the user's IAL is below
-  // the minimum required by their cases. Redirect to ID proofing.
+  const shouldFetchCardDetails =
+    deferCardDetailsOnLoad && query.isSuccess && (query.data?.summerEbtCases.length ?? 0) > 0
+
+  const cardDetailsQuery = useQuery({
+    queryKey: ['householdData', 'cardDetails'],
+    queryFn: () => fetchHouseholdData(true),
+    enabled: shouldFetchCardDetails,
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: true,
+    retry: householdRetry,
+    retryDelay: householdRetryDelay
+  })
+
+  const data = useMemo(() => {
+    if (!query.data) {
+      return query.data
+    }
+
+    if (cardDetailsQuery.data) {
+      return mergeHouseholdCardDetails(query.data, cardDetailsQuery.data)
+    }
+
+    return query.data
+  }, [query.data, cardDetailsQuery.data])
+
+  useEffect(() => {
+    if (!query.data || !cardDetailsQuery.data) {
+      return
+    }
+
+    queryClient.setQueryData(
+      ['householdData'],
+      mergeHouseholdCardDetails(query.data, cardDetailsQuery.data)
+    )
+  }, [query.data, cardDetailsQuery.data, queryClient])
+
   const requiresProofing =
     query.error instanceof ApiError &&
     query.error.status === 403 &&
     'requiredIal' in ((query.error.data as Record<string, unknown>) ?? {})
 
-  // When apiFetch has triggered a 401 redirect to /login, suppress the error
-  // state so the dashboard stays in its loading shell instead of flashing the
-  // error alert before the browser navigates.
   const isRedirecting = query.error instanceof ApiError && query.error.isRedirecting
   const isError = query.isError && !isRedirecting
   const isLoading = query.isLoading || isRedirecting
+  const isLoadingCardDetails =
+    shouldFetchCardDetails && (cardDetailsQuery.isLoading || cardDetailsQuery.isFetching)
 
   useEffect(() => {
     if (requiresProofing && redirectOnInsufficientIal) {
@@ -69,5 +116,5 @@ export function useHouseholdData({ redirectOnInsufficientIal = true } = {}) {
     }
   }, [requiresProofing, redirectOnInsufficientIal, router])
 
-  return { ...query, isError, isLoading, requiresProofing }
+  return { ...query, data, isError, isLoading, requiresProofing, isLoadingCardDetails }
 }

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -107,8 +107,8 @@ export function useHouseholdData({
   const isRedirecting = query.error instanceof ApiError && query.error.isRedirecting
   const isError = query.isError && !isRedirecting
   const isLoading = query.isLoading || isRedirecting
-  const isLoadingCardDetails =
-    shouldFetchCardDetails && (cardDetailsQuery.isLoading || cardDetailsQuery.isFetching)
+  // Initial card fetch only; background refetches (refetchOnWindowFocus) keep showing merged card data.
+  const isLoadingCardDetails = shouldFetchCardDetails && cardDetailsQuery.isLoading
 
   useEffect(() => {
     if (requiresProofing && redirectOnInsufficientIal) {

--- a/src/SEBT.Portal.Web/src/features/household/components/ChildCard/ChildCard.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ChildCard/ChildCard.tsx
@@ -43,6 +43,8 @@ interface ChildCardProps {
    * When omitted, defaults to allowed (backward-compatible).
    */
   canRequestReplacementCard?: boolean | undefined
+  /** True while a deferred CBMS card-details request is in flight (CO dashboard). */
+  cardDetailsLoading?: boolean
 }
 
 // Keys map to CSV: "S2 - Portal Dashboard - Card Table - cardTableType{Sebt|Snap|Tanf}"
@@ -56,7 +58,8 @@ const CARD_TYPE_KEYS: Partial<Record<IssuanceType, string>> = {
 export function ChildCard({
   summerEbtCase,
   defaultExpanded = true,
-  canRequestReplacementCard = true
+  canRequestReplacementCard = true,
+  cardDetailsLoading = false
 }: ChildCardProps) {
   const { t, i18n } = useTranslation('dashboard')
   const showCaseNumber = useFeatureFlag('show_case_number')
@@ -129,23 +132,42 @@ export function ChildCard({
               <dd className="margin-left-0">{t(cardTypeKey)}</dd>
             </>
           )}
-          {showCardLast4 && ebtCardLastFour && (
+          {cardDetailsLoading ? (
             <>
-              <dt className="text-bold margin-top-2">
-                {t('cardTableHeadingCardNumber', { defaultValue: 'Card number' })}
-              </dt>
-              <dd className="margin-left-0">
-                {t('cardTableLastFourDigits', { defaultValue: '[9999]' }).replace(
-                  '[9999]',
-                  ebtCardLastFour
-                )}
+              <dt className="text-bold margin-top-2">{t('cardTableHeadingCardStatus')}</dt>
+              <dd
+                className="margin-left-0"
+                aria-live="polite"
+              >
+                {t('cardTableCardDetailsLoading', {
+                  defaultValue: 'Loading card information…'
+                })}
               </dd>
             </>
-          )}
-          {isWithinCooldownPeriod(cardRequestedAt) ? (
-            <CardStatusTimeline cardRequestedAt={cardRequestedAt} />
           ) : (
-            <CardStatusDisplay cardStatus={ebtCardStatus} cardIssuedAt={ebtCardIssueDate ?? null} />
+            <>
+              {showCardLast4 && ebtCardLastFour && (
+                <>
+                  <dt className="text-bold margin-top-2">
+                    {t('cardTableHeadingCardNumber', { defaultValue: 'Card number' })}
+                  </dt>
+                  <dd className="margin-left-0">
+                    {t('cardTableLastFourDigits', { defaultValue: '[9999]' }).replace(
+                      '[9999]',
+                      ebtCardLastFour
+                    )}
+                  </dd>
+                </>
+              )}
+              {isWithinCooldownPeriod(cardRequestedAt) ? (
+                <CardStatusTimeline cardRequestedAt={cardRequestedAt} />
+              ) : (
+                <CardStatusDisplay
+                  cardStatus={ebtCardStatus}
+                  cardIssuedAt={ebtCardIssueDate ?? null}
+                />
+              )}
+            </>
           )}
         </dl>
         {replacementLink && (

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -3,6 +3,7 @@
 import { ApiError } from '@/api'
 import { CoLoadingScreen } from '@/components/CoLoadingScreen'
 import { SignOutLink, useAuth } from '@/features/auth'
+import { useFeatureFlag } from '@/features/feature-flags'
 import { getColoadingStatus } from '@/lib/coloadingStatus'
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
 import { Alert, getState } from '@sebt/design-system'
@@ -11,6 +12,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useHouseholdData } from '../../api'
 import { toAnalyticsCohort } from '../../api/schema'
+import { HouseholdCardDetailsLoadingProvider } from '../../context/HouseholdCardDetailsLoadingContext'
 import { ActionButtons } from '../ActionButtons'
 import { ApplicationsSection } from '../ApplicationsSection'
 import { DashboardAlerts } from '../DashboardAlerts'
@@ -52,11 +54,15 @@ export function DashboardContent() {
   const { t } = useTranslation('dashboard')
   const { t: tProcessing } = useTranslation('step-upProcessing')
 
-  const { data, isLoading, isError, error, requiresProofing } = useHouseholdData()
+  const deferEbtCardLoading = useFeatureFlag('defer_ebt_card_data_loading')
+  const isCO = getState() === 'co'
+  const { data, isLoading, isError, error, requiresProofing, isLoadingCardDetails } =
+    useHouseholdData({
+      deferCardDetailsOnLoad: isCO && deferEbtCardLoading
+    })
   const { setPageData, setUserData, trackEvent } = useDataLayer()
   const { session } = useAuth()
   const sessionIsCoLoaded = session?.isCoLoaded
-  const isCO = getState() === 'co'
 
   useEffect(() => {
     if (isLoading) return
@@ -180,7 +186,7 @@ export function DashboardContent() {
   }
 
   return (
-    <>
+    <HouseholdCardDetailsLoadingProvider value={isLoadingCardDetails}>
       {pageHeading}
       <DashboardAlerts />
       <ActionButtons
@@ -196,6 +202,6 @@ export function DashboardContent() {
         </>
       )}
       <ApplicationsSection />
-    </>
+    </HouseholdCardDetailsLoadingProvider>
   )
 }

--- a/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/EnrolledChildren/EnrolledChildren.tsx
@@ -5,12 +5,14 @@ import { useTranslation } from 'react-i18next'
 import { getApplyHref } from '@/lib/applyHref'
 
 import { useRequiredHouseholdData } from '../../api'
+import { useHouseholdCardDetailsLoading } from '../../context/HouseholdCardDetailsLoadingContext'
 import { ChildCard } from '../ChildCard'
 
 // Keys map to CSV: "S2 - Portal Dashboard - Section Enrolled Children - {Key}"
 export function EnrolledChildren() {
   const { t, i18n } = useTranslation('dashboard')
   const data = useRequiredHouseholdData()
+  const cardDetailsLoading = useHouseholdCardDetailsLoading()
   const applyHref = getApplyHref(i18n.language)
 
   return (
@@ -41,6 +43,7 @@ export function EnrolledChildren() {
             summerEbtCase={c}
             defaultExpanded={index === 0}
             canRequestReplacementCard={data.allowedActions?.canRequestReplacementCard}
+            cardDetailsLoading={cardDetailsLoading}
           />
         ))}
       </div>

--- a/src/SEBT.Portal.Web/src/features/household/context/HouseholdCardDetailsLoadingContext.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/context/HouseholdCardDetailsLoadingContext.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+
+const HouseholdCardDetailsLoadingContext = createContext(false)
+
+export function HouseholdCardDetailsLoadingProvider({
+  value,
+  children
+}: {
+  value: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <HouseholdCardDetailsLoadingContext.Provider value={value}>
+      {children}
+    </HouseholdCardDetailsLoadingContext.Provider>
+  )
+}
+
+export function useHouseholdCardDetailsLoading(): boolean {
+  return useContext(HouseholdCardDetailsLoadingContext)
+}

--- a/src/SEBT.Portal.Web/src/mocks/handlers.ts
+++ b/src/SEBT.Portal.Web/src/mocks/handlers.ts
@@ -46,6 +46,7 @@ export const TEST_FEATURE_FLAGS = {
   show_application_number: true,
   show_case_number: true,
   show_card_last4: true,
+  defer_ebt_card_data_loading: false,
   enable_beta_banner: false
 } as const
 
@@ -332,10 +333,25 @@ export const handlers = [
   })(),
 
   // Household data endpoint
-  http.get('/api/household/data', async () => {
+  http.get('/api/household/data', async ({ request }) => {
     await delay(50)
 
-    return HttpResponse.json(TEST_HOUSEHOLD_DATA)
+    const url = new URL(request.url)
+    const includeCardDetails = url.searchParams.get('includeCardDetails') !== 'false'
+    if (includeCardDetails) {
+      return HttpResponse.json(TEST_HOUSEHOLD_DATA)
+    }
+
+    return HttpResponse.json({
+      ...TEST_HOUSEHOLD_DATA,
+      summerEbtCases: TEST_HOUSEHOLD_DATA.summerEbtCases.map((c) => ({
+        ...c,
+        ebtCardLastFour: undefined,
+        ebtCardStatus: 'Unknown',
+        ebtCardIssueDate: undefined,
+        ebtCardBalance: undefined
+      }))
+    })
   }),
 
   // Address update endpoint

--- a/test/SEBT.Portal.Tests/Unit/Controllers/HouseholdControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/HouseholdControllerTests.cs
@@ -60,6 +60,10 @@ public class HouseholdControllerTests
     {
         var logger = NullLogger<GetHouseholdDataQueryHandler>.Instance;
         var userRepository = Substitute.For<IUserRepository>();
+        var featureManager = Substitute.For<Microsoft.FeatureManagement.IFeatureManager>();
+        featureManager.IsEnabledAsync(SEBT.Portal.Core.AppSettings.FeatureFlags.DeferEbtCardDataLoading)
+            .Returns(false);
+
         return new GetHouseholdDataQueryHandler(
             resolver,
             repository,
@@ -70,6 +74,7 @@ public class HouseholdControllerTests
             _cardReplacementRepo,
             _identifierHasher,
             new CoLoadedCohortFilterSettings(),
+            featureManager,
             logger);
     }
 
@@ -154,7 +159,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -167,7 +172,7 @@ public class HouseholdControllerTests
         Assert.Equal(email, response.Email);
         Assert.NotNull(response.AddressOnFile);
         Assert.Equal("123 Main St", response.AddressOnFile.StreetAddress1);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -198,7 +203,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -210,7 +215,7 @@ public class HouseholdControllerTests
         var response = Assert.IsType<HouseholdDataResponse>(okResult.Value);
         Assert.Equal(email, response.Email);
         Assert.Null(response.AddressOnFile);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -224,7 +229,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
         // Act
@@ -235,7 +240,7 @@ public class HouseholdControllerTests
         var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
         var errorResponse = Assert.IsType<ErrorResponse>(notFoundResult.Value);
         Assert.Contains("Household data not found", errorResponse.Error, StringComparison.OrdinalIgnoreCase);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -261,7 +266,7 @@ public class HouseholdControllerTests
         var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result);
         var errorResponse = Assert.IsType<ErrorResponse>(unauthorizedResult.Value);
         Assert.Contains("Unable to identify user", errorResponse.Error, StringComparison.OrdinalIgnoreCase);
-        await repositoryMock.DidNotReceive().GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.DidNotReceive().GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -285,7 +290,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -294,7 +299,7 @@ public class HouseholdControllerTests
         // Assert
         Assert.NotNull(result);
         var okResult = Assert.IsType<OkObjectResult>(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -317,7 +322,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -325,7 +330,7 @@ public class HouseholdControllerTests
 
         // Assert
         Assert.NotNull(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -358,7 +363,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -367,7 +372,7 @@ public class HouseholdControllerTests
         // Assert
         Assert.NotNull(result);
         var okResult = Assert.IsType<OkObjectResult>(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -400,7 +405,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -409,7 +414,7 @@ public class HouseholdControllerTests
         // Assert
         Assert.NotNull(result);
         var okResult = Assert.IsType<OkObjectResult>(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -424,7 +429,7 @@ public class HouseholdControllerTests
         var householdData = new HouseholdData { Email = email };
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -432,7 +437,7 @@ public class HouseholdControllerTests
 
         // Assert
         Assert.NotNull(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -447,7 +452,7 @@ public class HouseholdControllerTests
         var householdData = new HouseholdData { Email = email };
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -455,7 +460,7 @@ public class HouseholdControllerTests
 
         // Assert
         Assert.NotNull(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -477,7 +482,7 @@ public class HouseholdControllerTests
         var householdData = new HouseholdData { Email = email };
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -485,7 +490,7 @@ public class HouseholdControllerTests
 
         // Assert
         Assert.NotNull(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     // --- RequestCardReplacement tests ---
@@ -583,7 +588,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -591,7 +596,7 @@ public class HouseholdControllerTests
 
         // Assert
         Assert.NotNull(result);
-        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await repositoryMock.Received(1).GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -636,7 +641,7 @@ public class HouseholdControllerTests
 
         var resolverMock = CreateResolverMock(email);
         var repositoryMock = Substitute.For<IHouseholdRepository>();
-        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        repositoryMock.GetHouseholdByIdentifierAsync(Arg.Is<HouseholdIdentifier>(id => id.Type == PreferredHouseholdIdType.Email && id.Value == EmailNormalizer.Normalize(email)), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         // Act
@@ -689,7 +694,7 @@ public class HouseholdControllerTests
         var repositoryMock = Substitute.For<IHouseholdRepository>();
         repositoryMock.GetHouseholdByIdentifierAsync(
             Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-            Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var coConfig = new ConfigurationBuilder()
@@ -733,7 +738,7 @@ public class HouseholdControllerTests
         var repositoryMock = Substitute.For<IHouseholdRepository>();
         repositoryMock.GetHouseholdByIdentifierAsync(
             Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-            Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var coConfig = new ConfigurationBuilder()
@@ -773,7 +778,7 @@ public class HouseholdControllerTests
         var repositoryMock = Substitute.For<IHouseholdRepository>();
         repositoryMock.GetHouseholdByIdentifierAsync(
             Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-            Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var dcConfig = new ConfigurationBuilder()

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/GetHouseholdDataQueryHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/GetHouseholdDataQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.FeatureManagement;
 using NSubstitute;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models;
@@ -23,6 +24,7 @@ public class GetHouseholdDataQueryHandlerTests
     private readonly ISelfServiceEvaluator _selfServiceEvaluator = Substitute.For<ISelfServiceEvaluator>();
     private readonly ICardReplacementRequestRepository _cardReplacementRepo = Substitute.For<ICardReplacementRequestRepository>();
     private readonly IIdentifierHasher _identifierHasher = Substitute.For<IIdentifierHasher>();
+    private readonly IFeatureManager _featureManager = Substitute.For<IFeatureManager>();
     private readonly NullLogger<GetHouseholdDataQueryHandler> _logger = NullLogger<GetHouseholdDataQueryHandler>.Instance;
 
     private GetHouseholdDataQueryHandler CreateHandler(CoLoadedCohortFilterSettings? coLoadedCohortFilter = null) =>
@@ -36,10 +38,13 @@ public class GetHouseholdDataQueryHandlerTests
             _cardReplacementRepo,
             _identifierHasher,
             coLoadedCohortFilter ?? new CoLoadedCohortFilterSettings(),
+            _featureManager,
             _logger);
 
     public GetHouseholdDataQueryHandlerTests()
     {
+        _featureManager.IsEnabledAsync(FeatureFlags.DeferEbtCardDataLoading).Returns(false);
+
         _userRepository.GetUserByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((User?)null);
 
@@ -119,6 +124,7 @@ public class GetHouseholdDataQueryHandlerTests
                 Arg.Any<PiiVisibility>(),
                 UserIalLevel.IAL1plus,
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
@@ -200,6 +206,7 @@ public class GetHouseholdDataQueryHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
@@ -236,6 +243,7 @@ public class GetHouseholdDataQueryHandlerTests
                 piiVisibility,
                 UserIalLevel.IAL1plus,
                 userId,
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns(new HouseholdData { Email = email });
 
@@ -247,7 +255,8 @@ public class GetHouseholdDataQueryHandlerTests
             piiVisibility,
             UserIalLevel.IAL1plus,
             userId,
-            Arg.Any<CancellationToken>());
+            Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -267,7 +276,7 @@ public class GetHouseholdDataQueryHandlerTests
         _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.IAL1plus).Returns(piiVisibility);
-        _repository.GetHouseholdByIdentifierAsync(identifier, Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(identifier, Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -286,7 +295,8 @@ public class GetHouseholdDataQueryHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -302,7 +312,7 @@ public class GetHouseholdDataQueryHandlerTests
         _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.None).Returns(piiVisibility);
-        _repository.GetHouseholdByIdentifierAsync(identifier, Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(identifier, Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -320,7 +330,8 @@ public class GetHouseholdDataQueryHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -341,7 +352,7 @@ public class GetHouseholdDataQueryHandlerTests
         Assert.False(result.IsSuccess);
         var unauthorizedResult = Assert.IsType<UnauthorizedResult<HouseholdData>>(result);
         Assert.Contains("Unable to identify user", unauthorizedResult.Message, StringComparison.OrdinalIgnoreCase);
-        await _repository.DidNotReceive().GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -356,7 +367,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.IAL1plus)
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
-        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
         var handler = CreateHandler();
@@ -385,7 +396,7 @@ public class GetHouseholdDataQueryHandlerTests
         _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.None).Returns(piiVisibility);
-        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -401,7 +412,8 @@ public class GetHouseholdDataQueryHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -417,7 +429,7 @@ public class GetHouseholdDataQueryHandlerTests
         _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>())
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.None).Returns(piiVisibility);
-        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -433,7 +445,8 @@ public class GetHouseholdDataQueryHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -449,7 +462,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.IAL1)
             .Returns(new PiiVisibility(IncludeAddress: false, IncludeEmail: true, IncludePhone: true));
-        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
         _idProofingService.Evaluate(
             Arg.Any<ProtectedResource>(), Arg.Any<ProtectedAction>(),
@@ -482,7 +495,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.IAL1plus)
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
-        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
         _idProofingService.Evaluate(
             Arg.Any<ProtectedResource>(), Arg.Any<ProtectedAction>(),
@@ -527,7 +540,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -568,7 +581,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
         _selfServiceEvaluator.Evaluate(Arg.Is<SummerEbtCase>(c => c.SummerEBTCaseID == "SEBT-001"))
             .Returns(new AllowedActions { CanUpdateAddress = true, CanRequestReplacementCard = false });
@@ -612,7 +625,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -650,7 +663,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -693,7 +706,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -732,7 +745,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -778,7 +791,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -815,7 +828,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -856,7 +869,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -900,7 +913,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -935,7 +948,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var cohortFilter = new CoLoadedCohortFilterSettings { SuppressCoLoadedCasesForExcludedCohort = false };
@@ -975,7 +988,7 @@ public class GetHouseholdDataQueryHandlerTests
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
         _repository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(householdData);
 
         var cohortFilter = new CoLoadedCohortFilterSettings { SuppressCoLoadedCasesForExcludedCohort = false };
@@ -1005,7 +1018,7 @@ public class GetHouseholdDataQueryHandlerTests
         _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), token).Returns(identifier);
         _piiVisibilityService.GetVisibility(UserIalLevel.IAL1plus)
             .Returns(new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true));
-        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), token)
+        _repository.GetHouseholdByIdentifierAsync(Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), token)
             .Returns(householdData);
 
         var handler = CreateHandler();
@@ -1022,6 +1035,40 @@ public class GetHouseholdDataQueryHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
+            Arg.Any<bool>(),
             token);
+    }
+
+    [Fact]
+    public async Task Handle_WhenDeferFlagEnabled_PassesIncludeCardServiceFromQuery()
+    {
+        _featureManager.IsEnabledAsync(FeatureFlags.DeferEbtCardDataLoading).Returns(true);
+
+        var email = "user@example.com";
+        var user = CreateUser(email, UserIalLevel.IAL1plus);
+        var identifier = HouseholdIdentifier.Email(EmailNormalizer.Normalize(email));
+        var piiVisibility = new PiiVisibility(IncludeAddress: true, IncludeEmail: true, IncludePhone: true);
+
+        _resolver.ResolveAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<CancellationToken>()).Returns(identifier);
+        _piiVisibilityService.GetVisibility(UserIalLevel.IAL1plus).Returns(piiVisibility);
+        _repository.GetHouseholdByIdentifierAsync(
+                identifier,
+                piiVisibility,
+                UserIalLevel.IAL1plus,
+                Arg.Any<Guid?>(),
+                false,
+                Arg.Any<CancellationToken>())
+            .Returns(new HouseholdData { Email = email });
+
+        var handler = CreateHandler();
+        await handler.Handle(new GetHouseholdDataQuery { User = user, IncludeCardDetails = false });
+
+        await _repository.Received(1).GetHouseholdByIdentifierAsync(
+            identifier,
+            piiVisibility,
+            UserIalLevel.IAL1plus,
+            Arg.Any<Guid?>(),
+            false,
+            Arg.Any<CancellationToken>());
     }
 }

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/RequestCardReplacementCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/RequestCardReplacementCommandHandlerTests.cs
@@ -126,7 +126,8 @@ public class RequestCardReplacementCommandHandlerTests
             Arg.Any<PiiVisibility>(),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>()
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>()
         ).Returns(householdData);
     }
 
@@ -566,7 +567,8 @@ public class RequestCardReplacementCommandHandlerTests
             Arg.Any<PiiVisibility>(),
             UserIalLevel.IAL1plus,
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -591,7 +593,8 @@ public class RequestCardReplacementCommandHandlerTests
             Arg.Any<PiiVisibility>(),
             UserIalLevel.None,
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     // --- Hashing verification ---

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
@@ -108,7 +108,7 @@ public class UpdateAddressCommandHandlerTests
     {
         _householdRepository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new HouseholdData { SummerEbtCases = cases.ToList() });
     }
 
@@ -116,7 +116,7 @@ public class UpdateAddressCommandHandlerTests
     {
         _householdRepository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new HouseholdData { BenefitIssuanceType = benefitType });
     }
 
@@ -387,7 +387,7 @@ public class UpdateAddressCommandHandlerTests
         SetupResolverReturnsEmail();
         _householdRepository.GetHouseholdByIdentifierAsync(
                 Arg.Any<HouseholdIdentifier>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
         var result = await handler.Handle(command, CancellationToken.None);

--- a/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/IdProofing/SubmitIdProofingCommandHandlerTests.cs
@@ -232,6 +232,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>());
         await socureClient.DidNotReceive()
             .RunIdProofingAssessmentAsync(
@@ -269,7 +270,7 @@ public class SubmitIdProofingCommandHandlerTests
         await householdRepository.DidNotReceive()
             .GetHouseholdByEmailAsync(
                 Arg.Any<string>(), Arg.Any<PiiVisibility>(),
-                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+                Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -295,6 +296,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 user.IalLevel,
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
@@ -347,6 +349,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 user.IalLevel,
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns(household);
 
@@ -386,6 +389,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 user.IalLevel,
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
@@ -426,7 +430,7 @@ public class SubmitIdProofingCommandHandlerTests
         challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns((DocVerificationChallenge?)null);
         householdRepository.GetHouseholdByEmailAsync(
-                user.Email, Arg.Any<PiiVisibility>(), user.IalLevel, Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                user.Email, Arg.Any<PiiVisibility>(), user.IalLevel, Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
         await handler.Handle(command, CancellationToken.None);
@@ -623,7 +627,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(false);
         householdRepository.GetHouseholdByEmailAsync(
-                Arg.Any<string>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
         await handler.Handle(command, CancellationToken.None);
@@ -961,7 +965,7 @@ public class SubmitIdProofingCommandHandlerTests
         challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns((DocVerificationChallenge?)null);
         householdRepository.GetHouseholdByEmailAsync(
-                "test@example.com", Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                "test@example.com", Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(new HouseholdData
             {
                 UserProfile = new UserProfile { FirstName = "Jane", LastName = "Doe" },
@@ -1006,7 +1010,8 @@ public class SubmitIdProofingCommandHandlerTests
             Arg.Is<PiiVisibility>(p => p.IncludeAddress && p.IncludeEmail && p.IncludePhone),
             Arg.Any<UserIalLevel>(),
             Arg.Any<Guid?>(),
-            Arg.Any<CancellationToken>());
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -1020,7 +1025,7 @@ public class SubmitIdProofingCommandHandlerTests
         challengeRepository.GetActiveByUserIdAsync(command.UserId, Arg.Any<CancellationToken>())
             .Returns((DocVerificationChallenge?)null);
         householdRepository.GetHouseholdByEmailAsync(
-                Arg.Any<string>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+                Arg.Any<string>(), Arg.Any<PiiVisibility>(), Arg.Any<UserIalLevel>(), Arg.Any<Guid?>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("DB timeout"));
         socureClient.RunIdProofingAssessmentAsync(
                 command.UserId, "test@example.com", command.DateOfBirth,
@@ -1315,6 +1320,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns((HouseholdData?)null);
 
@@ -1351,6 +1357,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns(emptyHousehold);
 
@@ -1384,6 +1391,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("warehouse unavailable"));
 
@@ -1416,6 +1424,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("warehouse unavailable"));
 
@@ -1460,6 +1469,7 @@ public class SubmitIdProofingCommandHandlerTests
                 Arg.Any<PiiVisibility>(),
                 Arg.Any<UserIalLevel>(),
                 Arg.Any<Guid?>(),
+                Arg.Any<bool>(),
                 Arg.Any<CancellationToken>())
             .Returns(householdWithCase);
 


### PR DESCRIPTION
#### 🔗 Jira ticket

[DC-479](https://codeforamerica.atlassian.net/browse/DC-479)

#### ✍️ Description

Colorado `get-account-details` is slow when CBMS calls FIS for each enrolled child (often several seconds per child). CBMS is adding `?ebtCardService=N|Y` so the portal can load household data without card fields first, then fetch card details in a second call.

This PR wires that behavior through the portal behind feature flag `defer_ebt_card_data_loading` (which is by default off - we don't want this behavior to follow through for DC).

Backend:
- `GET /api/household/data?includeCardDetails=true|false` (default `true` for backward compatibility).
- `GetHouseholdDataQueryHandler` honors `includeCardDetails=false` only when the feature flag is enabled; otherwise always requests full card data from the state connector.
- `HouseholdRepository` passes `includeCardService` through to `ISummerEbtCaseService`.

Frontend (CO dashboard only, when flag on):
- `useHouseholdData({ deferCardDetailsOnLoad })` loads shell first (`includeCardDetails=false`), then a second query for full card data when enrolled cases exist.
- `mergeHouseholdCardDetails` merges card fields into the shell response.
- `HouseholdCardDetailsLoadingProvider` and `ChildCard` show loading copy while card details are in flight; dashboard shell renders after the first response (CO uses existing `CoLoadingScreen` during shell load).
- MSW handler respects `includeCardDetails` for local tests.

Rollout:
- Flag stays false in base `appsettings.json` until CBMS supports `ebtCardService` in prod (target around May 31).
- Enable in CO AWS AppConfig when UAT/prod CBMS is ready. Not required for DC.

Requires companion CO connector PR on the same branch name that maps `includeCardService` to `ebtCardService` and uses separate HybridCache keys (`:shell` and `:full`). Build and deploy CO plugin DLLs before testing against real CBMS.

#### 🔗 Links to related PRs

- CO connector: https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/46
- State connector: None, the relevant changes happened in an earlier ticket.

#### ✅ Completion tasks

- [x] Added relevant tests (handler, controller, `useHouseholdData`, `mergeHouseholdCardDetails`, MSW)
- [ ] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu (N/A)
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager (N/A)
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig: `defer_ebt_card_data_loading` added to `appsettings.json` (default false); enable in CO AppConfig at rollout
  - [ ] If appsettings are changed, update in AWS AppConfig (CO only, when enabling flag)

#### Test plan

Prerequisites: CO connector branch built (`pnpm api:build-co`), API restarted with `STATE=co`, `defer_ebt_card_data_loading: true` in dev config or AppConfig.

1. Flag off (default): Dashboard still uses a single full `GET /api/household/data`; behavior unchanged.
2. Flag on with mocks (`Cbms:UseMockResponses=true`): Network shows `?includeCardDetails=false` then full fetch; dashboard appears after shell; card rows show loading then populate.
3. Flag on with UAT (`UseMockResponses=false`): Shell about 1 to 2 seconds, full about 6 to 10 seconds for multi-child households; dashboard usable before cards finish.
4. Regression: Address update, card replacement, and auth flows still pass existing tests (handlers updated to pass `includeCardService: true`).

[DC-479]: https://codeforamerica.atlassian.net/browse/DC-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ