### PR TITLE
DC-456 - spinner-only loading state for DC id-proofing; stop copy key leak

### DIFF
--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
@@ -18,6 +18,9 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18n } from '@sebt/design-system/client'
+
+import enCoStepUpProcessing from '@/content/locales/en/co/step-upProcessing.json'
 import enDcValidation from '@/content/locales/en/dc/validation.json'
 import { server } from '@/mocks/server'
 
@@ -1097,12 +1100,63 @@ describe('IdProofingForm', () => {
       })
     })
 
-    it('does not leak step-upProcessing key names as visible copy during DC loading', async () => {
-      // DC's content sheet marks S10 - Step-up Processing rows as !N/A!, so the
-      // step-upProcessing namespace is not registered for DC. If the form renders
-      // LoadingInterstitial with tProcessing('title') / tProcessing('body'),
-      // i18next falls back to the literal key names — DC users see "body" in a
-      // box. The loading state must avoid those keys for DC.
+    it('renders the titled LoadingInterstitial when step-upProcessing copy is present in the locale bundle', async () => {
+      // Forward-compatibility guard: when a state's content sheet ships
+      // step-upProcessing.title/body upstream, the form must pick it up and
+      // render the titled interstitial without any code change. We simulate
+      // that by adding the CO bundle for the duration of this test.
+      i18n.addResourceBundle('en', 'step-upProcessing', enCoStepUpProcessing, true, true)
+      try {
+        let resolveResponse: () => void = () => {}
+        const responsePromise = new Promise<void>((resolve) => {
+          resolveResponse = resolve
+        })
+
+        server.use(
+          http.post('/api/id-proofing', async () => {
+            await responsePromise
+            return HttpResponse.json({ result: 'matched' })
+          })
+        )
+
+        const user = userEvent.setup()
+        renderWithProviders(
+          <IdProofingForm
+            idOptions={TEST_ID_OPTIONS}
+            contactLink={TEST_CONTACT_LINK}
+          />
+        )
+
+        await user.selectOptions(screen.getByRole('combobox', { name: /month/i }), '03')
+        await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '10')
+        await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), '1990')
+        await user.click(screen.getByRole('radio', { name: LABEL_SSN }))
+        await user.type(await screen.findByRole('textbox', { name: INPUT_LABEL_SSN }), '999999999')
+        await user.click(screen.getByRole('button', { name: /continue/i }))
+
+        await waitFor(() => {
+          expect(screen.getByRole('status')).toBeInTheDocument()
+        })
+        expect(screen.getByText(enCoStepUpProcessing.title)).toBeInTheDocument()
+        expect(screen.getByText(enCoStepUpProcessing.body)).toBeInTheDocument()
+
+        resolveResponse()
+        await waitFor(() => {
+          expect(mockPush).toHaveBeenCalledWith('/dashboard')
+        })
+      } finally {
+        i18n.removeResourceBundle('en', 'step-upProcessing')
+      }
+    })
+
+    it('renders a spinner-only status region when step-upProcessing copy is missing from the active locale bundle', async () => {
+      // DC's content sheet currently marks S10 - Step-up Processing rows as
+      // !N/A!, so the step-upProcessing namespace is not registered for DC. If
+      // the form rendered LoadingInterstitial with tProcessing('title') /
+      // tProcessing('body'), i18next would fall back to the literal key names
+      // — DC users would see "body" in a box. The loading state falls back to a
+      // spinner-only status region whenever the copy is missing, regardless of
+      // which state is active.
       let resolveResponse: () => void = () => {}
       const responsePromise = new Promise<void>((resolve) => {
         resolveResponse = resolve

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
@@ -1097,6 +1097,51 @@ describe('IdProofingForm', () => {
       })
     })
 
+    it('does not leak step-upProcessing key names as visible copy during DC loading', async () => {
+      // DC's content sheet marks S10 - Step-up Processing rows as !N/A!, so the
+      // step-upProcessing namespace is not registered for DC. If the form renders
+      // LoadingInterstitial with tProcessing('title') / tProcessing('body'),
+      // i18next falls back to the literal key names — DC users see "body" in a
+      // box. The loading state must avoid those keys for DC.
+      let resolveResponse: () => void = () => {}
+      const responsePromise = new Promise<void>((resolve) => {
+        resolveResponse = resolve
+      })
+
+      server.use(
+        http.post('/api/id-proofing', async () => {
+          await responsePromise
+          return HttpResponse.json({ result: 'matched' })
+        })
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      await user.selectOptions(screen.getByRole('combobox', { name: /month/i }), '03')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_DAY }), '10')
+      await user.type(screen.getByRole('textbox', { name: INPUT_LABEL_YEAR }), '1990')
+      await user.click(screen.getByRole('radio', { name: LABEL_SSN }))
+      await user.type(await screen.findByRole('textbox', { name: INPUT_LABEL_SSN }), '999999999')
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole('status')).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/^title$/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^body$/)).not.toBeInTheDocument()
+
+      resolveResponse()
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/dashboard')
+      })
+    })
+
     it('restores the form and shows the submit error alert when the mutation throws', async () => {
       // The error path must NOT leave the loading interstitial stuck on screen —
       // the user needs to see the alert above the form so they can retry.

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
@@ -5,7 +5,7 @@ import { useId, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
-import { Alert, Button, InputField, LoadingInterstitial } from '@sebt/design-system'
+import { Alert, Button, getState, InputField, LoadingInterstitial } from '@sebt/design-system'
 
 import { useAuth } from '@/features/auth'
 import {
@@ -296,12 +296,32 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
   // see the submit button text change to "Continue..." and any eventual outcome
   // (off-boarding navigation or an inline error) reads as "we just got an error
   // after waiting."
+  //
+  // CO has step-upProcessing copy for the titled interstitial. DC marks those
+  // rows !N/A! in the content sheet, so the namespace is not registered for DC
+  // and tProcessing('title')/tProcessing('body') would render the literal key
+  // names. For DC, render a spinner-only status region instead.
   if (isProcessing || submitIdProofing.isPending) {
+    if (getState() === 'co') {
+      return (
+        <LoadingInterstitial
+          title={tProcessing('title')}
+          message={tProcessing('body')}
+        />
+      )
+    }
     return (
-      <LoadingInterstitial
-        title={tProcessing('title')}
-        message={tProcessing('body')}
-      />
+      <div
+        className="padding-y-4 text-center"
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+      >
+        <span
+          className="usa-spinner"
+          aria-hidden="true"
+        />
+      </div>
     )
   }
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
@@ -5,7 +5,7 @@ import { useId, useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
-import { Alert, Button, getState, InputField, LoadingInterstitial } from '@sebt/design-system'
+import { Alert, Button, InputField, LoadingInterstitial } from '@sebt/design-system'
 
 import { useAuth } from '@/features/auth'
 import {
@@ -297,12 +297,16 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
   // (off-boarding navigation or an inline error) reads as "we just got an error
   // after waiting."
   //
-  // CO has step-upProcessing copy for the titled interstitial. DC marks those
-  // rows !N/A! in the content sheet, so the namespace is not registered for DC
-  // and tProcessing('title')/tProcessing('body') would render the literal key
-  // names. For DC, render a spinner-only status region instead.
+  // The titled interstitial only renders when the active locale bundle has
+  // step-upProcessing copy. States whose content sheet omits those rows (DC
+  // marks them !N/A!) would otherwise see i18next leak the literal key names
+  // "title"/"body" through the fallback chain — they fall back to a spinner-only
+  // status region. Adding the copy upstream is enough to switch in the titled
+  // interstitial; no code change needed.
   if (isProcessing || submitIdProofing.isPending) {
-    if (getState() === 'co') {
+    const hasInterstitialCopy =
+      i18n.exists('step-upProcessing:title') && i18n.exists('step-upProcessing:body')
+    if (hasInterstitialCopy) {
       return (
         <LoadingInterstitial
           title={tProcessing('title')}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-456](https://codeforamerica.atlassian.net/browse/DC-456?atlOrigin=eyJpIjoiNjlhOWQ0Yjg2MmQzNDM5YjhiZjY5MzM3YmU3ZDJjOTEiLCJwIjoiaiJ9)

#### ✍️ Description
DC users who submitted the id-proofing form briefly saw the literal text "title" and "body" inside a blue box while the request was in flight. The form used `LoadingInterstitial` with i18n keys from the `step-upProcessing` namespace, which is only populated for CO (DC's content sheet marks those rows `!N/A!`), so i18next fell back to the key names. The loading branch now gates on copy presence in the active locale bundle (`i18n.exists('step-upProcessing:title') && i18n.exists('step-upProcessing:body')`): when the keys exist the titled `LoadingInterstitial` renders, when they don't the form falls back to a centered USWDS spinner inside a `role="status"` region. Adding the copy upstream is enough to switch in the titled interstitial for any state, no code change needed.

#### 🔗 Links to related PRs
- {sibling repo / branch — leave a placeholder if not yet pushed}

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `IdProofingForm.tsx` | loading-state branch | Low | Low | Med | new presence-check gate, a11y on spinner |
| 🟢 | `IdProofingForm.test.tsx` | two new tests covering both gate branches | Low | Low | Low | i18n bundle add/remove via try/finally |




[DC-456]: https://codeforamerica.atlassian.net/browse/DC-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ