### PR TITLE
DC-477 - prevent double-submit on enrollment checker review page

### DIFF
--- a/src/SEBT.EnrollmentChecker.Web/src/app/review/page.test.tsx
+++ b/src/SEBT.EnrollmentChecker.Web/src/app/review/page.test.tsx
@@ -1,0 +1,58 @@
+import { act, render, screen } from '@testing-library/react'
+import { useEffect } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EnrollmentProvider, useEnrollment } from '@/features/enrollment/context/EnrollmentContext'
+import { checkEnrollment } from '@/features/enrollment/api/checkEnrollment'
+import Page from './page'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
+vi.mock('@/features/enrollment/api/checkEnrollment', () => ({
+  checkEnrollment: vi.fn()
+}))
+
+vi.mock('@/lib/stateConfig', () => ({
+  getEnrollmentConfig: () => ({ apiBaseUrl: '' })
+}))
+
+const mockedCheckEnrollment = vi.mocked(checkEnrollment)
+
+// Seeds one child so the Submit button is enabled, then renders the page wrapper.
+function PageWithChild() {
+  return (
+    <EnrollmentProvider>
+      <Seeder />
+      <Page />
+    </EnrollmentProvider>
+  )
+}
+function Seeder() {
+  const { addChild } = useEnrollment()
+  useEffect(() => {
+    addChild({ firstName: 'Jane', lastName: 'Doe', month: '4', day: '12', year: '2015' })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  return null
+}
+
+describe('review Page — double-submit guard', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    mockedCheckEnrollment.mockReset()
+    mockedCheckEnrollment.mockResolvedValue({ results: [] } as never)
+  })
+
+  it('fires checkEnrollment only once when Submit is double-clicked in the same tick', async () => {
+    render(<PageWithChild />)
+    const submit = await screen.findByRole('button', { name: /submit/i })
+
+    // Two synchronous clicks before React can re-render reproduce the race: both
+    // handlers run against the same render, so a state-only guard lets both through.
+    await act(async () => {
+      submit.click()
+      submit.click()
+    })
+
+    expect(mockedCheckEnrollment).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/SEBT.EnrollmentChecker.Web/src/app/review/page.tsx
+++ b/src/SEBT.EnrollmentChecker.Web/src/app/review/page.tsx
@@ -6,7 +6,7 @@ import { useEnrollment } from '@/features/enrollment/context/EnrollmentContext'
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
 import { Alert, LoadingInterstitial } from '@sebt/design-system'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getEnrollmentConfig } from '@/lib/stateConfig'
 
@@ -17,11 +17,17 @@ export default function Page() {
   const { state } = useEnrollment()
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  // Synchronous re-entrancy guard. `isSubmitting` state can't catch a fast
+  // double-click: both handlers run against the same render with the stale value
+  // `false`, so both pass the guard before React re-renders. A ref is read/written
+  // synchronously, so the second click sees the flag the first click just set.
+  const submittingRef = useRef(false)
   const config = getEnrollmentConfig()
   const { setPageData, trackEvent } = useDataLayer()
 
   async function handleSubmit() {
-    if (isSubmitting) return
+    if (submittingRef.current) return
+    submittingRef.current = true
     setError(null)
     setIsSubmitting(true)
     try {
@@ -36,6 +42,7 @@ export default function Page() {
       trackEvent(AnalyticsEvents.ENROLLMENT_CHECK_ERROR)
       setError(message.includes('rate') ? t('rateLimitError') : t('submitError'))
     } finally {
+      submittingRef.current = false
       setIsSubmitting(false)
     }
   }
@@ -57,7 +64,7 @@ export default function Page() {
   return (
     <>
       {error && <Alert variant="error">{error}</Alert>}
-      <ReviewPage onSubmit={handleSubmit} />
+      <ReviewPage onSubmit={handleSubmit} isSubmitting={isSubmitting} />
     </>
   )
 }

--- a/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/ReviewPage.test.tsx
+++ b/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/ReviewPage.test.tsx
@@ -9,11 +9,17 @@ const mockPush = vi.fn()
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
 
 // Helper to pre-populate context with a child
-function ReviewPageWithChild({ onSubmit }: { onSubmit: () => void }) {
+function ReviewPageWithChild({
+  onSubmit,
+  isSubmitting
+}: {
+  onSubmit: () => void
+  isSubmitting?: boolean
+}) {
   return (
     <EnrollmentProvider>
       <Seeder />
-      <ReviewPage onSubmit={onSubmit} />
+      <ReviewPage onSubmit={onSubmit} isSubmitting={isSubmitting} />
     </EnrollmentProvider>
   )
 }
@@ -62,6 +68,15 @@ describe('ReviewPage', () => {
     await screen.findByText(/Jane Doe/i)
     await userEvent.click(screen.getByRole('button', { name: /remove/i }))
     expect(screen.queryByText(/Jane Doe/i)).not.toBeInTheDocument()
+  })
+
+  it('disables Submit and Back while submitting', async () => {
+    render(<ReviewPageWithChild onSubmit={vi.fn()} isSubmitting />)
+    await screen.findByText(/Jane Doe/i)
+    const submit = screen.getByRole('button', { name: /submit/i })
+    expect(submit).toBeDisabled()
+    expect(submit).toHaveAttribute('aria-busy', 'true')
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled()
   })
 
   it('disables Submit when the last child is removed and ignores clicks', async () => {

--- a/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/ReviewPage.tsx
+++ b/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/ReviewPage.tsx
@@ -9,9 +9,10 @@ import { ChildReviewCard } from './ChildReviewCard'
 
 interface ReviewPageProps {
   onSubmit: () => void
+  isSubmitting?: boolean
 }
 
-export function ReviewPage({ onSubmit }: ReviewPageProps) {
+export function ReviewPage({ onSubmit, isSubmitting = false }: ReviewPageProps) {
   const { t } = useTranslation('confirmInfo')
   const { t: tCommon } = useTranslation('common')
   const router = useRouter()
@@ -51,12 +52,15 @@ export function ReviewPage({ onSubmit }: ReviewPageProps) {
             variant="outline"
             className="margin-right-1"
             onClick={() => router.push('/check')}
+            disabled={isSubmitting}
           >
             {tCommon('back')}
           </Button>
           <Button
             onClick={onSubmit}
             disabled={state.children.length === 0}
+            isLoading={isSubmitting}
+            loadingText={`${tCommon('submit')}...`}
           >
             {tCommon('submit')}
           </Button>


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-477](https://codeforamerica.atlassian.net/browse/DC-477?atlOrigin=eyJpIjoiOTU4NzA2YTZjMTQxNDIzOGFhNjU4Mzc0NjNhNjNiODMiLCJwIjoiaiJ9)

#### ✍️ Description
Prevents double submission on the enrollment checker review page. A fast double-click on Submit could fire the check twice: the `isSubmitting` state flag isn't updated until React's next render, so both click handlers ran against the stale `false` value and both passed the guard. A synchronous `useRef` guard now rejects the second click immediately. The Submit button shows a loading state and the Back button is disabled while the request is in flight.

#### 🔗 Links to related PRs
- none

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `src/SEBT.EnrollmentChecker.Web/src/app/review/page.tsx` | `handleSubmit()` + `submittingRef` | Low | Med | Med | sync guard blocks double-submit |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/ReviewPage.tsx` | `isSubmitting` prop wiring | Low | Low | Low | |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/app/review/page.test.tsx` | new tests | Low | Low | Low | |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/ReviewPage.test.tsx` | updated tests | Low | Low | Low | |


[DC-477]: https://codeforamerica.atlassian.net/browse/DC-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ