### PR TITLE
DC-374(Bug): check authentication before allowing users to go to Callback

### DIFF
--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
@@ -287,8 +287,8 @@ describe('CallbackPage', () => {
   })
 
   describe('back-button re-entry after successful login', () => {
-    it('skips the code exchange and redirects to /dashboard when the visitor is already authenticated', async () => {
-      sessionState.current = { ial: '1', userId: 'user-1' }
+    it('skips exchange and redirects to /dashboard when step-up is already complete (stale code in URL)', async () => {
+      sessionState.current = { ial: '1plus', idProofingExpiresAt: 9999999999 }
       const callbackSpy = vi.fn()
       const completeLoginSpy = vi.fn()
       server.use(
@@ -309,6 +309,30 @@ describe('CallbackPage', () => {
       })
       expect(callbackSpy).not.toHaveBeenCalled()
       expect(completeLoginSpy).not.toHaveBeenCalled()
+      expect(mockReplace).not.toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+    })
+
+    it('runs exchange when authenticated but step-up is still in progress', async () => {
+      sessionState.current = { ial: '1', userId: 'user-1' }
+      const callbackSpy = vi.fn()
+      server.use(
+        http.post('/api/auth/oidc/callback', () => {
+          callbackSpy()
+          return HttpResponse.json({ callbackToken: 'mock-callback-token-for-step-up' })
+        }),
+        http.post('/api/auth/oidc/complete-login', () => {
+          return HttpResponse.json({ returnUrl: '/profile/address' })
+        })
+      )
+
+      render(<CallbackPage />)
+
+      await waitFor(() => {
+        expect(callbackSpy).toHaveBeenCalled()
+      })
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/profile/address')
+      })
       expect(mockReplace).not.toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
     })
 
@@ -339,6 +363,24 @@ describe('CallbackPage', () => {
       await waitFor(() => {
         expect(mockReplace).not.toHaveBeenCalled()
       })
+    })
+
+    it('redirects to off-boarding for IdP error even when already authenticated', async () => {
+      sessionState.current = { ial: '1plus', idProofingExpiresAt: 9999999999 }
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '?error=access_denied',
+          href: 'http://localhost:3000/callback?error=access_denied'
+        },
+        writable: true
+      })
+
+      render(<CallbackPage />)
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+      })
+      expect(mockReplace).not.toHaveBeenCalledWith('/dashboard')
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
@@ -382,5 +382,24 @@ describe('CallbackPage', () => {
       })
       expect(mockReplace).not.toHaveBeenCalledWith('/dashboard')
     })
+
+    it('redirects to off-boarding for IdP error before auth status finishes loading', async () => {
+      authLoading.current = true
+      sessionState.current = { ial: '1plus', idProofingExpiresAt: 9999999999 }
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '?error=server_error',
+          href: 'http://localhost:3000/callback?error=server_error'
+        },
+        writable: true
+      })
+
+      render(<CallbackPage />)
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+      })
+      expect(mockReplace).not.toHaveBeenCalledWith('/dashboard')
+    })
   })
 })

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
@@ -32,10 +32,11 @@ vi.mock('next/navigation', () => ({
 }))
 
 // Mock @/features/auth without loading the barrel (barrel pulls IalGuard → @/env and breaks Vitest).
-// `sessionState` is mutable so individual tests can simulate an already-authenticated visitor.
-const { mockLogin, sessionState } = vi.hoisted(() => ({
+// `sessionState` / `authLoading` are mutable so tests can simulate session hydration and back-button re-entry.
+const { mockLogin, sessionState, authLoading } = vi.hoisted(() => ({
   mockLogin: vi.fn(),
-  sessionState: { current: null as Record<string, unknown> | null }
+  sessionState: { current: null as Record<string, unknown> | null },
+  authLoading: { current: false }
 }))
 vi.mock('@/features/auth', async () => {
   const api = await vi.importActual<typeof import('@/features/auth/api')>('@/features/auth/api')
@@ -46,7 +47,7 @@ vi.mock('@/features/auth', async () => {
       logout: vi.fn(),
       isAuthenticated: sessionState.current !== null,
       session: sessionState.current,
-      isLoading: false
+      isLoading: authLoading.current
     })
   }
 })
@@ -86,6 +87,7 @@ describe('CallbackPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionState.current = null
+    authLoading.current = false
     // Default: URL has code and state
     Object.defineProperty(window, 'location', {
       value: {
@@ -286,7 +288,7 @@ describe('CallbackPage', () => {
 
   describe('back-button re-entry after successful login', () => {
     it('skips the code exchange and redirects to /dashboard when the visitor is already authenticated', async () => {
-      sessionState.current = { ial: '1plus', idProofingExpiresAt: 9999999999 }
+      sessionState.current = { ial: '1', userId: 'user-1' }
       const callbackSpy = vi.fn()
       const completeLoginSpy = vi.fn()
       server.use(
@@ -308,6 +310,35 @@ describe('CallbackPage', () => {
       expect(callbackSpy).not.toHaveBeenCalled()
       expect(completeLoginSpy).not.toHaveBeenCalled()
       expect(mockReplace).not.toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+    })
+
+    it('redirects to /dashboard when authenticated and callback URL has no code or state', async () => {
+      sessionState.current = { ial: '1plus', userId: 'user-1' }
+      Object.defineProperty(window, 'location', {
+        value: { search: '', href: 'http://localhost:3000/callback' },
+        writable: true
+      })
+
+      render(<CallbackPage />)
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/dashboard')
+      })
+      expect(mockReplace).not.toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+    })
+
+    it('does not treat missing code as failure while auth status is still loading', async () => {
+      authLoading.current = true
+      Object.defineProperty(window, 'location', {
+        value: { search: '', href: 'http://localhost:3000/callback' },
+        writable: true
+      })
+
+      render(<CallbackPage />)
+
+      await waitFor(() => {
+        expect(mockReplace).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
@@ -8,9 +8,10 @@ import {
   OidcCallbackTokenResponseSchema,
   OidcCompleteLoginResponseSchema
 } from '@/features/auth/api/oidc'
+import { hasIal1Plus, isIdProofingCompletionFresh } from '@/lib/jwt'
 import { getState } from '@sebt/design-system'
 import { useRouter } from 'next/navigation'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 /**
@@ -26,24 +27,26 @@ import { useTranslation } from 'react-i18next'
  * Any failure (IdP error redirect, missing params, token exchange error) sends the user
  * to id-proofing off-boarding with {@link OIDC_CALLBACK_ERROR_OFF_BOARDING}.
  *
- * Back-button re-entry: if the visitor already has a portal session, skip exchange and
- * return to the dashboard so a stale or missing authorization code is not treated as failure.
+ * Back-button re-entry: authenticated visitors with no OAuth params, or who already
+ * completed step-up (IAL1+ with a fresh proofing window), skip exchange so stale codes
+ * are not treated as failure. In-progress step-up still runs exchange when code and state
+ * are present, even if a portal session already exists from the initial sign-in.
  */
 export default function CallbackPage() {
   const router = useRouter()
-  const { isAuthenticated, isLoading, login } = useAuth()
+  const { session, isAuthenticated, isLoading, login } = useAuth()
   const { t } = useTranslation('login')
   const { t: tProcessing } = useTranslation('step-upProcessing')
   const exchangeStartedRef = useRef(false)
   const isCO = getState() === 'co'
 
+  const isProofedReEntry = useMemo(
+    () => hasIal1Plus(session) && isIdProofingCompletionFresh(session),
+    [session]
+  )
+
   useEffect(() => {
     if (isLoading) {
-      return
-    }
-
-    if (isAuthenticated) {
-      router.replace('/dashboard')
       return
     }
 
@@ -54,6 +57,16 @@ export default function CallbackPage() {
 
     if (errorParam) {
       router.replace(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+      return
+    }
+
+    if (isAuthenticated && (!code || !state)) {
+      router.replace('/dashboard')
+      return
+    }
+
+    if (isProofedReEntry) {
+      router.replace('/dashboard')
       return
     }
 
@@ -111,7 +124,7 @@ export default function CallbackPage() {
     return () => {
       cancelled = true
     }
-  }, [isAuthenticated, isLoading, login, router])
+  }, [isAuthenticated, isLoading, isProofedReEntry, login, router])
 
   if (isCO) {
     return (

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
@@ -8,7 +8,6 @@ import {
   OidcCallbackTokenResponseSchema,
   OidcCompleteLoginResponseSchema
 } from '@/features/auth/api/oidc'
-import { hasIal1Plus, isIdProofingCompletionFresh } from '@/lib/jwt'
 import { getState } from '@sebt/design-system'
 import { useRouter } from 'next/navigation'
 import { useEffect, useRef } from 'react'
@@ -26,16 +25,28 @@ import { useTranslation } from 'react-i18next'
  *
  * Any failure (IdP error redirect, missing params, token exchange error) sends the user
  * to id-proofing off-boarding with {@link OIDC_CALLBACK_ERROR_OFF_BOARDING}.
+ *
+ * Back-button re-entry: if the visitor already has a portal session, skip exchange and
+ * return to the dashboard so a stale or missing authorization code is not treated as failure.
  */
 export default function CallbackPage() {
   const router = useRouter()
-  const { session, login } = useAuth()
+  const { isAuthenticated, isLoading, login } = useAuth()
   const { t } = useTranslation('login')
   const { t: tProcessing } = useTranslation('step-upProcessing')
   const exchangeStartedRef = useRef(false)
   const isCO = getState() === 'co'
 
   useEffect(() => {
+    if (isLoading) {
+      return
+    }
+
+    if (isAuthenticated) {
+      router.replace('/dashboard')
+      return
+    }
+
     const params = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
     const code = params.get('code')
     const state = params.get('state')
@@ -51,13 +62,7 @@ export default function CallbackPage() {
       return
     }
 
-    if (exchangeStartedRef.current) return
-
-    // Back-button re-entry after a successful step-up: the visitor already has IAL1+
-    // and a fresh proofing window. Re-running the exchange here would burn the
-    // single-use code and bounce them to off-boarding.
-    if (hasIal1Plus(session) && isIdProofingCompletionFresh(session)) {
-      router.replace('/dashboard')
+    if (exchangeStartedRef.current) {
       return
     }
 
@@ -71,20 +76,26 @@ export default function CallbackPage() {
           body: { code, state },
           schema: OidcCallbackTokenResponseSchema
         })
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
 
         const response = await apiFetch('/auth/oidc/complete-login', {
           method: 'POST',
           body: { callbackToken },
           schema: OidcCompleteLoginResponseSchema
         })
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
 
         await login()
         const destination = response.returnUrl ?? '/dashboard'
         router.replace(destination)
       } catch (e) {
-        if (cancelled) return
+        if (cancelled) {
+          return
+        }
         const statusCode = e instanceof ApiError ? e.status : undefined
         const logDetail = e instanceof Error ? e.message : ''
         if (process.env.NODE_ENV === 'development') {
@@ -100,7 +111,7 @@ export default function CallbackPage() {
     return () => {
       cancelled = true
     }
-  }, [session, login, router])
+  }, [isAuthenticated, isLoading, login, router])
 
   if (isCO) {
     return (

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
@@ -24,8 +24,10 @@ import { useTranslation } from 'react-i18next'
  * All flow metadata (stateCode, isStepUp, returnUrl) is stored in the server-side
  * pre-auth session — no sessionStorage is used.
  *
- * Any failure (IdP error redirect, missing params, token exchange error) sends the user
- * to id-proofing off-boarding with {@link OIDC_CALLBACK_ERROR_OFF_BOARDING}.
+ * IdP error redirects (?error=) always go to off-boarding immediately, including when the
+ * visitor already has a portal session (step-up denied, back-button into PingOne, etc.).
+ * Other failures (missing params when logged out, token exchange error) also use
+ * {@link OIDC_CALLBACK_ERROR_OFF_BOARDING}.
  *
  * Back-button re-entry: authenticated visitors with no OAuth params, or who already
  * completed step-up (IAL1+ with a fresh proofing window), skip exchange so stale codes
@@ -46,17 +48,19 @@ export default function CallbackPage() {
   )
 
   useEffect(() => {
-    if (isLoading) {
-      return
-    }
-
     const params = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
     const code = params.get('code')
     const state = params.get('state')
     const errorParam = params.get('error')
 
+    // IdP errors do not require /auth/status; evaluate before isLoading and before
+    // authenticated back-button shortcuts so step-up failures are not sent to /dashboard.
     if (errorParam) {
       router.replace(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+      return
+    }
+
+    if (isLoading) {
       return
     }
 


### PR DESCRIPTION
#### 🔗 Jira ticket

[DC-374](https://codeforamerica.atlassian.net/browse/DC-374)

#### ✍️ Description

After a successful OIDC login, using the browser back button from the dashboard could land users on `/callback` again (or on a stale callback URL without query params). The callback page treated that as a failed login and sent them to id-proofing off-boarding with `reason=oidcCallbackError` ("We aren't able to show your Summer EBT information").

This change makes `/callback` a **one-time handoff** for unauthenticated users only:

- Wait until `/auth/status` has finished loading before treating missing `code` or `state` as an error.
- If the visitor already has a portal session (`isAuthenticated`), redirect to `/dashboard` and skip the OIDC token exchange, including when the URL still has a used authorization code or no query string at all.
- Unauthenticated visitors keep the existing behavior: IdP errors, missing params, and exchange failures still route to off-boarding.

Effect deps now use `isAuthenticated` and `isLoading` instead of `session`, so a session update after `login()` does not re-run the effect and cancel an in-flight exchange.

#### 🔗 Links to related PRs

None

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes: **N/A**
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsettings are changed, update in AWS AppConfig

#### Test plan

1. Log in through MyCO/OIDC until you reach the dashboard.
2. Press the browser back button.
3. Confirm you return to `/dashboard` (or stay in the app) and do not see the off-boarding "can't show your information" screen.
4. Repeat with back from dashboard when history includes `/callback` with no query params and with a stale `?code=` and `?state=` in the URL.
5. Confirm a logged-out visit to `/callback` without params still goes to off-boarding.
6. Run `cd src/SEBT.Portal.Web && pnpm test -- src/app/(public)/callback/page.test.tsx --run`.

[DC-374]: https://codeforamerica.atlassian.net/browse/DC-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ