### PR TITLE
DC-307(Bug): Fix Colorado URL preview title and description

### DIFF
--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -40,6 +40,7 @@ export {
   getStateConfig,
   getStateName,
   getSiteDisplayName,
+  getPortalMetadataDescription,
   getStateAssetPath
 } from './lib/state'
 

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -35,7 +35,13 @@ export { SkipNav } from './components/layout/SkipNav'
 
 // State configuration
 export type { StateCode, StateConfig } from './lib/state'
-export { getState, getStateConfig, getStateName, getStateAssetPath } from './lib/state'
+export {
+  getState,
+  getStateConfig,
+  getStateName,
+  getSiteDisplayName,
+  getStateAssetPath
+} from './lib/state'
 
 // External links
 export type { StateLinks, LinkItem } from './lib/links'

--- a/packages/design-system/src/lib/state.test.ts
+++ b/packages/design-system/src/lib/state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getStateConfig, getSiteDisplayName } from './state'
+import { getPortalMetadataDescription, getSiteDisplayName, getStateConfig } from './state'
 
 describe('getStateConfig — supportedLanguages', () => {
   it('omits Amharic from the CO config', () => {
@@ -27,5 +27,15 @@ describe('getSiteDisplayName', () => {
 
   it('returns DC SUN Bucks for DC', () => {
     expect(getSiteDisplayName('dc')).toBe('DC SUN Bucks')
+  })
+})
+
+describe('getPortalMetadataDescription', () => {
+  it('describes benefit management for CO', () => {
+    expect(getPortalMetadataDescription('co')).toBe('Manage your CO Summer EBT benefits online.')
+  })
+
+  it('describes applying and managing benefits for DC', () => {
+    expect(getPortalMetadataDescription('dc')).toContain('Apply for Summer EBT (SUN Bucks) benefits')
   })
 })

--- a/packages/design-system/src/lib/state.test.ts
+++ b/packages/design-system/src/lib/state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getStateConfig } from './state'
+import { getStateConfig, getSiteDisplayName } from './state'
 
 describe('getStateConfig — supportedLanguages', () => {
   it('omits Amharic from the CO config', () => {
@@ -17,5 +17,15 @@ describe('getStateConfig — supportedLanguages', () => {
 
   it('exposes English, Spanish, and Amharic for DC', () => {
     expect(getStateConfig('dc').supportedLanguages).toEqual(['en', 'es', 'am'])
+  })
+})
+
+describe('getSiteDisplayName', () => {
+  it('returns Colorado Summer EBT for CO', () => {
+    expect(getSiteDisplayName('co')).toBe('Colorado Summer EBT')
+  })
+
+  it('returns DC SUN Bucks for DC', () => {
+    expect(getSiteDisplayName('dc')).toBe('DC SUN Bucks')
   })
 })

--- a/packages/design-system/src/lib/state.test.ts
+++ b/packages/design-system/src/lib/state.test.ts
@@ -25,8 +25,8 @@ describe('getSiteDisplayName', () => {
     expect(getSiteDisplayName('co')).toBe('Colorado Summer EBT')
   })
 
-  it('returns DC SUN Bucks for DC', () => {
-    expect(getSiteDisplayName('dc')).toBe('DC SUN Bucks')
+  it('returns District of Columbia SUN Bucks for DC', () => {
+    expect(getSiteDisplayName('dc')).toBe('District of Columbia SUN Bucks')
   })
 })
 

--- a/packages/design-system/src/lib/state.ts
+++ b/packages/design-system/src/lib/state.ts
@@ -49,7 +49,7 @@ const stateConfigs: Record<StateCode, StateConfig> = {
   dc: {
     name: 'District of Columbia',
     programName: 'DC SUN Bucks',
-    siteDisplayName: 'DC SUN Bucks',
+    siteDisplayName: 'District of Columbia SUN Bucks',
     portalMetadataDescription:
       'Apply for Summer EBT (SUN Bucks) benefits in District of Columbia. Check eligibility, track your application status, and manage your benefits online.',
     sealAlt: 'Government of the District of Columbia - Muriel Bowser, Mayor',

--- a/packages/design-system/src/lib/state.ts
+++ b/packages/design-system/src/lib/state.ts
@@ -25,6 +25,8 @@ export interface StateConfig {
   programName: string
   /** Branded site name for page titles and link previews (e.g., 'DC SUN Bucks', 'Colorado Summer EBT') */
   siteDisplayName: string
+  /** Meta description for page titles, Open Graph, and link previews */
+  portalMetadataDescription: string
   /** Alt text for the state seal image in the footer */
   sealAlt: string
   /** Languages offered in this state's UI (drives the LanguageSelector and `?lang=` validation) */
@@ -48,6 +50,8 @@ const stateConfigs: Record<StateCode, StateConfig> = {
     name: 'District of Columbia',
     programName: 'DC SUN Bucks',
     siteDisplayName: 'DC SUN Bucks',
+    portalMetadataDescription:
+      'Apply for Summer EBT (SUN Bucks) benefits in District of Columbia. Check eligibility, track your application status, and manage your benefits online.',
     sealAlt: 'Government of the District of Columbia - Muriel Bowser, Mayor',
     supportedLanguages: ['en', 'es', 'am'],
     actionButtonBg: 'bg-secondary',
@@ -57,6 +61,7 @@ const stateConfigs: Record<StateCode, StateConfig> = {
     name: 'Colorado',
     programName: 'Summer EBT',
     siteDisplayName: 'Colorado Summer EBT',
+    portalMetadataDescription: 'Manage your CO Summer EBT benefits online.',
     sealAlt: 'Colorado Official State Web Portal',
     supportedLanguages: ['en', 'es'],
     languageSelectorClass: 'border-primary radius-md text-primary',
@@ -96,6 +101,13 @@ export function getStateName(state: StateCode): string {
  */
 export function getSiteDisplayName(state: StateCode): string {
   return getStateConfig(state).siteDisplayName
+}
+
+/**
+ * Meta description for page titles, Open Graph, and link previews.
+ */
+export function getPortalMetadataDescription(state: StateCode): string {
+  return getStateConfig(state).portalMetadataDescription
 }
 
 /**

--- a/packages/design-system/src/lib/state.ts
+++ b/packages/design-system/src/lib/state.ts
@@ -23,6 +23,8 @@ export interface StateConfig {
   name: string
   /** State-specific program name (e.g., 'DC SUN Bucks', 'Summer EBT') */
   programName: string
+  /** Branded site name for page titles and link previews (e.g., 'DC SUN Bucks', 'Colorado Summer EBT') */
+  siteDisplayName: string
   /** Alt text for the state seal image in the footer */
   sealAlt: string
   /** Languages offered in this state's UI (drives the LanguageSelector and `?lang=` validation) */
@@ -45,6 +47,7 @@ const stateConfigs: Record<StateCode, StateConfig> = {
   dc: {
     name: 'District of Columbia',
     programName: 'DC SUN Bucks',
+    siteDisplayName: 'DC SUN Bucks',
     sealAlt: 'Government of the District of Columbia - Muriel Bowser, Mayor',
     supportedLanguages: ['en', 'es', 'am'],
     actionButtonBg: 'bg-secondary',
@@ -53,6 +56,7 @@ const stateConfigs: Record<StateCode, StateConfig> = {
   co: {
     name: 'Colorado',
     programName: 'Summer EBT',
+    siteDisplayName: 'Colorado Summer EBT',
     sealAlt: 'Colorado Official State Web Portal',
     supportedLanguages: ['en', 'es'],
     languageSelectorClass: 'border-primary radius-md text-primary',
@@ -85,6 +89,13 @@ export function getState(): StateCode {
  */
 export function getStateName(state: StateCode): string {
   return getStateConfig(state).name
+}
+
+/**
+ * Branded site name for page titles, Open Graph, and link previews.
+ */
+export function getSiteDisplayName(state: StateCode): string {
+  return getStateConfig(state).siteDisplayName
 }
 
 /**

--- a/src/SEBT.Portal.Web/e2e/example.spec.ts
+++ b/src/SEBT.Portal.Web/e2e/example.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from '@playwright/test'
 
+import { currentState } from './fixtures/state'
+
+const expectedPortalTitle = currentState === 'co' ? /Colorado Summer EBT/i : /SUN Bucks/i
+
 /**
  * Example E2E Test - SEBT Portal entry + login
  *
@@ -14,7 +18,7 @@ test.describe('Homepage', () => {
   test('should load and display the login entry', async ({ page }) => {
     await page.goto('/login')
 
-    await expect(page).toHaveTitle(/SUN Bucks/i)
+    await expect(page).toHaveTitle(expectedPortalTitle)
 
     // DC: submit shows "Continue"; CO: "Sign in with myColorado®"
     const primaryAction = page.getByRole('button', { name: /continue|log in|sign in/i }).first()

--- a/src/SEBT.Portal.Web/src/app/layout.tsx
+++ b/src/SEBT.Portal.Web/src/app/layout.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/providers'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { AmplitudeAnalytics, MixpanelAnalytics, SiteImproveAnalytics } from '@sebt/analytics'
-import { getState, getStateName, SkipNav } from '@sebt/design-system'
+import { getSiteDisplayName, getState, getStateName, SkipNav } from '@sebt/design-system'
 import { Footer, Header, HelpSection } from '@sebt/design-system/client'
 import type { Metadata, Viewport } from 'next'
 import { headers } from 'next/headers'
@@ -20,6 +20,8 @@ import './styles.scss'
 
 const state = getState()
 const stateName = getStateName(state)
+const siteDisplayName = getSiteDisplayName(state)
+const portalTitle = `${siteDisplayName} Self-Service Portal`
 
 function getDefaultBaseUrl() {
   return process.env.NEXT_PUBLIC_BASE_URL ?? `https://sebt.${state}.gov`
@@ -43,8 +45,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return {
     title: {
-      default: `${stateName} SUN Bucks Self-Service Portal`,
-      template: `%s | ${stateName} SUN Bucks`
+      default: portalTitle,
+      template: `%s | ${siteDisplayName}`
     },
     description: `Apply for Summer EBT (SUN Bucks) benefits in ${stateName}. Check eligibility, track your application status, and manage your benefits online.`,
     keywords: ['SUN Bucks', 'Summer EBT', 'SEBT', 'summer meals', 'food benefits', stateName],
@@ -64,21 +66,21 @@ export async function generateMetadata(): Promise<Metadata> {
       type: 'website',
       locale: 'en_US',
       url: baseUrl,
-      siteName: `${stateName} SUN Bucks`,
-      title: `${stateName} SUN Bucks Self-Service Portal`,
+      siteName: siteDisplayName,
+      title: portalTitle,
       description: `Apply for Summer EBT (SUN Bucks) benefits in ${stateName}. Check eligibility and manage your benefits online.`,
       images: [
         {
           url: `${baseUrl}/images/states/${state}/og-image.png`,
           width: 1200,
           height: 630,
-          alt: `${stateName} SUN Bucks Portal`
+          alt: `${siteDisplayName} Portal`
         }
       ]
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${stateName} SUN Bucks Self-Service Portal`,
+      title: portalTitle,
       description: `Apply for Summer EBT (SUN Bucks) benefits in ${stateName}.`,
       images: [`${baseUrl}/images/states/${state}/og-image.png`]
     },

--- a/src/SEBT.Portal.Web/src/app/layout.tsx
+++ b/src/SEBT.Portal.Web/src/app/layout.tsx
@@ -11,7 +11,13 @@ import {
 } from '@/providers'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { AmplitudeAnalytics, MixpanelAnalytics, SiteImproveAnalytics } from '@sebt/analytics'
-import { getSiteDisplayName, getState, getStateName, SkipNav } from '@sebt/design-system'
+import {
+  getPortalMetadataDescription,
+  getSiteDisplayName,
+  getState,
+  getStateName,
+  SkipNav
+} from '@sebt/design-system'
 import { Footer, Header, HelpSection } from '@sebt/design-system/client'
 import type { Metadata, Viewport } from 'next'
 import { headers } from 'next/headers'
@@ -21,6 +27,7 @@ import './styles.scss'
 const state = getState()
 const stateName = getStateName(state)
 const siteDisplayName = getSiteDisplayName(state)
+const portalMetadataDescription = getPortalMetadataDescription(state)
 const portalTitle = `${siteDisplayName} Self-Service Portal`
 
 function getDefaultBaseUrl() {
@@ -48,7 +55,7 @@ export async function generateMetadata(): Promise<Metadata> {
       default: portalTitle,
       template: `%s | ${siteDisplayName}`
     },
-    description: `Apply for Summer EBT (SUN Bucks) benefits in ${stateName}. Check eligibility, track your application status, and manage your benefits online.`,
+    description: portalMetadataDescription,
     keywords: ['SUN Bucks', 'Summer EBT', 'SEBT', 'summer meals', 'food benefits', stateName],
     authors: [{ name: `${stateName} Government` }],
     robots: {
@@ -68,7 +75,7 @@ export async function generateMetadata(): Promise<Metadata> {
       url: baseUrl,
       siteName: siteDisplayName,
       title: portalTitle,
-      description: `Apply for Summer EBT (SUN Bucks) benefits in ${stateName}. Check eligibility and manage your benefits online.`,
+      description: portalMetadataDescription,
       images: [
         {
           url: `${baseUrl}/images/states/${state}/og-image.png`,
@@ -81,7 +88,7 @@ export async function generateMetadata(): Promise<Metadata> {
     twitter: {
       card: 'summary_large_image',
       title: portalTitle,
-      description: `Apply for Summer EBT (SUN Bucks) benefits in ${stateName}.`,
+      description: portalMetadataDescription,
       images: [`${baseUrl}/images/states/${state}/og-image.png`]
     },
     icons: {


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-307

#### ✍️ Description
Colorado link previews (Open Graph, Twitter cards, and page metadata) were using DC-branded copy. The title showed "Colorado SUN Bucks Self-Service Portal" and the description referenced applying for benefits, which does not match how the CO portal works.

This PR moves portal metadata into the design system state config and wires the root layout to use it.

Colorado changes:
- Title: "Colorado Summer EBT Self-Service Portal"
- Description: "Manage your CO Summer EBT benefits online."

DC behavior is unchanged:
- Title: "DC SUN Bucks Self-Service Portal"
- Description: existing apply and manage benefits copy

New state config fields: `siteDisplayName`, `portalMetadataDescription`
New helpers: `getSiteDisplayName()`, `getPortalMetadataDescription()`

#### 🔗 Links to related PRs
None

#### ✅ Completion tasks

- [x] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

#### Test plan
- Run `pnpm test` in `packages/design-system` and confirm `getSiteDisplayName` and `getPortalMetadataDescription` tests pass
- Build or run the CO portal locally (`pnpm dev:co`)
- View page source or use a link preview debugger and confirm:
  - `<title>` is "Colorado Summer EBT Self-Service Portal"
  - `og:title` matches the title above
  - `og:description` is "Manage your CO Summer EBT benefits online."
  - `twitter:title` and `twitter:description` match the Open Graph values
- Repeat for DC (`pnpm dev:dc`) and confirm DC title and description are unchanged
- Note: Slack, iMessage, and similar apps may cache old previews until their cache expires