### PR TITLE
DC-459 - hide applications CTA if no applications in progress

### DIFF
--- a/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.test.tsx
@@ -125,19 +125,36 @@ describe('ActionButtons', () => {
     expect(screen.queryByText('Request new cards')).toBeNull()
   })
 
-  it('shows only the Check existing applications CTA for a no-case household', () => {
-    // A household with no enrolled cases: the backend evaluator denies address
-    // and card actions, so denyAll is the realistic allowedActions shape here.
+  it('shows only the Check existing applications CTA for a no-case household with applications', () => {
+    // A household with no enrolled cases but with applications in progress: the
+    // backend evaluator denies address and card actions, so denyAll is the
+    // realistic allowedActions shape here.
     render(
       <ActionButtons
         allowedActions={denyAll}
         hasCases={false}
+        hasApplications={true}
       />
     )
     expect(screen.queryByText('Check existing cards')).toBeNull()
     expect(screen.queryByText('Change my mailing address')).toBeNull()
     expect(screen.queryByText('Request new cards')).toBeNull()
     expect(screen.getByText('Check existing applications')).toBeInTheDocument()
+  })
+
+  it('hides the Check existing applications CTA when hasApplications is false', () => {
+    // A household with enrolled cases but no applications in progress: the
+    // applications section renders nothing, so the CTA would scroll nowhere.
+    render(
+      <ActionButtons
+        allowedActions={allowAll}
+        hasCases={true}
+        hasApplications={false}
+      />
+    )
+    expect(screen.queryByText('Check existing applications')).toBeNull()
+    // Case-based CTA is unaffected.
+    expect(screen.getByText('Check existing cards')).toBeInTheDocument()
   })
 
   it('shows Check existing cards CTA when hasCases is true', () => {

--- a/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.tsx
@@ -15,6 +15,8 @@ interface ActionButton {
   gatedBy?: keyof Pick<AllowedActions, 'canUpdateAddress' | 'canRequestReplacementCard'>
   /** When true, the CTA is hidden if hasCases is explicitly false. Omitting hasCases keeps the CTA visible (backward-compatible). */
   requiresCases?: boolean
+  /** When true, the CTA is hidden if hasApplications is explicitly false. Omitting hasApplications keeps the CTA visible (backward-compatible). */
+  requiresApplications?: boolean
   /** When set, the CTA renders only for these states. Omitting it shows the CTA for every state. */
   states?: string[]
 }
@@ -24,6 +26,8 @@ interface ActionButtonsProps {
   allowedActions?: AllowedActions | null | undefined
   /** Whether the household has any enrolled children (summerEbtCases.length > 0). When false, CTAs that require cases are hidden. */
   hasCases?: boolean
+  /** Whether the household has any applications in progress (applications.length > 0). When false, CTAs that require applications are hidden. */
+  hasApplications?: boolean
 }
 
 // Keys map to CSV: "S2 - Portal Dashboard - Action Navigation - {Key}"
@@ -49,7 +53,8 @@ const ACTIONS: ActionButton[] = [
   {
     labelKey: 'actionNavigationCheckExistingApplications',
     href: '#applications-heading',
-    ctaId: 'check_applications_cta'
+    ctaId: 'check_applications_cta',
+    requiresApplications: true
   },
   {
     // CO-only for now: the authored label exists for CO, while DC's is still !N/A!
@@ -62,7 +67,7 @@ const ACTIONS: ActionButton[] = [
   }
 ]
 
-export function ActionButtons({ allowedActions, hasCases }: ActionButtonsProps) {
+export function ActionButtons({ allowedActions, hasCases, hasApplications }: ActionButtonsProps) {
   const { t } = useTranslation('dashboard')
   const currentState = getState()
   const { actionButtonBg, actionButtonText } = getStateConfig(currentState)
@@ -70,6 +75,7 @@ export function ActionButtons({ allowedActions, hasCases }: ActionButtonsProps) 
   const visibleActions = ACTIONS.filter((action) => {
     if (action.states && !action.states.includes(currentState)) return false
     if (action.requiresCases && hasCases === false) return false
+    if (action.requiresApplications && hasApplications === false) return false
     if (!action.gatedBy) return true
     // When allowedActions is not provided, default to showing the CTA (backward-compatible).
     if (!allowedActions) return true

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -339,6 +339,30 @@ describe('DashboardContent', () => {
     expect(document.getElementById('help-section-heading')).not.toBeNull()
   })
 
+  it('hides the Check existing applications CTA when the household has cases but no applications', async () => {
+    server.use(
+      http.get('/api/household/data', () => {
+        return HttpResponse.json({
+          ...TEST_HOUSEHOLD_DATA,
+          applications: []
+        })
+      })
+    )
+
+    renderWithProviders(<DashboardContent />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Sophia Martinez')).toBeInTheDocument()
+    })
+
+    // No applications: the section (and its scroll anchor) must not render, so the
+    // CTA that scrolls to it must be hidden.
+    expect(screen.queryByText('Check existing applications')).toBeNull()
+    expect(document.getElementById('applications-heading')).toBeNull()
+    // The case-based CTA still renders because there are enrolled cases.
+    expect(screen.getByText('Check existing cards')).toBeInTheDocument()
+  })
+
   describe('analytics tagging when a co-loaded user lands on an empty dashboard', () => {
     it('tags household_reason="no_children" when a co-loaded user lands on an empty dashboard', async () => {
       mockAuthSession.isCoLoaded = true

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -192,6 +192,7 @@ export function DashboardContent() {
       <ActionButtons
         allowedActions={data.allowedActions}
         hasCases={data.summerEbtCases.length > 0}
+        hasApplications={data.applications.length > 0}
       />
       {data.userProfile ? <UserProfileCard /> : <SignOutLink />}
       <HouseholdSummary />


### PR DESCRIPTION
## PR Description

#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-459

#### ✍️ Description
Hides the "Check existing applications" quick-action on the dashboard when the household has no applications in progress. Previously the CTA always rendered; with no applications there is no applications section to scroll to, so clicking it did nothing. The CTA now follows the same gating pattern already used for the case-based actions ("Check existing cards", "Activate a card").

#### 🔗 Links to related PRs
- _none_

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟢 | `src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.tsx` | `ActionButtons` filter | Low | Low | Low | mirrors existing `requiresCases` gating |
| 🟢 | `src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx` | `DashboardContent` | Low | Low | Low | passes `hasApplications` prop |
| 🟢 | `src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.test.tsx` | tests | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx` | tests | Low | Low | Low | |
