### PR TITLE
DC-165 Add "Date submitted" to dashboard applications

### DIFF
--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -150,6 +150,7 @@
     "show_application_number": true,
     "show_case_number": true,
     "show_card_last4": true,
+    "show_application_date": true,
     "defer_ebt_card_data_loading": false,
     "enable_beta_banner": false,
     "show_contact_preferences": false,

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -333,6 +333,7 @@ public class MockHouseholdRepository : IHouseholdRepository
                 app.ApplicationNumber = "APP-2025-01-100001";
                 app.CaseNumber = "CASE-100001";
                 app.IssuanceType = IssuanceType.SummerEbt;
+                app.ApplicationDate = now.AddDays(-45);
                 app.BenefitIssueDate = now.AddDays(-30);
                 app.BenefitExpirationDate = now.AddDays(60);
                 // Set specific children names for test
@@ -700,6 +701,7 @@ public class MockHouseholdRepository : IHouseholdRepository
                 ApplicationNumber = $"APP-{now.AddDays(-30):yyyy-MM}-{faker.Random.Number(100000, 999999)}",
                 CaseNumber = $"CASE-{faker.Random.Number(100000, 999999)}",
                 ApplicationStatus = ApplicationStatus.Approved,
+                ApplicationDate = now.AddDays(-45),
                 IssuanceType = IssuanceType.SummerEbt,
                 BenefitIssueDate = now.AddDays(-30),
                 BenefitExpirationDate = now.AddDays(60),
@@ -714,6 +716,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             {
                 ApplicationNumber = $"APP-{now.AddDays(-10):yyyy-MM}-{faker.Random.Number(100000, 999999)}",
                 ApplicationStatus = ApplicationStatus.Pending,
+                ApplicationDate = now.AddDays(-12),
                 Children = new List<Child>
                 {
                     new Child { FirstName = "Olivia", LastName = "Wilson" }
@@ -1212,6 +1215,7 @@ public class MockHouseholdRepository : IHouseholdRepository
                 ApplicationNumber = a.ApplicationNumber,
                 CaseNumber = a.CaseNumber,
                 ApplicationStatus = a.ApplicationStatus,
+                ApplicationDate = a.ApplicationDate,
                 BenefitIssueDate = a.BenefitIssueDate,
                 BenefitExpirationDate = a.BenefitExpirationDate,
                 // If application-level issuance type isn't set, inherit from the

--- a/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.test.tsx
@@ -12,6 +12,7 @@ const mockApplication: Application = {
   applicationNumber: 'APP-2026-001',
   caseNumber: 'CASE-DC-2026-001',
   applicationStatus: 'Approved',
+  applicationDate: '2026-01-15T00:00:00Z',
   benefitIssueDate: '2026-01-08T00:00:00Z',
   benefitExpirationDate: '2026-03-19T00:00:00Z',
   children: [
@@ -32,8 +33,11 @@ const defaultMockData: HouseholdData = {
 
 let mockReturnData: HouseholdData
 
+// formatDate is stubbed to a deterministic sentinel so date assertions don't
+// depend on locale/Intl behavior — we only verify it's wired to applicationDate.
 vi.mock('../../api', () => ({
-  useRequiredHouseholdData: () => mockReturnData
+  useRequiredHouseholdData: () => mockReturnData,
+  formatDate: (isoDate: string) => `formatted:${isoDate}`
 }))
 
 const defaultFlags: FeatureFlagsContextValue = {
@@ -150,5 +154,33 @@ describe('ApplicationsSection', () => {
     })
 
     expect(screen.queryByText('CASE-DC-2026-001')).not.toBeInTheDocument()
+  })
+
+  it('renders application date when show_application_date flag is on', () => {
+    renderWithFlags()
+
+    expect(screen.getByText('formatted:2026-01-15T00:00:00Z')).toBeInTheDocument()
+  })
+
+  it('hides application date when show_application_date flag is off', () => {
+    renderWithFlags({
+      flags: { ...TEST_FEATURE_FLAGS, show_application_date: false },
+      isLoading: false,
+      isError: false
+    })
+
+    expect(screen.queryByText('formatted:2026-01-15T00:00:00Z')).not.toBeInTheDocument()
+  })
+
+  it('hides application date when applicationDate is absent', () => {
+    const appWithoutDate: Application = { ...mockApplication, applicationDate: undefined }
+    mockReturnData = {
+      ...defaultMockData,
+      applications: [appWithoutDate]
+    }
+
+    renderWithFlags()
+
+    expect(screen.queryByText(/^formatted:/)).not.toBeInTheDocument()
   })
 })

--- a/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useFeatureFlag } from '@/features/feature-flags'
 
 import type { Application } from '../../api'
-import { useRequiredHouseholdData } from '../../api'
+import { formatDate, useRequiredHouseholdData } from '../../api'
 
 function getStatusTextClass(status: string): string {
   switch (status) {
@@ -34,8 +34,9 @@ const APPLICATION_STATUS_KEYS: Record<string, { key: string; fallback: string }>
 }
 
 function ApplicationCard({ application }: { application: Application }) {
-  const { t } = useTranslation('dashboard')
+  const { t, i18n } = useTranslation('dashboard')
   const showCaseNumber = useFeatureFlag('show_case_number')
+  const showApplicationDate = useFeatureFlag('show_application_date')
 
   const childrenNames = application.children
     .map((child) => `${child.firstName} ${child.lastName}`)
@@ -45,6 +46,15 @@ function ApplicationCard({ application }: { application: Application }) {
     <div className="usa-card__container margin-bottom-2">
       <div className="usa-card__body">
         <dl className="margin-0">
+          {showApplicationDate && application.applicationDate && (
+            <>
+              <dt className="text-bold">{t('applicationsTableHeadingDateSubmitted')}</dt>
+              <dd className="margin-left-0 margin-bottom-2">
+                {formatDate(application.applicationDate, i18n.language)}
+              </dd>
+            </>
+          )}
+
           {showCaseNumber && application.caseNumber && (
             <>
               <dt className="text-bold">{t('applicationsTableHeadingNumber')}</dt>

--- a/src/SEBT.Portal.Web/src/mocks/handlers.ts
+++ b/src/SEBT.Portal.Web/src/mocks/handlers.ts
@@ -46,6 +46,7 @@ export const TEST_FEATURE_FLAGS = {
   show_application_number: true,
   show_case_number: true,
   show_card_last4: true,
+  show_application_date: true,
   defer_ebt_card_data_loading: false,
   enable_beta_banner: false
 } as const

--- a/test/SEBT.Portal.Tests/Unit/Models/HouseholdDataResponseMapperTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Models/HouseholdDataResponseMapperTests.cs
@@ -12,6 +12,7 @@ public class HouseholdDataResponseMapperTests
     public void ToResponse_MapsAllHouseholdDataProperties_WhenFullyPopulated()
     {
         // Arrange
+        var applicationDate = new DateTime(2025, 12, 15, 9, 0, 0, DateTimeKind.Utc);
         var benefitIssue = new DateTime(2026, 1, 1, 10, 0, 0, DateTimeKind.Utc);
         var benefitExpiry = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc);
 
@@ -27,6 +28,7 @@ public class HouseholdDataResponseMapperTests
                     ApplicationNumber = "APP-123",
                     CaseNumber = "CASE-456",
                     ApplicationStatus = ApplicationStatus.Approved,
+                    ApplicationDate = applicationDate,
                     IssuanceType = IssuanceType.SnapEbtCard,
                     BenefitIssueDate = benefitIssue,
                     BenefitExpirationDate = benefitExpiry,
@@ -79,6 +81,7 @@ public class HouseholdDataResponseMapperTests
         Assert.Equal("APP-123", app.ApplicationNumber);
         Assert.Equal("CASE-456", app.CaseNumber);
         Assert.Equal(ApplicationStatus.Approved, app.ApplicationStatus);
+        Assert.Equal(applicationDate, app.ApplicationDate);
         Assert.Equal(IssuanceType.SnapEbtCard, app.IssuanceType);
         Assert.Equal(benefitIssue, app.BenefitIssueDate);
         Assert.Equal(benefitExpiry, app.BenefitExpirationDate);
@@ -199,6 +202,7 @@ public class HouseholdDataResponseMapperTests
     [Fact]
     public void ToResponse_MapsSummerEbtCases()
     {
+        var caseApplicationDate = new DateTime(2025, 11, 1, 0, 0, 0, DateTimeKind.Utc);
         var domain = new HouseholdData
         {
             Email = "user@example.com",
@@ -212,6 +216,7 @@ public class HouseholdDataResponseMapperTests
                     ChildLastName = "Garcia",
                     ChildDateOfBirth = new DateTime(2015, 5, 15),
                     ApplicationStatus = ApplicationStatus.Approved,
+                    ApplicationDate = caseApplicationDate,
                     EbtCardLastFour = "1234",
                     EbtCardBalance = 120.50m,
                     EbtCaseNumber = "CBMS-REF",
@@ -230,6 +235,7 @@ public class HouseholdDataResponseMapperTests
         Assert.Equal("Garcia", sec.ChildLastName);
         Assert.Equal(new DateTime(2015, 5, 15), sec.ChildDateOfBirth);
         Assert.Equal(ApplicationStatus.Approved, sec.ApplicationStatus);
+        Assert.Equal(caseApplicationDate, sec.ApplicationDate);
         Assert.Equal("1234", sec.EbtCardLastFour);
         Assert.Equal(120.50m, sec.EbtCardBalance);
         Assert.Equal("CBMS-REF", sec.EbtCaseNumber);


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-165](https://codeforamerica.atlassian.net/browse/DC-165)

#### ✍️ Description
Adds a **"Date submitted"** field to each application card in the **DC SUN Bucks Applications** section of the dashboard (View Benefits), gated behind a new `show_application_date` feature flag. Matches the [Figma](https://www.figma.com/design/avGrKdO2PMFQSOkgjNaWGd/DC---10-14-2025---%F0%9F%9F%A1-Enrollment-Checker---Self-service-Portal--WORKING-?node-id=2041-3611): the date renders as the first row of the card, above "Students included in application" and "Status".

Notes for reviewers:
- **The backend field already existed.** `ApplicationResponse.ApplicationDate` flows end-to-end (domain → DTO → `HouseholdDataResponseMapper` → DC connector populates it from the source DB). The net-new work in this PR is the feature flag and the frontend display, not adding the backend field.
- **Feature flag** `show_application_date` added to `appsettings.json` (default `true`); DC inherits it (no DC override) so the field shows on the DC dashboard. It is exposed via the existing `/api/features` endpoint and consumed with `useFeatureFlag(...)` exactly like `show_case_number` / `show_card_last4` — i.e. a frontend display gate; the API always returns the field.
- **i18n:** reuses the existing `applicationsTableHeadingDateSubmitted` ("Date submitted") key — no content change, and it's already present for DC en/es/am.
- **Mock-data fix (beyond the original scope):** `MockHouseholdRepository`'s read-path clone silently dropped `ApplicationDate`; fixed it and seeded a submitted date on the `verified` and `multipleapps` personas so the field is demonstrable in local mock mode.
- **CO is out of scope:** the CO connector doesn't provide an application submitted date and `co.csv` has no label for it, so CO renders nothing even with the flag inherited on.

Verified live on DC (`verified` persona) in addition to unit tests (3 new `ApplicationsSection` cases; backend mock-repo tests updated).

⚠️ **Ops follow-up:** the flag default lives in `appsettings.json`, so set `show_application_date = true` for DC in **AWS AppConfig** to enable it in deployed environments.

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig _(new `show_application_date` flag — needs setting for DC in AWS AppConfig; see ops follow-up above)_


[DC-165]: https://codeforamerica.atlassian.net/browse/DC-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ