### PR TITLE
DC-402 - hide application CTA when no applications

### DIFF
--- a/src/SEBT.Portal.Core/Seeding/SeedScenarios.cs
+++ b/src/SEBT.Portal.Core/Seeding/SeedScenarios.cs
@@ -14,6 +14,8 @@ public static class SeedScenarios
     public static readonly SeedScenario CoLoadedPendingIdProofing = new("co-loaded-pending-id-proofing", UserIalLevel.None);
     /// <summary>Co-loaded with SNAP/TANF on file; ID proofing completed, but the linked household has zero enrolled children and zero applications.</summary>
     public static readonly SeedScenario CoLoadedNoChildren = new("co-loaded-no-children", UserIalLevel.IAL1plus);
+    /// <summary>Co-loaded with SNAP/TANF on file and enrolled cases, but zero applications. ID proofing completed (IAL1+) so it lands on the dashboard; the "Check existing applications" CTA must stay hidden (DC-402).</summary>
+    public static readonly SeedScenario CoLoadedNoApplication = new("co-loaded-no-application", UserIalLevel.IAL1plus);
     public static readonly SeedScenario Verified = new("verified", UserIalLevel.IAL1plus);
     public static readonly SeedScenario Expired = new("expired", UserIalLevel.IAL1plus);
     public static readonly SeedScenario Review = new("review", UserIalLevel.IAL1plus);
@@ -62,7 +64,7 @@ public static class SeedScenarios
     /// </summary>
     public static readonly IReadOnlyList<SeedScenario> UserScenarios =
     [
-        CoLoaded, CoLoadedPendingIdProofing, CoLoadedNoChildren, Verified, SingleChild, LargeFamily, Expired,
+        CoLoaded, CoLoadedPendingIdProofing, CoLoadedNoChildren, CoLoadedNoApplication, Verified, SingleChild, LargeFamily, Expired,
         NonCoLoaded, IdProofInProgress, NotStarted, Pending, Minimal, Denied,
         Review, Cancelled, Unknown, SummerActive, SummerLost,
         DcMixed, CoUndeliverable, CoFrozen, CoNotActivated, CoDeactivatedByState, CoActive,
@@ -79,6 +81,7 @@ public static class SeedScenarios
             Simple1, Simple2, Simple3, Simple4, Simple5, Simple6, Simple7,
             CoLoadedPendingIdProofing,
             CoLoadedNoChildren,
+            CoLoadedNoApplication,
         };
 
     /// <summary>

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -320,6 +320,20 @@ public class MockHouseholdRepository : IHouseholdRepository
             });
             _households[coLoadedNoChildrenEmail] = coLoadedNoChildren;
             IndexByPhone(coLoadedNoChildren);
+
+            // Co-loaded household with enrolled cases but ZERO applications. Lands on the
+            // dashboard (ID verified, address on file) and must NOT show the "Check existing
+            // applications" CTA — the applications section renders nothing at zero applications,
+            // so the CTA would scroll to a missing anchor (DC-402).
+            var coLoadedNoApplicationEmail = _settings.BuildEmail(SeedScenarios.CoLoadedNoApplication.Name);
+            var coLoadedNoApplication = CreateCopy(coLoaded, fullPii) with
+            {
+                Email = coLoadedNoApplicationEmail,
+                Phone = "8185558441",
+                Applications = new List<Application>(),
+            };
+            _households[coLoadedNoApplicationEmail] = coLoadedNoApplication;
+            IndexByPhone(coLoadedNoApplication);
         }
 
         // Scenario 2: Approved application with address (ID verified user)

--- a/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.test.tsx
@@ -150,6 +150,31 @@ describe('ActionButtons', () => {
     expect(screen.getByText('Check existing cards')).toBeInTheDocument()
   })
 
+  it('hides Check existing applications CTA when hasApplications is false', () => {
+    // Co-loaded households have cases but no applications; the CTA scrolls to an
+    // applications section that does not render, so it must hide (DC-402).
+    render(
+      <ActionButtons
+        allowedActions={allowAll}
+        hasCases={true}
+        hasApplications={false}
+      />
+    )
+    expect(screen.queryByText('Check existing applications')).toBeNull()
+    expect(screen.getByText('Check existing cards')).toBeInTheDocument()
+  })
+
+  it('shows Check existing applications CTA when hasApplications is true', () => {
+    render(
+      <ActionButtons
+        allowedActions={allowAll}
+        hasCases={true}
+        hasApplications={true}
+      />
+    )
+    expect(screen.getByText('Check existing applications')).toBeInTheDocument()
+  })
+
   it('does not render the self-service-unavailable alert even when actions are denied', () => {
     render(<ActionButtons allowedActions={denyAll} />)
     expect(screen.queryByRole('status')).toBeNull()

--- a/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/ActionButtons/ActionButtons.tsx
@@ -15,6 +15,8 @@ interface ActionButton {
   gatedBy?: keyof Pick<AllowedActions, 'canUpdateAddress' | 'canRequestReplacementCard'>
   /** When true, the CTA is hidden if hasCases is explicitly false. Omitting hasCases keeps the CTA visible (backward-compatible). */
   requiresCases?: boolean
+  /** When true, the CTA is hidden if hasApplications is explicitly false. Omitting hasApplications keeps the CTA visible (backward-compatible). */
+  requiresApplications?: boolean
   /** When set, the CTA renders only for these states. Omitting it shows the CTA for every state. */
   states?: string[]
 }
@@ -24,6 +26,8 @@ interface ActionButtonsProps {
   allowedActions?: AllowedActions | null | undefined
   /** Whether the household has any enrolled children (summerEbtCases.length > 0). When false, CTAs that require cases are hidden. */
   hasCases?: boolean
+  /** Whether the household has any applications (applications.length > 0). When false, CTAs that require applications are hidden. */
+  hasApplications?: boolean
 }
 
 // Keys map to CSV: "S2 - Portal Dashboard - Action Navigation - {Key}"
@@ -49,7 +53,8 @@ const ACTIONS: ActionButton[] = [
   {
     labelKey: 'actionNavigationCheckExistingApplications',
     href: '#applications-heading',
-    ctaId: 'check_applications_cta'
+    ctaId: 'check_applications_cta',
+    requiresApplications: true
   },
   {
     // CO-only for now: the authored label exists for CO, while DC's is still !N/A!
@@ -62,7 +67,7 @@ const ACTIONS: ActionButton[] = [
   }
 ]
 
-export function ActionButtons({ allowedActions, hasCases }: ActionButtonsProps) {
+export function ActionButtons({ allowedActions, hasCases, hasApplications }: ActionButtonsProps) {
   const { t } = useTranslation('dashboard')
   const currentState = getState()
   const { actionButtonBg, actionButtonText } = getStateConfig(currentState)
@@ -70,6 +75,7 @@ export function ActionButtons({ allowedActions, hasCases }: ActionButtonsProps) 
   const visibleActions = ACTIONS.filter((action) => {
     if (action.states && !action.states.includes(currentState)) return false
     if (action.requiresCases && hasCases === false) return false
+    if (action.requiresApplications && hasApplications === false) return false
     if (!action.gatedBy) return true
     // When allowedActions is not provided, default to showing the CTA (backward-compatible).
     if (!allowedActions) return true

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.tsx
@@ -192,6 +192,7 @@ export function DashboardContent() {
       <ActionButtons
         allowedActions={data.allowedActions}
         hasCases={data.summerEbtCases.length > 0}
+        hasApplications={data.applications.length > 0}
       />
       {data.userProfile ? <UserProfileCard /> : <SignOutLink />}
       <HouseholdSummary />

--- a/test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs
@@ -176,6 +176,22 @@ public class MockHouseholdRepositoryTests
     }
 
     [Fact]
+    public async Task GetHouseholdByEmailAsync_WhenDcCoLoadedNoApplication_HasCoLoadedCasesAndZeroApplications()
+    {
+        var repo = CreateRepository("{0}@example.com", state: "dc");
+        const string email = "co-loaded-no-application@example.com";
+
+        var result = await repo.GetHouseholdByEmailAsync(email, FullPiiVisibility, UserIalLevel.IAL1plus);
+
+        Assert.NotNull(result);
+        Assert.Equal(email, result!.Email);
+        Assert.Equal("8185558441", result.Phone);
+        Assert.NotEmpty(result.SummerEbtCases);
+        Assert.All(result.SummerEbtCases, c => Assert.True(c.IsCoLoaded));
+        Assert.Empty(result.Applications);
+    }
+
+    [Fact]
     public async Task GetHouseholdByEmailAsync_WhenHouseholdDoesNotExist_ReturnsNull()
     {
         // Arrange


### PR DESCRIPTION
## PR Description

#### 🔗 Jira ticket
[DC-402](https://codeforamerica.atlassian.net/browse/DC-402?atlOrigin=eyJpIjoiODg1ZDhlNmFmNDFlNDk2YzgwMzM5YmM3ZDM0NWE3OTYiLCJwIjoiaiJ9)

#### ✍️ Description
Hides the "Check existing applications" dashboard CTA for households that have enrolled children but no applications. That CTA links to an applications section that does not render when there are zero applications, so it would scroll to a missing anchor. The CTA still shows when the household has at least one application. Adds a mock persona (co-loaded household with enrolled cases and zero applications) so the scenario can be exercised locally.

#### 🔗 Links to related PRs
- _none yet — branch not pushed_

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟢 | `src/SEBT.Portal.Core/Seeding/SeedScenarios.cs` | `CoLoadedNoApplication` scenario | Low | Low | Low | dev/test seeding |
| 🟢 | `src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs` | persona seed | Low | Low | Low | mock data, fake values |
| 🟢 | `.../ActionButtons/ActionButtons.test.tsx` | added tests | Low | Low | Low | |
| 🟢 | `.../ActionButtons/ActionButtons.tsx` | `ActionButtons` visibility filter | Low | Low | Low | mirrors `requiresCases` |
| 🟢 | `.../DashboardContent/DashboardContent.tsx` | `hasApplications` prop wiring | Low | Low | Low | |
| 🟢 | `test/SEBT.Portal.Tests/Unit/Repositories/MockHouseholdRepositoryTests.cs` | added test | Low | Low | Low | |


[DC-402]: https://codeforamerica.atlassian.net/browse/DC-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ