### PR TITLE
[DC-506] Enable default tracking and autocapture in Amplitude

### DIFF
--- a/packages/analytics/src/amplitude-bridge.test.ts
+++ b/packages/analytics/src/amplitude-bridge.test.ts
@@ -143,19 +143,6 @@ describe('initAmplitudeBridge', () => {
   })
 
   describe('privacy configuration', () => {
-    it('disables default tracking and autocapture', () => {
-      new DataLayer('digitalData')
-      initAmplitudeBridge('test-key', amplitudeStub)
-
-      expect(amplitudeStub.init).toHaveBeenCalledWith(
-        'test-key',
-        expect.objectContaining({
-          defaultTracking: false,
-          autocapture: false
-        })
-      )
-    })
-
     it('disables cross-session identity storage', () => {
       new DataLayer('digitalData')
       initAmplitudeBridge('test-key', amplitudeStub)

--- a/packages/analytics/src/amplitude-bridge.ts
+++ b/packages/analytics/src/amplitude-bridge.ts
@@ -1,9 +1,7 @@
 /**
  * DOM event bridge that listens to DataLayer CustomEvents and forwards
  * them to Amplitude. Forwards both PageViewed (page_load) and EventTracked
- * events. The Amplitude init is configured with no session replay, no
- * autocapture, and no user identity — page tracking is opt-in via the
- * data layer's pageLoad() call rather than Amplitude's defaultTracking.
+ * events. 
  *
  * @see docs/tdd/analytics-data-layer.md — "DOM Bridge & Sample Integration"
  */

--- a/packages/analytics/src/amplitude-bridge.ts
+++ b/packages/analytics/src/amplitude-bridge.ts
@@ -44,8 +44,6 @@ function attachBridge(dl: DataLayerRoot, amplitude: AmplitudeLike): () => void {
 
 export function initAmplitudeBridge(apiKey: string, amplitude: AmplitudeLike): () => void {
   // Privacy posture:
-  // - defaultTracking: false        → no page view / session / form / file-download autocapture
-  // - autocapture: false            → no DOM element interaction autocapture
   // - identityStorage: 'none'       → no cross-session user identity persistence
   // - trackingOptions.ipAddress: false → do not capture client IP
   //
@@ -53,8 +51,8 @@ export function initAmplitudeBridge(apiKey: string, amplitude: AmplitudeLike): (
   // require opting in via additional plugins — not enabled here by construction.
   try {
     amplitude.init(apiKey, {
-      defaultTracking: false,
-      autocapture: false,
+      defaultTracking: true,
+      autocapture: true,
       identityStorage: 'none',
       trackingOptions: {
         ipAddress: false


### PR DESCRIPTION
Updated Amplitude bridge initialization to enable default tracking (for utm and session tracking) and autocapture, per request.

---
[DC-506] Enable default tracking and autocapture in Amplitude
---

#### 🔗 Jira ticket
[DC-506](https://codeforamerica.atlassian.net/browse/DC-506)

[DC-506]: https://codeforamerica.atlassian.net/browse/DC-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DC-506]: https://codeforamerica.atlassian.net/browse/DC-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


``` 
RUN  v4.1.6 /Users/mtodd@codeforamerica.org/dev/cfa/sebt/sebt-self-service-portal/packages/analytics

 ✓ src/data-layer.test.ts (53 tests) 11ms
 ✓ src/siteimprove-bridge.test.ts (14 tests) 19ms
 ✓ src/AmplitudeAnalytics.test.tsx (4 tests) 13ms
 ✓ src/MixpanelAnalytics.test.tsx (4 tests) 30ms
 ✓ src/useDataLayer.test.tsx (7 tests) 16ms
 ✓ src/SiteImproveAnalytics.test.tsx (5 tests) 48ms
Not implemented: navigation to another Document
 ✓ src/DataLayerProvider.test.tsx (8 tests) 47ms
 ✓ src/mixpanel-bridge.test.ts (17 tests) 8ms
 ✓ src/amplitude-bridge.test.ts (12 tests) 7ms

 Test Files  9 passed (9)
      Tests  124 passed (124)
   Start at  15:23:34
   Duration  2.39s (transform 601ms, setup 0ms, import 1.59s, tests 200ms, environment 8.72s)```