### PR TITLE
DC-504 Fix OIDC missing_session

### DIFF
--- a/src/SEBT.Portal.Api/Services/IPreAuthSessionStore.cs
+++ b/src/SEBT.Portal.Api/Services/IPreAuthSessionStore.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+using System.Text;
+using Medallion.Threading;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace SEBT.Portal.Api.Services;
+
+/// <summary>
+/// manages the lifecycle of server-side pre-auth OIDC sessions.
+/// Sessions are stored in <see cref="HybridCache"/> (L1 memory + optional L2 Redis)
+/// with an automatic TTL so abandoned flows expire without explicit cleanup.
+/// </summary>
+public interface IPreAuthSessionStore
+{
+    /// <summary>Creates a new pre-auth session and returns its ID (for the cookie).</summary>
+    Task<PreAuthSession> CreateAsync(
+        string stateCode,
+        string state,
+        string codeVerifier,
+        string redirectUri,
+        bool isStepUp,
+        string? returnUrl = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Retrieves a session by ID. Returns null if expired or not found.</summary>
+    Task<PreAuthSession?> GetAsync(string sessionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Advances the session to <see cref="PreAuthSessionPhase.CallbackCompleted"/>
+    /// and stores the callback token hash. Fails if the session is not in <c>Created</c> phase.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="IDistributedLockProvider"/> to serialize concurrent transitions
+    /// across all container instances (Redis-backed in production, SQL fallback otherwise).
+    /// </remarks>
+    Task<bool> TryAdvanceToCallbackCompletedAsync(
+        string sessionId,
+        string callbackTokenHash,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Advances the session to <see cref="PreAuthSessionPhase.LoginCompleted"/>.
+    /// Fails if the session is not in <c>CallbackCompleted</c> phase or the callback token
+    /// hash doesn't match. Uses the same distributed lock as <see cref="TryAdvanceToCallbackCompletedAsync"/>.
+    /// </summary>
+    Task<bool> TryAdvanceToLoginCompletedAsync(
+        string sessionId,
+        string callbackTokenHash,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a session (used after login completion or on error cleanup).</summary>
+    Task RemoveAsync(string sessionId, CancellationToken cancellationToken = default);
+
+    /// <summary>Computes the SHA-256 hash of a callback token for storage/comparison.</summary>
+    static string HashCallbackToken(string callbackToken)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(callbackToken));
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
+++ b/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
@@ -78,7 +78,7 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        await using (await _lockProvider.AcquireLockAsync(CacheKey(sessionId), cancellationToken: cancellationToken))
+        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: cancellationToken))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -107,7 +107,7 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        await using (await _lockProvider.AcquireLockAsync(CacheKey(sessionId), cancellationToken: cancellationToken))
+        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: cancellationToken))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -144,6 +144,7 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
     }
 
     private static string CacheKey(string sessionId) => $"{CacheKeyPrefix}{sessionId}";
+    private static string LockKey(string sessionId) => $"{CacheKeyPrefix}lock:{sessionId}";
 
     private static string SanitizeForLog(string? value)
     {

--- a/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
+++ b/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
@@ -113,9 +113,12 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        var tokenWithTimeout = WithLockTimeout(cancellationToken);
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
 
-        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: tokenWithTimeout))
+        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: linkedCts.Token))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -144,9 +147,12 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        var tokenWithTimeout = WithLockTimeout(cancellationToken);
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCts.Token);
 
-        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: tokenWithTimeout))
+        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: linkedCts.Token))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -184,17 +190,6 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
 
     private static string CacheKey(string sessionId) => $"{CacheKeyPrefix}{sessionId}";
     private static string LockKey(string sessionId) => $"{CacheKeyPrefix}lock:{sessionId}";
-
-    private static CancellationToken WithLockTimeout(CancellationToken sourceToken)
-    {
-        var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-
-        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-            sourceToken,
-            timeoutCts.Token);
-
-        return linkedCts.Token;
-    }
 
     private static string SanitizeForLog(string? value)
     {

--- a/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
+++ b/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
@@ -1,65 +1,8 @@
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
-using System.Text;
+using Medallion.Threading;
 using Microsoft.Extensions.Caching.Hybrid;
 
 namespace SEBT.Portal.Api.Services;
-
-/// <summary>
-/// manages the lifecycle of server-side pre-auth OIDC sessions.
-/// Sessions are stored in <see cref="HybridCache"/> (L1 memory + optional L2 Redis)
-/// with an automatic TTL so abandoned flows expire without explicit cleanup.
-/// </summary>
-public interface IPreAuthSessionStore
-{
-    /// <summary>Creates a new pre-auth session and returns its ID (for the cookie).</summary>
-    Task<PreAuthSession> CreateAsync(
-        string stateCode,
-        string state,
-        string codeVerifier,
-        string redirectUri,
-        bool isStepUp,
-        string? returnUrl = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>Retrieves a session by ID. Returns null if expired or not found.</summary>
-    Task<PreAuthSession?> GetAsync(string sessionId, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Advances the session to <see cref="PreAuthSessionPhase.CallbackCompleted"/>
-    /// and stores the callback token hash. Fails if the session is not in <c>Created</c> phase.
-    /// </summary>
-    /// <remarks>
-    /// Single-writer assumption: with in-memory L1 cache (single process) this is safe.
-    /// Under horizontal scaling with Redis L2, two concurrent requests could both read
-    /// <c>Created</c> and both advance. If multi-instance deployment is added, replace the
-    /// read-modify-write with a Redis WATCH/MULTI or Lua script for CAS semantics.
-    /// </remarks>
-    Task<bool> TryAdvanceToCallbackCompletedAsync(
-        string sessionId,
-        string callbackTokenHash,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Advances the session to <see cref="PreAuthSessionPhase.LoginCompleted"/>.
-    /// Fails if the session is not in <c>CallbackCompleted</c> phase or the callback token
-    /// hash doesn't match. Same single-writer assumption as <see cref="TryAdvanceToCallbackCompletedAsync"/>.
-    /// </summary>
-    Task<bool> TryAdvanceToLoginCompletedAsync(
-        string sessionId,
-        string callbackTokenHash,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>Removes a session (used after login completion or on error cleanup).</summary>
-    Task RemoveAsync(string sessionId, CancellationToken cancellationToken = default);
-
-    /// <summary>Computes the SHA-256 hash of a callback token for storage/comparison.</summary>
-    static string HashCallbackToken(string callbackToken)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(callbackToken));
-        return Convert.ToHexStringLower(bytes);
-    }
-}
 
 /// <inheritdoc cref="IPreAuthSessionStore"/>
 public sealed class PreAuthSessionStore : IPreAuthSessionStore
@@ -76,25 +19,15 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         LocalCacheExpiration = SessionTtl
     };
 
-    private const string CacheKeyPrefix = "oidc:preauth:";
+    internal const string CacheKeyPrefix = "oidc:preauth:";
 
-    /// <summary>
-    /// Tracks known session IDs to avoid calling <see cref="HybridCache"/>.GetOrCreateAsync
-    /// for fabricated IDs (which would cache null entries and amplify memory usage).
-    /// </summary>
-    private static readonly ConcurrentDictionary<string, byte> KnownSessionIds = new();
-
-    /// <summary>
-    /// Per-session locks to serialize state transitions and prevent TOCTOU races where
-    /// two concurrent requests both read the same phase, both pass the check, and both
-    /// advance. Locks are cleaned up when sessions are removed.
-    /// </summary>
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> SessionLocks = new();
+    private readonly IDistributedLockProvider _lockProvider;
 
     /// <inheritdoc cref="PreAuthSessionStore"/>
-    public PreAuthSessionStore(HybridCache cache, ILogger<PreAuthSessionStore> logger)
+    public PreAuthSessionStore(HybridCache cache, IDistributedLockProvider lockProvider, ILogger<PreAuthSessionStore> logger)
     {
         _cache = cache;
+        _lockProvider = lockProvider;
         _logger = logger;
     }
 
@@ -123,7 +56,6 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         };
 
         await _cache.SetAsync(CacheKey(sessionId), session, CacheOptions, cancellationToken: cancellationToken);
-        KnownSessionIds.TryAdd(sessionId, 0);
         _logger.LogInformation(
             "Pre-auth session created: SessionId={SessionId}, StateCode={StateCode} (reason=session_created)",
             sessionId, SanitizeForLog(stateCode));
@@ -133,26 +65,11 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
     /// <inheritdoc/>
     public async Task<PreAuthSession?> GetAsync(string sessionId, CancellationToken cancellationToken = default)
     {
-        // Fast-reject fabricated session IDs without touching the cache. Only IDs created
-        // by CreateAsync are tracked in the in-memory set; everything else returns null
-        // immediately, preventing cache amplification from attacker-generated IDs.
-        if (!KnownSessionIds.ContainsKey(sessionId))
-            return null;
-
-        var result = await _cache.GetOrCreateAsync(
+        return await _cache.GetOrCreateAsync(
             CacheKey(sessionId),
             _ => ValueTask.FromResult<PreAuthSession?>(null),
             CacheOptions,
             cancellationToken: cancellationToken);
-
-        // Session expired in cache — clean up tracking dictionaries so they don't grow unbounded.
-        if (result == null)
-        {
-            KnownSessionIds.TryRemove(sessionId, out _);
-            SessionLocks.TryRemove(sessionId, out _);
-        }
-
-        return result;
     }
 
     /// <inheritdoc/>
@@ -161,9 +78,7 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        var semaphore = SessionLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
-        await semaphore.WaitAsync(cancellationToken);
-        try
+        await using (await _lockProvider.AcquireLockAsync(CacheKey(sessionId), cancellationToken: cancellationToken))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -184,10 +99,6 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
             _logger.LogInformation("Pre-auth session advanced to CallbackCompleted: SessionId={SessionId} (reason=callback_completed)", sessionId);
             return true;
         }
-        finally
-        {
-            semaphore.Release();
-        }
     }
 
     /// <inheritdoc/>
@@ -196,9 +107,7 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        var semaphore = SessionLocks.GetOrAdd(sessionId, _ => new SemaphoreSlim(1, 1));
-        await semaphore.WaitAsync(cancellationToken);
-        try
+        await using (await _lockProvider.AcquireLockAsync(CacheKey(sessionId), cancellationToken: cancellationToken))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -226,17 +135,11 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
             _logger.LogInformation("Pre-auth session advanced to LoginCompleted: SessionId={SessionId} (reason=login_completed)", sessionId);
             return true;
         }
-        finally
-        {
-            semaphore.Release();
-        }
     }
 
     /// <inheritdoc/>
     public async Task RemoveAsync(string sessionId, CancellationToken cancellationToken = default)
     {
-        KnownSessionIds.TryRemove(sessionId, out _);
-        SessionLocks.TryRemove(sessionId, out _);
         await _cache.RemoveAsync(CacheKey(sessionId), cancellationToken);
     }
 

--- a/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
+++ b/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
@@ -16,7 +16,19 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
     private static readonly HybridCacheEntryOptions CacheOptions = new()
     {
         Expiration = SessionTtl,
-        LocalCacheExpiration = SessionTtl
+        LocalCacheExpiration = SessionTtl,
+    };
+
+    // Read-only lookup: suppress L1/L2 writes so a miss (factory returning null) does
+    // not cache a null entry for an attacker-controlled session ID. Without this,
+    // any fabricated session ID submitted via the OIDC callback cookie would pollute
+    // the cache with a null entry (TTL = SessionTtl), enabling cache amplification.
+    private static readonly HybridCacheEntryOptions LookupOptions = new()
+    {
+        Expiration = SessionTtl,
+        LocalCacheExpiration = SessionTtl,
+        Flags = HybridCacheEntryFlags.DisableLocalCacheWrite
+              | HybridCacheEntryFlags.DisableDistributedCacheWrite,
     };
 
     internal const string CacheKeyPrefix = "oidc:preauth:";
@@ -65,11 +77,34 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
     /// <inheritdoc/>
     public async Task<PreAuthSession?> GetAsync(string sessionId, CancellationToken cancellationToken = default)
     {
-        return await _cache.GetOrCreateAsync(
+        var session = await _cache.GetOrCreateAsync(
             CacheKey(sessionId),
             _ => ValueTask.FromResult<PreAuthSession?>(null),
-            CacheOptions,
+            LookupOptions,
             cancellationToken: cancellationToken);
+
+        if (session is not null)
+        {
+            // Promote to L1 (no L2 write — L2 already has it on the path that needed promotion;
+            // L1 hits result in a harmless re-write). TTL is the session's remaining absolute
+            // lifetime, not a fresh SessionTtl, so reads do not extend the session expiration.
+            var remaining = session.CreatedAt + SessionTtl - DateTimeOffset.UtcNow;
+            if (remaining > TimeSpan.Zero)
+            {
+                await _cache.SetAsync(
+                    CacheKey(sessionId),
+                    session,
+                    new HybridCacheEntryOptions
+                    {
+                        Expiration = remaining,
+                        LocalCacheExpiration = remaining,
+                        Flags = HybridCacheEntryFlags.DisableDistributedCacheWrite,
+                    },
+                    cancellationToken: cancellationToken);
+            }
+        }
+
+        return session;
     }
 
     /// <inheritdoc/>
@@ -80,7 +115,7 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
     {
         var tokenWithTimeout = WithLockTimeout(cancellationToken);
 
-        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: cancellationToken))
+        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: tokenWithTimeout))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)
@@ -109,7 +144,9 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
-        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: cancellationToken))
+        var tokenWithTimeout = WithLockTimeout(cancellationToken);
+
+        await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: tokenWithTimeout))
         {
             var session = await GetAsync(sessionId, cancellationToken);
             if (session == null)

--- a/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
+++ b/src/SEBT.Portal.Api/Services/PreAuthSessionStore.cs
@@ -78,6 +78,8 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
         string callbackTokenHash,
         CancellationToken cancellationToken = default)
     {
+        var tokenWithTimeout = WithLockTimeout(cancellationToken);
+
         await using (await _lockProvider.AcquireLockAsync(LockKey(sessionId), cancellationToken: cancellationToken))
         {
             var session = await GetAsync(sessionId, cancellationToken);
@@ -145,6 +147,17 @@ public sealed class PreAuthSessionStore : IPreAuthSessionStore
 
     private static string CacheKey(string sessionId) => $"{CacheKeyPrefix}{sessionId}";
     private static string LockKey(string sessionId) => $"{CacheKeyPrefix}lock:{sessionId}";
+
+    private static CancellationToken WithLockTimeout(CancellationToken sourceToken)
+    {
+        var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            sourceToken,
+            timeoutCts.Token);
+
+        return linkedCts.Token;
+    }
 
     private static string SanitizeForLog(string? value)
     {

--- a/test/SEBT.Portal.Tests/Helpers/InProcessLockProvider.cs
+++ b/test/SEBT.Portal.Tests/Helpers/InProcessLockProvider.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+using Medallion.Threading;
+
+namespace SEBT.Portal.Tests.Helpers;
+
+/// <summary>
+/// In-process <see cref="IDistributedLockProvider"/> backed by per-key <see cref="SemaphoreSlim"/>s.
+/// Used in tests that need real lock semantics (blocking, not mock) without an external service
+/// like Redis or SQL Server. Provides the same mutual-exclusion guarantees as
+/// <c>RedisDistributedSynchronizationProvider</c> or <c>SqlDistributedSynchronizationProvider</c>
+/// for tests where the lock semantics matter but a distributed backing store does not.
+/// </summary>
+public sealed class InProcessLockProvider : IDistributedLockProvider
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
+
+    public IDistributedLock CreateLock(string name) =>
+        new InProcessLock(name, _semaphores.GetOrAdd(name, _ => new SemaphoreSlim(1, 1)));
+
+    private sealed class InProcessLock(string name, SemaphoreSlim semaphore) : IDistributedLock
+    {
+        public string Name => name;
+
+        public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            if (!semaphore.Wait(timeout, cancellationToken))
+                return null;
+            return new Handle(semaphore);
+        }
+
+        public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            if (timeout.HasValue)
+            {
+                if (!semaphore.Wait(timeout.Value, cancellationToken))
+                    throw new TimeoutException($"Could not acquire lock '{name}'");
+            }
+            else
+            {
+                semaphore.Wait(cancellationToken);
+            }
+            return new Handle(semaphore);
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            var acquired = await semaphore.WaitAsync(timeout, cancellationToken);
+            return acquired ? new Handle(semaphore) : null;
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            if (timeout.HasValue)
+            {
+                var acquired = await semaphore.WaitAsync(timeout.Value, cancellationToken);
+                if (!acquired)
+                    throw new TimeoutException($"Could not acquire lock '{name}'");
+            }
+            else
+            {
+                await semaphore.WaitAsync(cancellationToken);
+            }
+            return new Handle(semaphore);
+        }
+    }
+
+    private sealed class Handle(SemaphoreSlim semaphore) : IDistributedSynchronizationHandle
+    {
+        public CancellationToken HandleLostToken => CancellationToken.None;
+        public void Dispose() => semaphore.Release();
+        public ValueTask DisposeAsync()
+        {
+            semaphore.Release();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
@@ -1,3 +1,4 @@
+using Medallion.Threading;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ using SEBT.Portal.Core.Services;
 using SEBT.Portal.Infrastructure.Data;
 using SEBT.Portal.Infrastructure.Services;
 using SEBT.Portal.StatesPlugins.Interfaces;
+using SEBT.Portal.Tests.Helpers;
 
 namespace SEBT.Portal.Tests.Integration.PluginIntegration;
 
@@ -96,6 +98,14 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
             // HouseholdRepository depends on it. Register a mock so DI validation
             // passes. TryAddSingleton is a no-op if a real plugin already registered it.
             services.TryAddSingleton(Substitute.For<ISummerEbtCaseService>());
+
+            // Replace the distributed lock provider with an in-process implementation so
+            // tests that exercise IPreAuthSessionStore do not depend on a reachable SQL
+            // Server or Redis instance for lock acquisition.
+            var lockDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributedLockProvider));
+            if (lockDescriptor != null)
+                services.Remove(lockDescriptor);
+            services.AddSingleton<IDistributedLockProvider>(new InProcessLockProvider());
         });
     }
 

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
@@ -52,6 +52,10 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
         Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", "plugins-none");
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey",
             "integration-test-key-must-be-at-least-32-bytes-long");
+        // Disable Redis so HybridCache uses in-memory only and distributed locking falls
+        // back to SQL. Matches PortalWebApplicationFactory — prevents env-var leakage from
+        // a preceding factory from leaving a non-empty Redis connection string in place.
+        Environment.SetEnvironmentVariable("ConnectionStrings__Redis", "");
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__application", "IAL1");
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__coloadedStreamline", "IAL1");
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__streamline", "IAL1plus");
@@ -100,6 +104,7 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
         Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", null);
         Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", null);
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey", null);
+        Environment.SetEnvironmentVariable("ConnectionStrings__Redis", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__application", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__coloadedStreamline", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__streamline", null);

--- a/test/SEBT.Portal.Tests/Integration/PortalWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PortalWebApplicationFactory.cs
@@ -1,9 +1,11 @@
+using Medallion.Threading;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Infrastructure.Services;
+using SEBT.Portal.Tests.Helpers;
 
 namespace SEBT.Portal.Tests.Integration;
 
@@ -77,6 +79,15 @@ public class PortalWebApplicationFactory : WebApplicationFactory<Program>
                 && d.ImplementationType?.FullName?.Contains("Redis", StringComparison.OrdinalIgnoreCase) == true);
             if (redisDescriptor != null)
                 services.Remove(redisDescriptor);
+
+            // Replace the distributed lock provider with an in-process implementation.
+            // Without this, AddDistributedLocking falls back to SqlDistributedSynchronizationProvider
+            // (since Redis is disabled above), which tries to open a real SQL connection on lock
+            // acquisition — failing in CI where no SQL Server is reachable at the default address.
+            var lockDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributedLockProvider));
+            if (lockDescriptor != null)
+                services.Remove(lockDescriptor);
+            services.AddSingleton<IDistributedLockProvider>(new InProcessLockProvider());
         });
     }
 

--- a/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -18,8 +18,10 @@
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
         <PackageReference Include="coverlet.collector" Version="10.0.1" />
+        <PackageReference Include="DistributedLock.Redis" Version="1.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
@@ -28,8 +30,10 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+        <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+        <PackageReference Include="Testcontainers.Redis" Version="4.12.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />

--- a/test/SEBT.Portal.Tests/Unit/Api/Services/RedisPreAuthSessionStoreFixture.cs
+++ b/test/SEBT.Portal.Tests/Unit/Api/Services/RedisPreAuthSessionStoreFixture.cs
@@ -1,0 +1,57 @@
+using Medallion.Threading;
+using Medallion.Threading.Redis;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using SEBT.Portal.Api.Services;
+using StackExchange.Redis;
+using Testcontainers.Redis;
+
+namespace SEBT.Portal.Tests.Unit.Api.Services;
+
+/// <summary>
+/// Spins up a Redis container once for the collection. Each call to
+/// <see cref="CreateInstance"/> returns a store backed by a fresh in-memory L1
+/// cache but sharing the same Redis L2 and <see cref="IDistributedLockProvider"/>
+/// — accurately simulating two separate container replicas.
+/// </summary>
+public sealed class RedisPreAuthSessionStoreFixture : IAsyncLifetime
+{
+    private readonly RedisContainer _container = new RedisBuilder().Build();
+    private ConnectionMultiplexer _multiplexer = null!;
+
+    public IDistributedLockProvider LockProvider { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        _multiplexer = await ConnectionMultiplexer.ConnectAsync(_container.GetConnectionString());
+        LockProvider = new RedisDistributedSynchronizationProvider(_multiplexer.GetDatabase());
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _multiplexer.CloseAsync();
+        await _container.DisposeAsync();
+    }
+
+    public (ServiceProvider ServiceProvider, PreAuthSessionStore Store) CreateInstance()
+    {
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddHybridCache();
+        // Each instance gets its own multiplexer so disposing the ServiceProvider
+        // doesn't tear down the shared lock-provider connection.
+        services.AddStackExchangeRedisCache(options =>
+            options.Configuration = _container.GetConnectionString());
+        var sp = services.BuildServiceProvider();
+        var cache = sp.GetRequiredService<HybridCache>();
+        var store = new PreAuthSessionStore(cache, LockProvider, NullLogger<PreAuthSessionStore>.Instance);
+        return (sp, store);
+    }
+}
+
+[CollectionDefinition("Redis")]
+public class RedisCollection : ICollectionFixture<RedisPreAuthSessionStoreFixture>
+{
+}

--- a/test/SEBT.Portal.Tests/Unit/Api/Services/RedisPreAuthSessionStoreTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Api/Services/RedisPreAuthSessionStoreTests.cs
@@ -1,0 +1,53 @@
+using SEBT.Portal.Api.Services;
+
+namespace SEBT.Portal.Tests.Unit.Api.Services;
+
+/// <summary>
+/// Integration tests for <see cref="PreAuthSessionStore"/> against a real Redis instance.
+/// Two stores share the same Redis L2 cache and distributed lock provider, simulating
+/// two ECS container replicas coordinating through a shared backing store.
+/// </summary>
+[Collection("Redis")]
+[Trait("Category", "Integration")]
+public class RedisPreAuthSessionStoreTests(RedisPreAuthSessionStoreFixture fixture)
+{
+    [Fact]
+    public async Task Get_ReturnsSession_WhenCreatedByDifferentContainerInstance()
+    {
+        // Container A creates the session; Container B (separate L1 cache) must find it via Redis L2.
+        var instanceA = fixture.CreateInstance();
+        var instanceB = fixture.CreateInstance();
+        await using (instanceA.ServiceProvider)
+        await using (instanceB.ServiceProvider)
+        {
+            var session = await instanceA.Store.CreateAsync("co", "s", "v", "https://r", false);
+
+            var retrieved = await instanceB.Store.GetAsync(session.Id);
+
+            Assert.NotNull(retrieved);
+            Assert.Equal(session.Id, retrieved.Id);
+            Assert.Equal(session.State, retrieved.State);
+        }
+    }
+
+    [Fact]
+    public async Task TryAdvanceToCallbackCompleted_OnlyOneSucceeds_WhenCalledConcurrentlyAcrossInstances()
+    {
+        // Two replicas race to advance the same session. The Redis-backed distributed lock
+        // must serialize the read-modify-write so exactly one succeeds.
+        var instanceA = fixture.CreateInstance();
+        var instanceB = fixture.CreateInstance();
+        await using (instanceA.ServiceProvider)
+        await using (instanceB.ServiceProvider)
+        {
+            var session = await instanceA.Store.CreateAsync("co", "s", "v", "https://r", false);
+
+            var results = await Task.WhenAll(
+                instanceA.Store.TryAdvanceToCallbackCompletedAsync(session.Id, "hash-a"),
+                instanceB.Store.TryAdvanceToCallbackCompletedAsync(session.Id, "hash-b"));
+
+            Assert.Equal(1, results.Count(r => r));
+            Assert.Equal(1, results.Count(r => !r));
+        }
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Services/EmailSenderServiceTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/EmailSenderServiceTests.cs
@@ -8,7 +8,7 @@ using SEBT.Portal.Kernel.Results;
 
 namespace SEBT.Portal.Tests.Unit.Services;
 
-public class EmailSenderServiceTests
+public class EmailSenderServiceTests : IDisposable
 {
     private readonly IOptionsMonitor<EmailOtpSenderServiceSettings> _optionsMonitor =
         Substitute.For<IOptionsMonitor<EmailOtpSenderServiceSettings>>();
@@ -17,6 +17,11 @@ public class EmailSenderServiceTests
 
     public EmailSenderServiceTests()
     {
+        // EmailOtpSenderService.LoadTranslations() reads STATE to pick which embedded
+        // resource to load. Cleared in Dispose so this test does not pollute STATE
+        // for other tests that run in parallel — without that cleanup, any
+        // WebApplicationFactory-based test building its host concurrently can read
+        // STATE=dc and load appsettings.dc.json with the wrong PluginAssemblyPaths.
         Environment.SetEnvironmentVariable("STATE", "dc");
         _optionsMonitor.CurrentValue.Returns(new EmailOtpSenderServiceSettings { SenderEmail = "sender@example.com" });
         _smtpClientService.SendEmailAsync(
@@ -26,6 +31,12 @@ public class EmailSenderServiceTests
             Arg.Any<string>(),
             Arg.Any<IEnumerable<EmailLinkedResource>>())
             .Returns(Task.CompletedTask);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("STATE", null);
+        GC.SuppressFinalize(this);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Services/PreAuthSessionStoreTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/PreAuthSessionStoreTests.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
 using Medallion.Threading;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SEBT.Portal.Api.Services;
+using SEBT.Portal.Tests.Helpers;
 
 namespace SEBT.Portal.Tests.Unit.Services;
 
@@ -234,72 +234,3 @@ public class PreAuthSessionStoreTests : IDisposable
     }
 }
 
-/// <summary>
-/// In-process <see cref="IDistributedLockProvider"/> backed by per-key <see cref="SemaphoreSlim"/>s.
-/// Used in tests that need real lock semantics (blocking, not mock) without an external service.
-/// </summary>
-file sealed class InProcessLockProvider : IDistributedLockProvider
-{
-    private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
-
-    public IDistributedLock CreateLock(string name) =>
-        new InProcessLock(name, _semaphores.GetOrAdd(name, _ => new SemaphoreSlim(1, 1)));
-
-    private sealed class InProcessLock(string name, SemaphoreSlim semaphore) : IDistributedLock
-    {
-        public string Name => name;
-
-        public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
-        {
-            if (!semaphore.Wait(timeout, cancellationToken))
-                return null;
-            return new Handle(semaphore);
-        }
-
-        public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
-        {
-            if (timeout.HasValue)
-            {
-                if (!semaphore.Wait(timeout.Value, cancellationToken))
-                    throw new TimeoutException($"Could not acquire lock '{name}'");
-            }
-            else
-            {
-                semaphore.Wait(cancellationToken);
-            }
-            return new Handle(semaphore);
-        }
-
-        public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
-        {
-            var acquired = await semaphore.WaitAsync(timeout, cancellationToken);
-            return acquired ? new Handle(semaphore) : null;
-        }
-
-        public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
-        {
-            if (timeout.HasValue)
-            {
-                var acquired = await semaphore.WaitAsync(timeout.Value, cancellationToken);
-                if (!acquired)
-                    throw new TimeoutException($"Could not acquire lock '{name}'");
-            }
-            else
-            {
-                await semaphore.WaitAsync(cancellationToken);
-            }
-            return new Handle(semaphore);
-        }
-    }
-
-    private sealed class Handle(SemaphoreSlim semaphore) : IDistributedSynchronizationHandle
-    {
-        public CancellationToken HandleLostToken => CancellationToken.None;
-        public void Dispose() => semaphore.Release();
-        public ValueTask DisposeAsync()
-        {
-            semaphore.Release();
-            return ValueTask.CompletedTask;
-        }
-    }
-}

--- a/test/SEBT.Portal.Tests/Unit/Services/PreAuthSessionStoreTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/PreAuthSessionStoreTests.cs
@@ -1,6 +1,8 @@
+using Medallion.Threading;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using SEBT.Portal.Api.Services;
 
 namespace SEBT.Portal.Tests.Unit.Services;
@@ -22,7 +24,14 @@ public class PreAuthSessionStoreTests : IDisposable
         services.AddMemoryCache();
         _serviceProvider = services.BuildServiceProvider();
         var cache = _serviceProvider.GetRequiredService<HybridCache>();
-        _store = new PreAuthSessionStore(cache, NullLogger<PreAuthSessionStore>.Instance);
+
+        var mockLock = Substitute.For<IDistributedLock>();
+        mockLock.AcquireAsync(Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<IDistributedSynchronizationHandle>());
+        var lockProvider = Substitute.For<IDistributedLockProvider>();
+        lockProvider.CreateLock(Arg.Any<string>()).Returns(mockLock);
+
+        _store = new PreAuthSessionStore(cache, lockProvider, NullLogger<PreAuthSessionStore>.Instance);
     }
 
     public void Dispose() => _serviceProvider.Dispose();
@@ -148,6 +157,37 @@ public class PreAuthSessionStoreTests : IDisposable
         var result = await _store.GetAsync(session.Id);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsSession_WhenSessionExistsInCacheButNotCreatedByThisInstance()
+    {
+        // Regression test for DC-504: KnownSessionIds was an in-memory gate that
+        // short-circuited cache lookups for IDs not created by the current process.
+        // On a multi-container deployment, sessions created on Container A never
+        // appeared in Container B's KnownSessionIds, so every cross-instance lookup
+        // returned null (missing_session) even though the session was in Redis.
+        //
+        // This test simulates that by seeding the HybridCache directly (bypassing
+        // CreateAsync, which was the only path that populated KnownSessionIds).
+        var cache = _serviceProvider.GetRequiredService<HybridCache>();
+        var sessionId = "simulated-remote-session";
+        var session = new PreAuthSession
+        {
+            Id = sessionId,
+            State = "remote-state",
+            CodeVerifier = "remote-verifier",
+            StateCode = "co",
+            RedirectUri = "https://example.com/callback",
+            Phase = PreAuthSessionPhase.Created
+        };
+
+        await cache.SetAsync(PreAuthSessionStore.CacheKeyPrefix + sessionId, session);
+
+        var retrieved = await _store.GetAsync(sessionId);
+
+        Assert.NotNull(retrieved);
+        Assert.Equal(sessionId, retrieved.Id);
     }
 
     [Fact]

--- a/test/SEBT.Portal.Tests/Unit/Services/PreAuthSessionStoreTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/PreAuthSessionStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Medallion.Threading;
 using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
@@ -207,5 +208,98 @@ public class PreAuthSessionStoreTests : IDisposable
         var hash2 = IPreAuthSessionStore.HashCallbackToken("token-b");
 
         Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public async Task TryAdvanceToCallbackCompleted_OnlyOneSucceeds_WhenCalledConcurrentlyAcrossInstances()
+    {
+        // Two stores share the same backing cache and a real in-process lock provider
+        // (not a mock), simulating two container replicas coordinating via a shared lock.
+        // The lock must serialize the read-modify-write: whichever store acquires first
+        // advances the phase to CallbackCompleted; the second reads that updated phase
+        // and returns false.
+        var cache = _serviceProvider.GetRequiredService<HybridCache>();
+        var lockProvider = new InProcessLockProvider();
+        var storeA = new PreAuthSessionStore(cache, lockProvider, NullLogger<PreAuthSessionStore>.Instance);
+        var storeB = new PreAuthSessionStore(cache, lockProvider, NullLogger<PreAuthSessionStore>.Instance);
+
+        var session = await storeA.CreateAsync("co", "s", "v", "https://r", false);
+
+        var results = await Task.WhenAll(
+            storeA.TryAdvanceToCallbackCompletedAsync(session.Id, "hash-a"),
+            storeB.TryAdvanceToCallbackCompletedAsync(session.Id, "hash-b"));
+
+        Assert.Equal(1, results.Count(r => r));
+        Assert.Equal(1, results.Count(r => !r));
+    }
+}
+
+/// <summary>
+/// In-process <see cref="IDistributedLockProvider"/> backed by per-key <see cref="SemaphoreSlim"/>s.
+/// Used in tests that need real lock semantics (blocking, not mock) without an external service.
+/// </summary>
+file sealed class InProcessLockProvider : IDistributedLockProvider
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
+
+    public IDistributedLock CreateLock(string name) =>
+        new InProcessLock(name, _semaphores.GetOrAdd(name, _ => new SemaphoreSlim(1, 1)));
+
+    private sealed class InProcessLock(string name, SemaphoreSlim semaphore) : IDistributedLock
+    {
+        public string Name => name;
+
+        public IDistributedSynchronizationHandle? TryAcquire(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            if (!semaphore.Wait(timeout, cancellationToken))
+                return null;
+            return new Handle(semaphore);
+        }
+
+        public IDistributedSynchronizationHandle Acquire(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            if (timeout.HasValue)
+            {
+                if (!semaphore.Wait(timeout.Value, cancellationToken))
+                    throw new TimeoutException($"Could not acquire lock '{name}'");
+            }
+            else
+            {
+                semaphore.Wait(cancellationToken);
+            }
+            return new Handle(semaphore);
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
+        {
+            var acquired = await semaphore.WaitAsync(timeout, cancellationToken);
+            return acquired ? new Handle(semaphore) : null;
+        }
+
+        public async ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            if (timeout.HasValue)
+            {
+                var acquired = await semaphore.WaitAsync(timeout.Value, cancellationToken);
+                if (!acquired)
+                    throw new TimeoutException($"Could not acquire lock '{name}'");
+            }
+            else
+            {
+                await semaphore.WaitAsync(cancellationToken);
+            }
+            return new Handle(semaphore);
+        }
+    }
+
+    private sealed class Handle(SemaphoreSlim semaphore) : IDistributedSynchronizationHandle
+    {
+        public CancellationToken HandleLostToken => CancellationToken.None;
+        public void Dispose() => semaphore.Release();
+        public ValueTask DisposeAsync()
+        {
+            semaphore.Release();
+            return ValueTask.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-504](https://codeforamerica.atlassian.net/browse/DC-504)

#### ✍️ Description

Fix for OIDC sign-in reliability across container replicas. Removes `KnownSessionIds` in-memory gate**. The pre-auth session callback path was checking an in-memory `HashSet<string>` of "known" session IDs before looking up the session in Redis. When container A created the session and container B handled the callback, B's local set didn't contain the ID, so the lookup short-circuited to `missing_session` even though Redis held the session. Removing the gate restores cross-container session visibility.

- **Drive-by fix:** `EmailSenderServiceTests` was leaking `STATE=dc` to the process environment (set in constructor, never cleared). Added `IDisposable` cleanup; without it, a `WebApplicationFactory` built concurrently could read the polluted `STATE`, load `appsettings.dc.json`, and have the wrong `PluginAssemblyPaths` win (state JSON is added *after* env vars in Program.cs).
- **Drive-by fix:** integration test factories now register an `InProcessLockProvider` for `IDistributedLockProvider`. Without it the SQL fallback tries to hit `localhost:1433`, which hangs in CI (`PreAuthSessionStore` started using distributed locks in 3baabebe).

#### 🧪 Tests added

- Unit: `TryAdvanceToCallbackCompletedAsync` — only one of two concurrent callers succeeds when sharing an in-process lock provider (validates the read-modify-write is serialized)
- Integration (Redis Testcontainer): cross-instance session visibility and concurrent mutual exclusion with a real Redis-backed `IDistributedLockProvider`

#### ✅ Completion tasks

- [x] Added relevant tests
- [X] Meets acceptance criteria in ticket
- [ ] Configuration changes: *N/A*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DC-504]: https://codeforamerica.atlassian.net/browse/DC-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ