### PR TITLE
DC-498(Chore): Improve OIDC logging for offboarding; Fix .NET deprecations

### DIFF
--- a/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -27,6 +27,7 @@ namespace SEBT.Portal.Api.Controllers.Auth;
 public class OidcController(
     IConfiguration config,
     ILogger<OidcController> logger,
+    IOidcCallbackFailureLogger callbackFailureLogger,
     IUserRepository userRepository,
     IOidcTokenService oidcTokenService,
     IOptions<JwtSettings> jwtSettingsOptions,
@@ -236,6 +237,50 @@ public class OidcController(
     }
 
     /// <summary>
+    /// Records browser-only OIDC callback failures (IdP redirect <c>?error=</c> or missing
+    /// <c>code</c>/<c>state</c>) before redirect to off-boarding. Failures from
+    /// <c>POST callback</c> / <c>complete-login</c> are logged server-side only.
+    /// </summary>
+    [HttpPost("report-failure")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ReportCallbackFailure(
+        [FromBody] OidcCallbackFailureReportRequest? body,
+        CancellationToken cancellationToken)
+    {
+        if (body == null
+            || string.IsNullOrWhiteSpace(body.Reason)
+            || !callbackFailureLogger.IsAllowedClientReason(body.Reason))
+        {
+            return BadRequest(new ErrorResponse("Invalid or missing reason."));
+        }
+
+        var sessionId = OidcSessionCookie.Read(Request);
+        bool? isStepUp = null;
+        if (!string.IsNullOrEmpty(sessionId))
+        {
+            var session = await sessionStore.GetAsync(sessionId, cancellationToken);
+            isStepUp = session?.IsStepUp;
+        }
+
+        callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+        {
+            Reason = body.Reason,
+            IdpError = body.IdpError,
+            IdpErrorDescription = body.IdpErrorDescription,
+            HttpStatus = body.HttpStatus,
+            ApiError = body.ApiError,
+            SessionId = sessionId,
+            IsStepUp = isStepUp,
+            Phase = body.Phase,
+            HasCode = body.HasCode,
+            HasState = body.HasState
+        });
+
+        return NoContent();
+    }
+
+    /// <summary>
     /// Server-side OIDC callback. Requires the <c>oidc_session</c> cookie to
     /// locate the pre-auth session. Validates <c>state</c> against the stored value,
     /// uses the stored <c>code_verifier</c> for the token exchange (never from the
@@ -260,31 +305,54 @@ public class OidcController(
         var sessionId = OidcSessionCookie.Read(Request);
         if (string.IsNullOrEmpty(sessionId))
         {
-            logger.LogError("OIDC Callback rejected: missing oidc_session cookie (reason=missing_session)");
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_session",
+                Phase = "callback",
+                HttpStatus = StatusCodes.Status403Forbidden
+            });
             return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse("Missing pre-auth session."));
         }
 
         var session = await sessionStore.GetAsync(sessionId, cancellationToken);
         if (session == null)
         {
-            logger.LogError("OIDC Callback rejected: session {SessionId} not found or expired (reason=missing_session)", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_session",
+                Phase = "callback",
+                SessionId = sessionId,
+                HttpStatus = StatusCodes.Status403Forbidden
+            });
             return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse("Pre-auth session expired or invalid."));
         }
 
         // --- Validate state matches stored value (CSRF protection) ---
         if (string.IsNullOrEmpty(body.State) || body.State != session.State)
         {
-            logger.LogError(
-                "OIDC Callback rejected: state mismatch (reason=mismatched_state, SessionId={SessionId})", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "mismatched_state",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest
+            });
             return BadRequest(new ErrorResponse("State parameter mismatch."));
         }
 
         // --- Verify the session hasn't already been used (fail fast before the exchange) ---
         if (session.Phase != PreAuthSessionPhase.Created)
         {
-            logger.LogError(
-                "OIDC Callback rejected: session already used, Phase={Phase} (reason=replay, SessionId={SessionId})",
-                session.Phase, sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "replay",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest,
+                ApiError = $"Phase={session.Phase}"
+            });
             return BadRequest(new ErrorResponse("Pre-auth session has already been used."));
         }
 
@@ -296,13 +364,12 @@ public class OidcController(
             session.CodeVerifier,
             session.RedirectUri,
             session.IsStepUp,
+            sessionId,
             cancellationToken);
 
         if (!result.Success)
         {
-            logger.LogError(
-                "OIDC Callback exchange failed: {Error} (reason=exchange_failed, SessionId={SessionId})",
-                result.Error, sessionId);
+            // Exchange failures are logged in <see cref="OidcExchangeService"/> with SessionId and IdP detail.
             return StatusCode(result.StatusCode, new ErrorResponse(result.Error ?? "Exchange failed."));
         }
 
@@ -311,8 +378,14 @@ public class OidcController(
         var advanced = await sessionStore.TryAdvanceToCallbackCompletedAsync(sessionId, tokenHash, cancellationToken);
         if (!advanced)
         {
-            logger.LogError(
-                "OIDC Callback rejected: session could not advance (reason=replay, SessionId={SessionId})", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "replay",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest
+            });
             return BadRequest(new ErrorResponse("Pre-auth session has already been used."));
         }
 
@@ -352,7 +425,12 @@ public class OidcController(
         var sessionId = OidcSessionCookie.Read(Request);
         if (string.IsNullOrEmpty(sessionId))
         {
-            logger.LogError("OIDC CompleteLogin rejected: missing oidc_session cookie (reason=missing_session)");
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_session",
+                Phase = "complete-login",
+                HttpStatus = StatusCodes.Status403Forbidden
+            });
             return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse("Missing pre-auth session."));
         }
 
@@ -360,7 +438,13 @@ public class OidcController(
         var session = await sessionStore.GetAsync(sessionId, cancellationToken);
         if (session == null)
         {
-            logger.LogError("OIDC CompleteLogin rejected: session not found (reason=missing_session, SessionId={SessionId})", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_session",
+                Phase = "complete-login",
+                SessionId = sessionId,
+                HttpStatus = StatusCodes.Status403Forbidden
+            });
             return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse("Pre-auth session invalid, expired, or already used."));
         }
 
@@ -369,8 +453,14 @@ public class OidcController(
         var advanced = await sessionStore.TryAdvanceToLoginCompletedAsync(sessionId, tokenHash, cancellationToken);
         if (!advanced)
         {
-            logger.LogError(
-                "OIDC CompleteLogin rejected: session advance failed (reason=replay, SessionId={SessionId})", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "replay",
+                Phase = "complete-login",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status403Forbidden
+            });
             return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse("Pre-auth session invalid, expired, or already used."));
         }
 
@@ -383,7 +473,14 @@ public class OidcController(
         var signingKey = config["Oidc:CompleteLoginSigningKey"];
         if (string.IsNullOrEmpty(signingKey))
         {
-            logger.LogError("Oidc:CompleteLoginSigningKey is not configured (SessionId={SessionId}).", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "complete_login_not_configured",
+                Phase = "complete-login",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status503ServiceUnavailable
+            });
             var hint = environment.IsDevelopment() ? "Set Oidc:CompleteLoginSigningKey in appsettings." : "";
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Complete-login not configured.", hint });
         }
@@ -413,8 +510,16 @@ public class OidcController(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Invalid or expired callback token for state {StateCode} (SessionId={SessionId})",
-                SanitizeForLog(session.StateCode), sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "invalid_callback_token",
+                Phase = "complete-login",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest,
+                ApiError = OidcLogSanitizer.Sanitize(ex.Message)
+            });
+            logger.LogError(ex, "OIDC complete-login off-boarding: invalid_callback_token (SessionId={SessionId})", sessionId);
             return BadRequest(new ErrorResponse("Invalid or expired callback token."));
         }
 
@@ -432,7 +537,14 @@ public class OidcController(
 
         if (string.IsNullOrWhiteSpace(email) && string.IsNullOrWhiteSpace(subClaim))
         {
-            logger.LogError("Callback token had no email or sub claim (SessionId={SessionId})", sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_identity_claim",
+                Phase = "complete-login",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest
+            });
             return BadRequest(new ErrorResponse("Callback token must contain an email or sub claim."));
         }
 
@@ -442,16 +554,28 @@ public class OidcController(
         {
             if (string.IsNullOrWhiteSpace(subClaim))
             {
-                logger.LogError("Step-up complete-login: missing sub claim (SessionId={SessionId})", sessionId);
+                callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+                {
+                    Reason = "missing_sub_claim",
+                    Phase = "complete-login",
+                    SessionId = sessionId,
+                    IsStepUp = true,
+                    HttpStatus = StatusCodes.Status400BadRequest
+                });
                 return BadRequest(new ErrorResponse("Callback token must contain a sub claim."));
             }
 
             var existingEntity = await userRepository.GetUserByExternalIdAsync(subClaim, cancellationToken);
             if (existingEntity == null)
             {
-                logger.LogError(
-                    "Step-up complete-login: no existing portal user for sub claim; sign-in required first (SessionId={SessionId}).",
-                    sessionId);
+                callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+                {
+                    Reason = "step_up_user_not_found",
+                    Phase = "complete-login",
+                    SessionId = sessionId,
+                    IsStepUp = true,
+                    HttpStatus = StatusCodes.Status400BadRequest
+                });
                 return BadRequest(new { error = "Step-up requires an existing session. Please sign in again." });
             }
 
@@ -461,9 +585,14 @@ public class OidcController(
         {
             if (string.IsNullOrWhiteSpace(subClaim))
             {
-                logger.LogError(
-                    "OIDC CompleteLogin: callback token missing sub claim (SessionId={SessionId})",
-                    sessionId);
+                callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+                {
+                    Reason = "missing_sub_claim",
+                    Phase = "complete-login",
+                    SessionId = sessionId,
+                    IsStepUp = false,
+                    HttpStatus = StatusCodes.Status400BadRequest
+                });
                 return BadRequest(new ErrorResponse("Callback token must contain a sub claim."));
             }
 
@@ -482,9 +611,15 @@ public class OidcController(
 
         if (!tokenResult.IsSuccess)
         {
-            logger.LogError(
-                "OIDC token generation failed: {Message} (SessionId={SessionId})",
-                tokenResult.Message, sessionId);
+            callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
+            {
+                Reason = "token_generation_failed",
+                Phase = "complete-login",
+                SessionId = sessionId,
+                IsStepUp = session.IsStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest,
+                ApiError = tokenResult.Message
+            });
             return BadRequest(new { error = "Step-up verification failed. Please try again." });
         }
 

--- a/src/SEBT.Portal.Api/Models/OidcCallbackFailureReportRequest.cs
+++ b/src/SEBT.Portal.Api/Models/OidcCallbackFailureReportRequest.cs
@@ -1,0 +1,18 @@
+namespace SEBT.Portal.Api.Models;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Browser-reported OIDC callback failure (IdP redirect errors and missing OAuth params)
+/// for server-side logging before redirect to off-boarding. Exchange and complete-login
+/// failures are logged on the server only.
+/// </summary>
+public record OidcCallbackFailureReportRequest(
+    [property: JsonPropertyName("reason")] string? Reason,
+    [property: JsonPropertyName("idpError")] string? IdpError = null,
+    [property: JsonPropertyName("idpErrorDescription")] string? IdpErrorDescription = null,
+    [property: JsonPropertyName("httpStatus")] int? HttpStatus = null,
+    [property: JsonPropertyName("apiError")] string? ApiError = null,
+    [property: JsonPropertyName("phase")] string? Phase = null,
+    [property: JsonPropertyName("hasCode")] bool? HasCode = null,
+    [property: JsonPropertyName("hasState")] bool? HasState = null);

--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -167,6 +167,7 @@ builder.Services.AddScoped<ResolveUserFilter>();
 
 // OIDC token exchange (replaces the Next.js /api/auth/oidc/callback route)
 builder.Services.AddScoped<IOidcExchangeService, OidcExchangeService>();
+builder.Services.AddScoped<IOidcCallbackFailureLogger, OidcCallbackFailureLogger>();
 // pre-auth session store (HybridCache-backed, 15 min TTL)
 builder.Services.AddSingleton<IPreAuthSessionStore, PreAuthSessionStore>();
 

--- a/src/SEBT.Portal.Api/Services/OidcCallbackFailureLogger.cs
+++ b/src/SEBT.Portal.Api/Services/OidcCallbackFailureLogger.cs
@@ -94,7 +94,7 @@ public sealed class OidcCallbackFailureLogger(
             OidcLogSanitizer.Sanitize(entry.ApiError),
             entry.SessionId,
             entry.IsStepUp,
-            entry.Phase,
+            OidcLogSanitizer.Sanitize(entry.Phase),
             entry.HasCode,
             entry.HasState);
     }

--- a/src/SEBT.Portal.Api/Services/OidcCallbackFailureLogger.cs
+++ b/src/SEBT.Portal.Api/Services/OidcCallbackFailureLogger.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Http;
+using SEBT.Portal.Core.Utilities;
+
+namespace SEBT.Portal.Api.Services;
+
+/// <summary>
+/// Structured logging for OIDC callback failures that send users to id-proofing off-boarding.
+/// </summary>
+public interface IOidcCallbackFailureLogger
+{
+    /// <summary>
+    /// Returns true when <paramref name="reason"/> may be submitted via
+    /// <c>POST /api/auth/oidc/report-failure</c>.
+    /// </summary>
+    bool IsAllowedClientReason(string reason);
+
+    /// <summary>
+    /// Logs a single correlated warning for operations and support.
+    /// </summary>
+    void Log(OidcCallbackFailureLogEntry entry);
+}
+
+/// <summary>Fields attached to an off-boarding OIDC failure log line.</summary>
+public sealed record OidcCallbackFailureLogEntry
+{
+    /// <summary>
+    /// Machine-readable cause. Examples: <c>idp_redirect</c>, <c>missing_params</c>,
+    /// <c>token_exchange_rejected</c>, <c>missing_session</c>.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>OAuth <c>error</c> from an IdP redirect or token response.</summary>
+    public string? IdpError { get; init; }
+
+    /// <summary>OAuth <c>error_description</c> (sanitized and truncated before logging).</summary>
+    public string? IdpErrorDescription { get; init; }
+
+    /// <summary>HTTP status when the failure came from an API response.</summary>
+    public int? HttpStatus { get; init; }
+
+    /// <summary>Portal error message returned to the browser (sanitized).</summary>
+    public string? ApiError { get; init; }
+
+    /// <summary>Pre-auth session id when available.</summary>
+    public string? SessionId { get; init; }
+
+    /// <summary>
+    /// Portal user GUID when known. When omitted, resolved from the authenticated JWT on
+    /// the current HTTP request (e.g. step-up while already signed in). Absent on first login.
+    /// </summary>
+    public Guid? PortalUserId { get; init; }
+
+    /// <summary>Whether the flow was step-up.</summary>
+    public bool? IsStepUp { get; init; }
+
+    /// <summary><c>callback</c> or <c>complete-login</c> when the failure is tied to an API phase.</summary>
+    public string? Phase { get; init; }
+
+    /// <summary>For <c>missing_params</c>: whether the authorization <c>code</c> query param was present.</summary>
+    public bool? HasCode { get; init; }
+
+    /// <summary>For <c>missing_params</c>: whether the OAuth <c>state</c> query param was present.</summary>
+    public bool? HasState { get; init; }
+}
+
+/// <inheritdoc cref="IOidcCallbackFailureLogger"/>
+public sealed class OidcCallbackFailureLogger(
+    ILogger<OidcCallbackFailureLogger> logger,
+    IHttpContextAccessor httpContextAccessor) : IOidcCallbackFailureLogger
+{
+    private static readonly HashSet<string> AllowedClientReasons = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "idp_redirect",
+        "missing_params"
+    };
+
+    /// <inheritdoc/>
+    public bool IsAllowedClientReason(string reason) => AllowedClientReasons.Contains(reason);
+
+    /// <inheritdoc/>
+    public void Log(OidcCallbackFailureLogEntry entry)
+    {
+        var portalUserId = entry.PortalUserId ?? httpContextAccessor.HttpContext?.User.GetUserId();
+
+        logger.LogWarning(
+            "OIDC callback off-boarding: Reason={Reason} PortalUserId={PortalUserId} IdpError={IdpError} "
+            + "IdpErrorDescription={IdpErrorDescription} HttpStatus={HttpStatus} ApiError={ApiError} "
+            + "SessionId={SessionId} IsStepUp={IsStepUp} Phase={Phase} HasCode={HasCode} HasState={HasState}",
+            entry.Reason,
+            portalUserId,
+            OidcLogSanitizer.Sanitize(entry.IdpError, OidcLogSanitizer.MaxErrorCodeLength),
+            OidcLogSanitizer.Sanitize(entry.IdpErrorDescription),
+            entry.HttpStatus,
+            OidcLogSanitizer.Sanitize(entry.ApiError),
+            entry.SessionId,
+            entry.IsStepUp,
+            entry.Phase,
+            entry.HasCode,
+            entry.HasState);
+    }
+}

--- a/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
+++ b/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
@@ -3,6 +3,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
@@ -27,6 +28,7 @@ public interface IOidcExchangeService
     /// <param name="codeVerifier">PKCE code_verifier (from the pre-auth session, never from the browser).</param>
     /// <param name="redirectUri">redirect_uri that was sent in the authorization request.</param>
     /// <param name="isStepUp">True when this is a step-up (IAL1+) flow.</param>
+    /// <param name="sessionId">Pre-auth session id for correlated off-boarding logs.</param>
     /// <param name="cancellationToken">Cancellation.</param>
     /// <returns>Signed callback token (short-lived JWT) on success.</returns>
     Task<OidcExchangeResult> ExchangeCodeAsync(
@@ -34,6 +36,7 @@ public interface IOidcExchangeService
         string codeVerifier,
         string redirectUri,
         bool isStepUp,
+        string? sessionId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -90,6 +93,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
     private readonly IConfiguration _config;
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<OidcExchangeService> _logger;
+    private readonly IOidcCallbackFailureLogger _callbackFailureLogger;
 
     /// <summary>strict exp check — ≤10 seconds clock skew tolerance.</summary>
     private static readonly TimeSpan IdTokenClockSkew = TimeSpan.FromSeconds(10);
@@ -128,11 +132,13 @@ public sealed class OidcExchangeService : IOidcExchangeService
     public OidcExchangeService(
         IConfiguration config,
         IHttpClientFactory httpFactory,
-        ILogger<OidcExchangeService> logger)
+        ILogger<OidcExchangeService> logger,
+        IOidcCallbackFailureLogger callbackFailureLogger)
     {
         _config = config;
         _httpFactory = httpFactory;
         _logger = logger;
+        _callbackFailureLogger = callbackFailureLogger;
     }
 
     /// <inheritdoc/>
@@ -166,6 +172,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
         string codeVerifier,
         string redirectUri,
         bool isStepUp,
+        string? sessionId = null,
         CancellationToken cancellationToken = default)
     {
         // --- Resolve per-flow config ---
@@ -176,7 +183,14 @@ public sealed class OidcExchangeService : IOidcExchangeService
         if (string.IsNullOrEmpty(clientId)
             || string.IsNullOrEmpty(clientSecret) || string.IsNullOrEmpty(signingKey))
         {
-            _logger.LogWarning("OIDC exchange: missing config (reason=oidc_not_configured, isStepUp={IsStepUp})", isStepUp);
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "oidc_not_configured",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status503ServiceUnavailable
+            });
             return OidcExchangeResult.Fail("OIDC not configured.", 503);
         }
 
@@ -188,12 +202,28 @@ public sealed class OidcExchangeService : IOidcExchangeService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "OIDC exchange: failed to fetch discovery document (reason=discovery_failed)");
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "discovery_failed",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status502BadGateway,
+                ApiError = OidcLogSanitizer.Sanitize(ex.Message)
+            }, ex);
             return OidcExchangeResult.Fail("Failed to load OIDC discovery document.", 502);
         }
 
         if (string.IsNullOrEmpty(oidcConfig.TokenEndpoint))
         {
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "discovery_invalid",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status502BadGateway
+            });
             return OidcExchangeResult.Fail("Invalid discovery document (missing token_endpoint).", 502);
         }
 
@@ -217,28 +247,45 @@ public sealed class OidcExchangeService : IOidcExchangeService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "OIDC exchange: token request failed (reason=token_request_failed)");
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "token_request_failed",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                ApiError = OidcLogSanitizer.Sanitize(ex.Message)
+            }, ex);
             return OidcExchangeResult.Fail("Token exchange failed.");
         }
 
         var tokenBody = await tokenRes.Content.ReadAsStringAsync(cancellationToken);
         if (!tokenRes.IsSuccessStatusCode)
         {
-            // Log the raw IdP error for debugging but never forward it to the client
+            // Log IdP OAuth error fields for support; never forward them to the client
             // (error_description can contain internal IdP infrastructure details).
+            string? idpError = null;
+            string? idpDescription = null;
             try
             {
                 using var doc = JsonDocument.Parse(tokenBody);
-                var desc = doc.RootElement.TryGetProperty("error_description", out var ed) ? ed.GetString() : null;
-                var err = doc.RootElement.TryGetProperty("error", out var e) ? e.GetString() : null;
-                _logger.LogError(
-                    "OIDC exchange: token endpoint returned {StatusCode}, error={Error}, description={Description} (reason=token_exchange_rejected)",
-                    (int)tokenRes.StatusCode, err, desc);
+                idpDescription = doc.RootElement.TryGetProperty("error_description", out var ed) ? ed.GetString() : null;
+                idpError = doc.RootElement.TryGetProperty("error", out var e) ? e.GetString() : null;
             }
             catch
             {
-                _logger.LogError("OIDC exchange: token endpoint returned {StatusCode} (reason=token_exchange_rejected)", (int)tokenRes.StatusCode);
+                // Non-JSON error body — HttpStatus only.
             }
+
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "token_exchange_rejected",
+                Phase = "callback",
+                SessionId = sessionId,
+                HttpStatus = (int)tokenRes.StatusCode,
+                IdpError = idpError,
+                IdpErrorDescription = idpDescription,
+                IsStepUp = isStepUp
+            });
             return OidcExchangeResult.Fail("Token exchange was rejected by the identity provider.");
         }
 
@@ -253,12 +300,27 @@ public sealed class OidcExchangeService : IOidcExchangeService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "OIDC exchange: failed to parse token response (reason=token_parse_failed)");
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "token_parse_failed",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                ApiError = OidcLogSanitizer.Sanitize(ex.Message)
+            }, ex);
             return OidcExchangeResult.Fail("Failed to parse token response.");
         }
 
         if (string.IsNullOrEmpty(idTokenRaw))
         {
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_id_token",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest
+            });
             return OidcExchangeResult.Fail("No id_token in token response.");
         }
 
@@ -284,14 +346,30 @@ public sealed class OidcExchangeService : IOidcExchangeService
         {
             principal = handler.ValidateToken(idTokenRaw, validationParams, out _);
         }
-        catch (SecurityTokenExpiredException)
+        catch (SecurityTokenExpiredException ex)
         {
-            _logger.LogError("OIDC exchange: id_token expired beyond {Skew}s skew (reason=expired_token)", IdTokenClockSkew.TotalSeconds);
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "expired_token",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest,
+                ApiError = OidcLogSanitizer.Sanitize(ex.Message)
+            }, ex);
             return OidcExchangeResult.Fail("Id token has expired.");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "OIDC exchange: id_token validation failed (reason=token_validation_failed)");
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "token_validation_failed",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest,
+                ApiError = OidcLogSanitizer.Sanitize(ex.Message)
+            }, ex);
             return OidcExchangeResult.Fail("Id token validation failed.");
         }
 
@@ -344,7 +422,14 @@ public sealed class OidcExchangeService : IOidcExchangeService
         // --- Verify we have at least sub or email ---
         if (!claims.ContainsKey("sub") && !claims.ContainsKey("email"))
         {
-            _logger.LogError("OIDC exchange: id_token + userinfo had no sub or email (reason=missing_identity_claim)");
+            LogOffboardingFailure(new OidcCallbackFailureLogEntry
+            {
+                Reason = "missing_identity_claim",
+                Phase = "callback",
+                SessionId = sessionId,
+                IsStepUp = isStepUp,
+                HttpStatus = StatusCodes.Status400BadRequest
+            });
             return OidcExchangeResult.Fail("Callback token must contain an email or sub claim.");
         }
 
@@ -374,6 +459,19 @@ public sealed class OidcExchangeService : IOidcExchangeService
             isStepUp);
 
         return OidcExchangeResult.Ok(callbackToken, phoneClaim);
+    }
+
+    /// <summary>
+    /// Writes the unified off-boarding log line and, when <paramref name="ex"/> is set,
+    /// a second error-level log entry with the full exception for Datadog.
+    /// </summary>
+    private void LogOffboardingFailure(OidcCallbackFailureLogEntry entry, Exception? ex = null)
+    {
+        _callbackFailureLogger.Log(entry);
+        if (ex != null)
+        {
+            _logger.LogError(ex, "OIDC exchange off-boarding: {Reason}", entry.Reason);
+        }
     }
 
     private async Task EnrichClaimsFromUserInfo(

--- a/src/SEBT.Portal.Api/Services/OidcLogSanitizer.cs
+++ b/src/SEBT.Portal.Api/Services/OidcLogSanitizer.cs
@@ -1,0 +1,35 @@
+namespace SEBT.Portal.Api.Services;
+
+/// <summary>
+/// Truncates and strips control characters from OIDC error strings before logging.
+/// IdP <c>error_description</c> values may be long URL-encoded JSON blobs.
+/// </summary>
+public static class OidcLogSanitizer
+{
+    /// <summary>Max length for <c>error_description</c> and similar fields in logs.</summary>
+    public const int MaxDescriptionLength = 500;
+
+    /// <summary>Max length for short OAuth <c>error</c> codes (e.g. <c>invalid_grant</c>).</summary>
+    public const int MaxErrorCodeLength = 128;
+
+    /// <summary>
+    /// Strips CR/LF and truncates for safe structured logging.
+    /// </summary>
+    public static string Sanitize(string? value, int maxLength = MaxDescriptionLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = value
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal);
+        if (sanitized.Length <= maxLength)
+        {
+            return sanitized;
+        }
+
+        return sanitized[..maxLength] + "…";
+    }
+}

--- a/src/SEBT.Portal.Core/AppSettings/IdProofingExpiration.cs
+++ b/src/SEBT.Portal.Core/AppSettings/IdProofingExpiration.cs
@@ -1,0 +1,13 @@
+namespace SEBT.Portal.Core.AppSettings;
+
+/// <summary>
+/// Computes the legacy <c>Users.IdProofingExpiresAt</c> column from completion time and validity settings.
+/// New code should treat expiration as <c>IdProofingCompletedAt</c> + <see cref="IdProofingValiditySettings.ValidityDays"/>.
+/// </summary>
+public static class IdProofingExpiration
+{
+    public static DateTime? ComputeStoredExpiration(
+        DateTime? completedAt,
+        int validityDays = 1826) =>
+        completedAt?.AddDays(validityDays);
+}

--- a/src/SEBT.Portal.Infrastructure.Seeding/Services/DatabaseSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure.Seeding/Services/DatabaseSeeder.cs
@@ -86,7 +86,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                 u.IdProofingStatus = IdProofingStatus.InProgress;
                 u.IalLevel = UserIalLevel.None;
                 u.IdProofingCompletedAt = null;
-                u.IdProofingExpiresAt = null;
                 u.Phone = "5555551234";
                 u.SnapId = "SNAP-NCO-001";
             }),
@@ -96,7 +95,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                 u.IdProofingStatus = IdProofingStatus.NotStarted;
                 u.IalLevel = UserIalLevel.None;
                 u.IdProofingCompletedAt = null;
-                u.IdProofingExpiresAt = null;
             })
         };
     }
@@ -176,7 +174,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             u.IdProofingStatus = IdProofingStatus.NotStarted;
                             u.IalLevel = UserIalLevel.None;
                             u.IdProofingCompletedAt = null;
-                            u.IdProofingExpiresAt = null;
                             u.CoLoadedLastUpdated = now.AddDays(DaysSinceCoLoadedUpdate);
                             u.Phone = "8185558438";
                             u.SnapId = "SNAP-CO-001";
@@ -222,7 +219,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             u.IdProofingStatus = IdProofingStatus.InProgress;
                             u.IalLevel = UserIalLevel.None;
                             u.IdProofingCompletedAt = null;
-                            u.IdProofingExpiresAt = null;
                             u.IsCoLoaded = false;
                             u.CoLoadedLastUpdated = null;
                             u.Phone = "5552223344";
@@ -248,7 +244,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                                 // Bogus may pre-set timestamps when the random draw is IAL1+; clear
                                 // so IAL None/1 never retain IdProofingCompletedAt from the generator.
                                 u.IdProofingCompletedAt = null;
-                                u.IdProofingExpiresAt = null;
                             }
                             u.IsCoLoaded = false;
                             u.CoLoadedLastUpdated = null;
@@ -376,7 +371,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             u.IdProofingStatus = IdProofingStatus.NotStarted;
                             u.IalLevel = UserIalLevel.None;
                             u.IdProofingCompletedAt = null;
-                            u.IdProofingExpiresAt = null;
                             u.CoLoadedLastUpdated = now.AddDays(DaysSinceCoLoadedUpdate);
                             u.Phone = "8185558438";
                             u.SnapId = "SNAP-CO-001";
@@ -422,7 +416,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             u.IdProofingStatus = IdProofingStatus.InProgress;
                             u.IalLevel = UserIalLevel.None;
                             u.IdProofingCompletedAt = null;
-                            u.IdProofingExpiresAt = null;
                             u.IsCoLoaded = false;
                             u.CoLoadedLastUpdated = null;
                             u.Phone = "5552223344";
@@ -446,7 +439,6 @@ public class DatabaseSeeder : Core.Services.IDatabaseSeeder
                             else
                             {
                                 u.IdProofingCompletedAt = null;
-                                u.IdProofingExpiresAt = null;
                             }
                             u.IsCoLoaded = false;
                             u.CoLoadedLastUpdated = null;

--- a/src/SEBT.Portal.Infrastructure/Helpers/UserFactory.cs
+++ b/src/SEBT.Portal.Infrastructure/Helpers/UserFactory.cs
@@ -1,3 +1,4 @@
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Infrastructure.Data.Entities;
@@ -95,7 +96,7 @@ public static class UserFactory
             IalLevel = (int)user.IalLevel,
             IdProofingSessionId = user.IdProofingSessionId,
             IdProofingCompletedAt = user.IdProofingCompletedAt,
-            IdProofingExpiresAt = user.IdProofingExpiresAt,
+            IdProofingExpiresAt = IdProofingExpiration.ComputeStoredExpiration(user.IdProofingCompletedAt),
             DateOfBirth = user.DateOfBirth,
             IsCoLoaded = user.IsCoLoaded,
             CoLoadedLastUpdated = user.CoLoadedLastUpdated,

--- a/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/DatabaseUserRepository.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
@@ -10,8 +12,13 @@ namespace SEBT.Portal.Infrastructure.Repositories;
 /// <summary>
 /// Database-backed implementation of <see cref="IUserRepository"/> using Entity Framework Core.
 /// </summary>
-public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher identifierHasher) : IUserRepository
+public class DatabaseUserRepository(
+    PortalDbContext dbContext,
+    IIdentifierHasher identifierHasher,
+    IOptions<IdProofingValiditySettings> validitySettings) : IUserRepository
 {
+    private readonly IdProofingValiditySettings _validitySettings = validitySettings.Value;
+
     public async Task<User?> GetUserByEmailAsync(string email, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(email))
@@ -88,7 +95,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
         entity.IalLevel = (int)user.IalLevel;
         entity.IdProofingSessionId = user.IdProofingSessionId;
         entity.IdProofingCompletedAt = user.IdProofingCompletedAt;
-        entity.IdProofingExpiresAt = user.IdProofingExpiresAt;
+        entity.IdProofingExpiresAt = ComputeStoredExpiration(user.IdProofingCompletedAt);
         entity.DateOfBirth = user.DateOfBirth;
         entity.IsCoLoaded = user.IsCoLoaded;
         entity.CoLoadedLastUpdated = user.CoLoadedLastUpdated;
@@ -307,6 +314,13 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
         return email.Trim().ToLowerInvariant();
     }
 
+    /// <summary>
+    /// Persists a derived expiration for legacy DB readers. Runtime/JWT use
+    /// <see cref="IdProofingCompletedAt"/> + <see cref="IdProofingValiditySettings.ValidityDays"/>.
+    /// </summary>
+    private DateTime? ComputeStoredExpiration(DateTime? completedAt) =>
+        IdProofingExpiration.ComputeStoredExpiration(completedAt, _validitySettings.ValidityDays);
+
     private static User MapToDomainModel(UserEntity entity)
     {
         return new User
@@ -318,7 +332,6 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             IalLevel = (UserIalLevel)entity.IalLevel,
             IdProofingSessionId = entity.IdProofingSessionId,
             IdProofingCompletedAt = entity.IdProofingCompletedAt,
-            IdProofingExpiresAt = entity.IdProofingExpiresAt,
             DateOfBirth = entity.DateOfBirth,
             IsCoLoaded = entity.IsCoLoaded,
             CoLoadedLastUpdated = entity.CoLoadedLastUpdated,
@@ -343,7 +356,7 @@ public class DatabaseUserRepository(PortalDbContext dbContext, IIdentifierHasher
             IalLevel = (int)user.IalLevel,
             IdProofingSessionId = user.IdProofingSessionId,
             IdProofingCompletedAt = user.IdProofingCompletedAt,
-            IdProofingExpiresAt = user.IdProofingExpiresAt,
+            IdProofingExpiresAt = ComputeStoredExpiration(user.IdProofingCompletedAt),
             DateOfBirth = user.DateOfBirth,
             IsCoLoaded = user.IsCoLoaded,
             CoLoadedLastUpdated = user.CoLoadedLastUpdated,

--- a/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
+++ b/src/SEBT.Portal.Infrastructure/Services/DataSeeder.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Core.Utilities;
@@ -39,7 +40,7 @@ public class DataSeeder : IDataSeeder
             IalLevel = (int)user.IalLevel,
             IdProofingSessionId = user.IdProofingSessionId,
             IdProofingCompletedAt = user.IdProofingCompletedAt,
-            IdProofingExpiresAt = user.IdProofingExpiresAt,
+            IdProofingExpiresAt = IdProofingExpiration.ComputeStoredExpiration(user.IdProofingCompletedAt),
             DateOfBirth = user.DateOfBirth,
             IsCoLoaded = user.IsCoLoaded,
             CoLoadedLastUpdated = user.CoLoadedLastUpdated,

--- a/src/SEBT.Portal.TestUtilities/Helpers/UserFactory.cs
+++ b/src/SEBT.Portal.TestUtilities/Helpers/UserFactory.cs
@@ -21,8 +21,6 @@ public static class UserFactory
             u.IalLevel is UserIalLevel.IAL1plus or UserIalLevel.IAL2
                 ? f.Date.Recent(30)
                 : null)
-        .RuleFor(u => u.IdProofingExpiresAt, (f, u) =>
-            u.IdProofingCompletedAt?.AddYears(1))
         .RuleFor(u => u.DateOfBirth, f =>
             DateOnly.FromDateTime(f.Date.Between(DateTime.UtcNow.AddYears(-65), DateTime.UtcNow.AddYears(-21))))
         .RuleFor(u => u.IsCoLoaded, f => f.Random.Bool(0.3f))

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.test.tsx
@@ -194,6 +194,14 @@ describe('CallbackPage', () => {
 
   describe('IdP error redirect (?error=)', () => {
     it('redirects to step-up failure for server_error with description', async () => {
+      const reportBodies: unknown[] = []
+      server.use(
+        http.post('/api/auth/oidc/report-failure', async ({ request }) => {
+          reportBodies.push(await request.json())
+          return new HttpResponse(null, { status: 204 })
+        })
+      )
+
       Object.defineProperty(window, 'location', {
         value: {
           search: '?error=server_error&error_description=User+cancelled',
@@ -206,6 +214,11 @@ describe('CallbackPage', () => {
 
       await waitFor(() => {
         expect(mockReplace).toHaveBeenCalledWith(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+        expect(reportBodies).toContainEqual({
+          reason: 'idp_redirect',
+          idpError: 'server_error',
+          idpErrorDescription: 'User cancelled'
+        })
       })
     })
 

--- a/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
+++ b/src/SEBT.Portal.Web/src/app/(public)/callback/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { ApiError, apiFetch } from '@/api'
+import { apiFetch } from '@/api'
 import { CoLoadingScreen } from '@/components/CoLoadingScreen'
 import { useAuth } from '@/features/auth'
 import {
-  OIDC_CALLBACK_ERROR_OFF_BOARDING,
   OidcCallbackTokenResponseSchema,
-  OidcCompleteLoginResponseSchema
+  OidcCompleteLoginResponseSchema,
+  redirectToOidcOffBoarding
 } from '@/features/auth/api/oidc'
 import { hasIal1Plus, isIdProofingCompletionFresh } from '@/lib/jwt'
 import { getState } from '@sebt/design-system'
@@ -56,7 +56,11 @@ export default function CallbackPage() {
     // IdP errors do not require /auth/status; evaluate before isLoading and before
     // authenticated back-button shortcuts so step-up failures are not sent to /dashboard.
     if (errorParam) {
-      router.replace(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+      redirectToOidcOffBoarding(router, {
+        reason: 'idp_redirect',
+        idpError: errorParam,
+        idpErrorDescription: params.get('error_description') ?? undefined
+      })
       return
     }
 
@@ -75,7 +79,11 @@ export default function CallbackPage() {
     }
 
     if (!code || !state) {
-      router.replace(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+      redirectToOidcOffBoarding(router, {
+        reason: 'missing_params',
+        hasCode: Boolean(code),
+        hasState: Boolean(state)
+      })
       return
     }
 
@@ -109,19 +117,12 @@ export default function CallbackPage() {
         await login()
         const destination = response.returnUrl ?? '/dashboard'
         router.replace(destination)
-      } catch (e) {
+      } catch {
         if (cancelled) {
           return
         }
-        const statusCode = e instanceof ApiError ? e.status : undefined
-        const logDetail = e instanceof Error ? e.message : ''
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('[callback] OIDC exchange failed', {
-            statusCode,
-            detail: logDetail.slice(0, 500)
-          })
-        }
-        router.replace(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+        // API failures are logged server-side; only browser-only failures use report-failure.
+        redirectToOidcOffBoarding(router)
       }
     }
     run()

--- a/src/SEBT.Portal.Web/src/features/auth/api/oidc/index.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/oidc/index.ts
@@ -1,3 +1,5 @@
+export { redirectToOidcOffBoarding } from './redirectToOidcOffBoarding'
+export { reportOidcCallbackFailure, type OidcCallbackFailureReason } from './reportCallbackFailure'
 export { OIDC_CALLBACK_ERROR_OFF_BOARDING } from './routes'
 export {
   OidcCallbackTokenResponseSchema,

--- a/src/SEBT.Portal.Web/src/features/auth/api/oidc/redirectToOidcOffBoarding.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/oidc/redirectToOidcOffBoarding.ts
@@ -1,0 +1,18 @@
+import {
+  reportOidcCallbackFailure,
+  type ReportOidcCallbackFailureParams
+} from './reportCallbackFailure'
+import { OIDC_CALLBACK_ERROR_OFF_BOARDING } from './routes'
+
+/**
+ * Reports OIDC callback failure to the API (when provided) and redirects to off-boarding.
+ */
+export function redirectToOidcOffBoarding(
+  router: { replace: (href: string) => void },
+  report?: ReportOidcCallbackFailureParams
+): void {
+  if (report) {
+    reportOidcCallbackFailure(report)
+  }
+  router.replace(OIDC_CALLBACK_ERROR_OFF_BOARDING)
+}

--- a/src/SEBT.Portal.Web/src/features/auth/api/oidc/reportCallbackFailure.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/api/oidc/reportCallbackFailure.ts
@@ -1,0 +1,33 @@
+/** Same-origin API prefix used by <c>apiFetch</c>. */
+const API_ROUTE_PREFIX = '/api'
+
+/**
+ * Reasons accepted by POST /api/auth/oidc/report-failure.
+ * API exchange/complete-login failures are logged on the server only.
+ */
+export type OidcCallbackFailureReason = 'idp_redirect' | 'missing_params'
+
+export interface ReportOidcCallbackFailureParams {
+  reason: OidcCallbackFailureReason
+  idpError?: string | undefined
+  idpErrorDescription?: string | undefined
+  hasCode?: boolean | undefined
+  hasState?: boolean | undefined
+}
+
+/**
+ * Fire-and-forget server log for OIDC callback failures that redirect to off-boarding.
+ * Uses <c>keepalive</c> so the request can finish after <c>router.replace</c> navigates away.
+ * Swallows errors so logging never blocks the user redirect.
+ */
+export function reportOidcCallbackFailure(params: ReportOidcCallbackFailureParams): void {
+  void fetch(`${API_ROUTE_PREFIX}/auth/oidc/report-failure`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+    credentials: 'same-origin',
+    keepalive: true
+  }).catch(() => {
+    // Logging must not affect the off-boarding redirect.
+  })
+}

--- a/src/SEBT.Portal.Web/src/mocks/handlers.ts
+++ b/src/SEBT.Portal.Web/src/mocks/handlers.ts
@@ -228,6 +228,8 @@ export const handlers = [
     })
   }),
 
+  http.post('/api/auth/oidc/report-failure', () => new HttpResponse(null, { status: 204 })),
+
   // OIDC callback (Next.js: exchange + validate; returns callbackToken for complete-login)
   // callback no longer expects code_verifier from the browser — the server
   // reads it from the pre-auth session. We only check code + stateCode here.

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcEnrollmentCheckIntegrationTests.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcEnrollmentCheckIntegrationTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
-using Microsoft.Data.SqlClient;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using SEBT.Portal.Core.Services;
 using SEBT.Portal.StatesPlugins.Interfaces;
 
 namespace SEBT.Portal.Tests.Integration.PluginIntegration;
@@ -22,17 +24,16 @@ namespace SEBT.Portal.Tests.Integration.PluginIntegration;
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
-[Trait("Category", "SqlServer")]
 public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseFixture>, IDisposable
 {
-    private readonly PluginIntegrationWebApplicationFactory? _factory;
+    private readonly DcEnrollmentCheckWebApplicationFactory? _factory;
     private readonly HttpClient? _client;
     private readonly bool _canRun;
     private readonly string _skipReason;
 
     public DcEnrollmentCheckIntegrationTests(DcSourceDatabaseFixture dcDatabase)
     {
-        PluginIntegrationWebApplicationFactory? factory = null;
+        DcEnrollmentCheckWebApplicationFactory? factory = null;
         HttpClient? client = null;
         var canRun = false;
         var skipReason = string.Empty;
@@ -45,14 +46,7 @@ public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseF
         {
             try
             {
-                factory = new PluginIntegrationWebApplicationFactory(
-                    pluginDir: "plugins-dc",
-                    configOverrides: new Dictionary<string, string>
-                    {
-                        ["DCConnector:ConnectionString"] = dcDatabase.ConnectionString,
-                        // Required by DcEnrollmentCheckService (no default); must match dbo.sp_CheckEligibility in DcSourceDatabaseFixture.
-                        ["DCConnector:CheckEligibilityProcName"] = "dbo.sp_CheckEligibility"
-                    });
+                factory = new DcEnrollmentCheckWebApplicationFactory(dcDatabase.ConnectionString);
 
                 using (var scope = factory.Services.CreateScope())
                 {
@@ -63,16 +57,8 @@ public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseF
                         factory = null;
                         skipReason =
                             "Expected DcEnrollmentCheckService but got " +
-                            $"{enrollment.GetType().FullName}. Rebuild dc-connector, copy DLLs to plugins-dc, " +
-                            "and ensure no other enrollment plugin is loaded.";
+                            $"{enrollment.GetType().FullName}. Rebuild dc-connector and copy DLLs to plugins-dc.";
                     }
-                }
-
-                if (factory != null && !CanConnectToDcSource(dcDatabase.ConnectionString, out var connectError))
-                {
-                    factory.Dispose();
-                    factory = null;
-                    skipReason = connectError;
                 }
 
                 if (factory != null)
@@ -168,20 +154,48 @@ public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseF
         _factory?.Dispose();
     }
 
-    private static bool CanConnectToDcSource(string connectionString, out string skipReason)
+    private sealed class DcEnrollmentCheckWebApplicationFactory : PluginIntegrationWebApplicationFactory
     {
-        try
+        private const int MaxPluginPathIndices = 8;
+        private readonly string _connectionString;
+
+        public DcEnrollmentCheckWebApplicationFactory(string connectionString)
+            : base(pluginDir: "plugins-dc")
         {
-            using var connection = new SqlConnection(connectionString);
-            connection.Open();
-            skipReason = string.Empty;
-            return true;
+            _connectionString = connectionString;
         }
-        catch (Exception ex)
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            skipReason =
-                $"DC source database is not reachable (Docker/Testcontainers may be unavailable): {ex.GetBaseException().Message}";
-            return false;
+            base.ConfigureWebHost(builder);
+
+            Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", PluginPathResolver.Resolve("plugins-dc"));
+            for (var i = 1; i < MaxPluginPathIndices; i++)
+            {
+                Environment.SetEnvironmentVariable($"PluginAssemblyPaths__{i}", null);
+            }
+
+            Environment.SetEnvironmentVariable("DCConnector__ConnectionString", _connectionString);
+            Environment.SetEnvironmentVariable("DCConnector__CheckEligibilityProcName", "dbo.sp_CheckEligibility");
+
+            builder.ConfigureServices(services =>
+            {
+                foreach (var descriptor in services
+                             .Where(d => d.ServiceType == typeof(IEnrollmentCheckSubmissionLogger))
+                             .ToList())
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddScoped(_ => Substitute.For<IEnrollmentCheckSubmissionLogger>());
+            });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Environment.SetEnvironmentVariable("DCConnector__ConnectionString", null);
+            Environment.SetEnvironmentVariable("DCConnector__CheckEligibilityProcName", null);
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcEnrollmentCheckIntegrationTests.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/DcEnrollmentCheckIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.DependencyInjection;
 using SEBT.Portal.StatesPlugins.Interfaces;
 
@@ -21,6 +22,7 @@ namespace SEBT.Portal.Tests.Integration.PluginIntegration;
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
+[Trait("Category", "SqlServer")]
 public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseFixture>, IDisposable
 {
     private readonly PluginIntegrationWebApplicationFactory? _factory;
@@ -55,13 +57,22 @@ public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseF
                 using (var scope = factory.Services.CreateScope())
                 {
                     var enrollment = scope.ServiceProvider.GetRequiredService<IEnrollmentCheckService>();
-                    if (enrollment.GetType().Name == "DefaultEnrollmentCheckService")
+                    if (enrollment.GetType().Name != "DcEnrollmentCheckService")
                     {
                         factory.Dispose();
                         factory = null;
                         skipReason =
-                            "plugins-dc has no IEnrollmentCheckService export; only the API default stub is registered. Rebuild dc-connector and copy DLLs to plugins-dc.";
+                            "Expected DcEnrollmentCheckService but got " +
+                            $"{enrollment.GetType().FullName}. Rebuild dc-connector, copy DLLs to plugins-dc, " +
+                            "and ensure no other enrollment plugin is loaded.";
                     }
+                }
+
+                if (factory != null && !CanConnectToDcSource(dcDatabase.ConnectionString, out var connectError))
+                {
+                    factory.Dispose();
+                    factory = null;
+                    skipReason = connectError;
                 }
 
                 if (factory != null)
@@ -155,5 +166,22 @@ public class DcEnrollmentCheckIntegrationTests : IClassFixture<DcSourceDatabaseF
     {
         _client?.Dispose();
         _factory?.Dispose();
+    }
+
+    private static bool CanConnectToDcSource(string connectionString, out string skipReason)
+    {
+        try
+        {
+            using var connection = new SqlConnection(connectionString);
+            connection.Open();
+            skipReason = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            skipReason =
+                $"DC source database is not reachable (Docker/Testcontainers may be unavailable): {ex.GetBaseException().Message}";
+            return false;
+        }
     }
 }

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/DefaultEnrollmentCheckIntegrationTests.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/DefaultEnrollmentCheckIntegrationTests.cs
@@ -1,6 +1,12 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using SEBT.Portal.Api.Composition.Defaults;
+using SEBT.Portal.Core.Services;
+using SEBT.Portal.StatesPlugins.Interfaces;
 
 namespace SEBT.Portal.Tests.Integration.PluginIntegration;
 
@@ -13,13 +19,14 @@ namespace SEBT.Portal.Tests.Integration.PluginIntegration;
 [Trait("Category", "Integration")]
 public class DefaultEnrollmentCheckIntegrationTests : IDisposable
 {
-    private readonly PluginIntegrationWebApplicationFactory _factory;
+    private const int MaxPluginPathIndices = 8;
+
+    private readonly DefaultEnrollmentCheckWebApplicationFactory _factory;
     private readonly HttpClient _client;
 
     public DefaultEnrollmentCheckIntegrationTests()
     {
-        // Load no plugins — DefaultEnrollmentCheckService provides the fallback
-        _factory = new PluginIntegrationWebApplicationFactory(pluginDir: null);
+        _factory = new DefaultEnrollmentCheckWebApplicationFactory();
         _client = _factory.CreateClient();
     }
 
@@ -66,5 +73,49 @@ public class DefaultEnrollmentCheckIntegrationTests : IDisposable
     {
         _client.Dispose();
         _factory.Dispose();
+    }
+
+    /// <summary>
+    /// Loads no connector plugins and always registers <see cref="DefaultEnrollmentCheckService"/>.
+    /// </summary>
+    private sealed class DefaultEnrollmentCheckWebApplicationFactory : PluginIntegrationWebApplicationFactory
+    {
+        public DefaultEnrollmentCheckWebApplicationFactory()
+            : base(pluginDir: null)
+        {
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            var pluginsNonePath = PluginPathResolver.Resolve("plugins-none");
+            Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", pluginsNonePath);
+            for (var i = 1; i < MaxPluginPathIndices; i++)
+            {
+                Environment.SetEnvironmentVariable($"PluginAssemblyPaths__{i}", null);
+            }
+
+            builder.ConfigureServices(services =>
+            {
+                foreach (var descriptor in services
+                             .Where(d => d.ServiceType == typeof(IEnrollmentCheckSubmissionLogger))
+                             .ToList())
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddScoped(_ => Substitute.For<IEnrollmentCheckSubmissionLogger>());
+
+                foreach (var descriptor in services
+                             .Where(d => d.ServiceType == typeof(IEnrollmentCheckService))
+                             .ToList())
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddSingleton<IEnrollmentCheckService, DefaultEnrollmentCheckService>();
+            });
+        }
     }
 }

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
+using SEBT.Portal.Api.Composition.Defaults;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Infrastructure.Data;
 using SEBT.Portal.Infrastructure.Services;
@@ -47,9 +48,7 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
         // Override plugin assembly paths via environment variables BEFORE the server starts.
         // Environment variables are visible immediately when Program.cs reads configuration,
         // unlike AddInMemoryCollection which can be applied too late.
-        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0",
-            _pluginDir != null ? PluginPathResolver.Resolve(_pluginDir) : "plugins-none");
-        Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", "plugins-none");
+        SetPluginAssemblyPathEnvironmentVariables(_pluginDir);
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey",
             "integration-test-key-must-be-at-least-32-bytes-long");
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__application", "IAL1");
@@ -92,13 +91,55 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
             // HouseholdRepository depends on it. Register a mock so DI validation
             // passes. TryAddSingleton is a no-op if a real plugin already registered it.
             services.TryAddSingleton(Substitute.For<ISummerEbtCaseService>());
+
+            foreach (var descriptor in services
+                         .Where(d => d.ServiceType == typeof(IEnrollmentCheckSubmissionLogger))
+                         .ToList())
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddScoped(_ => Substitute.For<IEnrollmentCheckSubmissionLogger>());
+
+            if (_pluginDir == null)
+            {
+                foreach (var descriptor in services
+                             .Where(d => d.ServiceType == typeof(IEnrollmentCheckService))
+                             .ToList())
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddSingleton<IEnrollmentCheckService, DefaultEnrollmentCheckService>();
+            }
         });
+    }
+
+    /// <summary>
+    /// Sets a single absolute plugin directory and clears any extra indices from
+    /// <c>appsettings.Development.json</c> (e.g. <c>plugins-co</c>) so only the intended connector loads.
+    /// </summary>
+    private static void SetPluginAssemblyPathEnvironmentVariables(string? pluginDir)
+    {
+        const int maxPluginPathIndices = 8;
+        var primaryPath = pluginDir != null
+            ? PluginPathResolver.Resolve(pluginDir)
+            : PluginPathResolver.Resolve("plugins-none");
+
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", primaryPath);
+        for (var i = 1; i < maxPluginPathIndices; i++)
+        {
+            Environment.SetEnvironmentVariable($"PluginAssemblyPaths__{i}", null);
+        }
     }
 
     protected override void Dispose(bool disposing)
     {
-        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", null);
-        Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", null);
+        const int maxPluginPathIndices = 8;
+        for (var i = 0; i < maxPluginPathIndices; i++)
+        {
+            Environment.SetEnvironmentVariable($"PluginAssemblyPaths__{i}", null);
+        }
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__application", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__coloadedStreamline", null);

--- a/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
+++ b/test/SEBT.Portal.Tests/Integration/PluginIntegration/PluginIntegrationWebApplicationFactory.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using NSubstitute;
-using SEBT.Portal.Api.Composition.Defaults;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Infrastructure.Data;
 using SEBT.Portal.Infrastructure.Services;
@@ -48,7 +47,9 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
         // Override plugin assembly paths via environment variables BEFORE the server starts.
         // Environment variables are visible immediately when Program.cs reads configuration,
         // unlike AddInMemoryCollection which can be applied too late.
-        SetPluginAssemblyPathEnvironmentVariables(_pluginDir);
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0",
+            _pluginDir != null ? PluginPathResolver.Resolve(_pluginDir) : "plugins-none");
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", "plugins-none");
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey",
             "integration-test-key-must-be-at-least-32-bytes-long");
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__application", "IAL1");
@@ -91,55 +92,13 @@ public class PluginIntegrationWebApplicationFactory : WebApplicationFactory<Prog
             // HouseholdRepository depends on it. Register a mock so DI validation
             // passes. TryAddSingleton is a no-op if a real plugin already registered it.
             services.TryAddSingleton(Substitute.For<ISummerEbtCaseService>());
-
-            foreach (var descriptor in services
-                         .Where(d => d.ServiceType == typeof(IEnrollmentCheckSubmissionLogger))
-                         .ToList())
-            {
-                services.Remove(descriptor);
-            }
-
-            services.AddScoped(_ => Substitute.For<IEnrollmentCheckSubmissionLogger>());
-
-            if (_pluginDir == null)
-            {
-                foreach (var descriptor in services
-                             .Where(d => d.ServiceType == typeof(IEnrollmentCheckService))
-                             .ToList())
-                {
-                    services.Remove(descriptor);
-                }
-
-                services.AddSingleton<IEnrollmentCheckService, DefaultEnrollmentCheckService>();
-            }
         });
-    }
-
-    /// <summary>
-    /// Sets a single absolute plugin directory and clears any extra indices from
-    /// <c>appsettings.Development.json</c> (e.g. <c>plugins-co</c>) so only the intended connector loads.
-    /// </summary>
-    private static void SetPluginAssemblyPathEnvironmentVariables(string? pluginDir)
-    {
-        const int maxPluginPathIndices = 8;
-        var primaryPath = pluginDir != null
-            ? PluginPathResolver.Resolve(pluginDir)
-            : PluginPathResolver.Resolve("plugins-none");
-
-        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", primaryPath);
-        for (var i = 1; i < maxPluginPathIndices; i++)
-        {
-            Environment.SetEnvironmentVariable($"PluginAssemblyPaths__{i}", null);
-        }
     }
 
     protected override void Dispose(bool disposing)
     {
-        const int maxPluginPathIndices = 8;
-        for (var i = 0; i < maxPluginPathIndices; i++)
-        {
-            Environment.SetEnvironmentVariable($"PluginAssemblyPaths__{i}", null);
-        }
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__0", null);
+        Environment.SetEnvironmentVariable("PluginAssemblyPaths__1", null);
         Environment.SetEnvironmentVariable("JwtSettings__SecretKey", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__application", null);
         Environment.SetEnvironmentVariable("IdProofingRequirements__household+view__coloadedStreamline", null);

--- a/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
@@ -29,6 +29,7 @@ public class OidcControllerTests
     private readonly IUserRepository _userRepository;
     private readonly IOidcTokenService _oidcTokenService;
     private readonly IPreAuthSessionStore _sessionStore;
+    private readonly IOidcCallbackFailureLogger _callbackFailureLogger;
     private readonly OidcController _controller;
 
     public OidcControllerTests()
@@ -66,9 +67,14 @@ public class OidcControllerTests
         var env = Substitute.For<IWebHostEnvironment>();
         env.EnvironmentName.Returns("Development");
 
+        _callbackFailureLogger = new OidcCallbackFailureLogger(
+            NullLogger<OidcCallbackFailureLogger>.Instance,
+            new HttpContextAccessor());
+
         _controller = new OidcController(
             _config,
             NullLogger<OidcController>.Instance,
+            _callbackFailureLogger,
             _userRepository,
             _oidcTokenService,
             jwtSettings,
@@ -170,6 +176,7 @@ public class OidcControllerTests
         var controller = new OidcController(
             _config,
             NullLogger<OidcController>.Instance,
+            _callbackFailureLogger,
             _userRepository,
             _oidcTokenService,
             jwtSettings,
@@ -980,6 +987,30 @@ public class OidcControllerTests
             ],
             authenticationType: "Test");
         controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(identity);
+    }
+
+    [Fact]
+    public async Task ReportCallbackFailure_WithIdpRedirect_Returns204()
+    {
+        var result = await _controller.ReportCallbackFailure(
+            new OidcCallbackFailureReportRequest(
+                Reason: "idp_redirect",
+                IdpError: "access_denied",
+                IdpErrorDescription: "User cancelled"),
+            CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task ReportCallbackFailure_WithInvalidReason_Returns400()
+    {
+        var result = await _controller.ReportCallbackFailure(
+            new OidcCallbackFailureReportRequest(Reason: "not_a_real_reason"),
+            CancellationToken.None);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.NotNull(badRequest.Value);
     }
 
     #endregion

--- a/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
@@ -18,6 +18,9 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
     private static readonly IIdentifierHasher TestHasher = new IdentifierHasher(
         Options.Create(new IdentifierHasherSettings { SecretKey = "TestKeyMustBeAtLeast32CharactersLong!!" }));
 
+    private static readonly IOptions<IdProofingValiditySettings> TestValiditySettings =
+        Options.Create(new IdProofingValiditySettings { ValidityDays = 1826 });
+
     public DatabaseUserRepositoryTests(SqlServerTestFixture fixture)
     {
         _fixture = fixture;
@@ -29,7 +32,7 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
     }
 
     private static DatabaseUserRepository CreateRepository(PortalDbContext context) =>
-        new(context, TestHasher);
+        new(context, TestHasher, TestValiditySettings);
 
     [Fact]
     public async Task GetUserByEmailAsync_WhenUserExists_ShouldReturnUser()
@@ -225,12 +228,12 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         context.Users.Add(entity);
         await context.SaveChangesAsync();
 
+        var completedAt = DateTime.UtcNow;
         var user = UserFactory.CreateUserWithEmail(uniqueEmail, u =>
         {
             u.IalLevel = UserIalLevel.IAL1plus;
             u.IdProofingSessionId = "new-session-456";
-            u.IdProofingCompletedAt = DateTime.UtcNow;
-            u.IdProofingExpiresAt = DateTime.UtcNow.AddYears(1);
+            u.IdProofingCompletedAt = completedAt;
         });
         // Set init-only properties using reflection
         var idProperty = typeof(User).GetProperty(nameof(User.Id));
@@ -247,7 +250,9 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         Assert.Equal((int)UserIalLevel.IAL1plus, updated!.IalLevel);
         Assert.Equal("new-session-456", updated.IdProofingSessionId);
         Assert.NotNull(updated.IdProofingCompletedAt);
-        Assert.NotNull(updated.IdProofingExpiresAt);
+        Assert.Equal(
+            completedAt.AddDays(TestValiditySettings.Value.ValidityDays),
+            updated.IdProofingExpiresAt);
     }
 
     [Fact]
@@ -744,7 +749,6 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         Assert.Equal(UserIalLevel.IAL1plus, result.IalLevel);
         Assert.Equal("test-session", result.IdProofingSessionId);
         Assert.Equal(completedAt, result.IdProofingCompletedAt);
-        Assert.Equal(expiresAt, result.IdProofingExpiresAt);
         Assert.True(result.IsCoLoaded);
         Assert.Equal(coLoadedUpdated, result.CoLoadedLastUpdated);
         Assert.Equal(createdAt, result.CreatedAt);
@@ -798,7 +802,6 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
             u.IalLevel = UserIalLevel.None;
             u.IdProofingSessionId = "full-session";
             u.IdProofingCompletedAt = completedAt;
-            u.IdProofingExpiresAt = expiresAt;
             u.IsCoLoaded = true;
             u.CoLoadedLastUpdated = coLoadedUpdated;
             u.UpdatedAt = DateTime.UtcNow.AddDays(-5);
@@ -816,7 +819,9 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         Assert.Equal((int)UserIalLevel.None, stored!.IalLevel);
         Assert.Equal("full-session", stored.IdProofingSessionId);
         Assert.Equal(completedAt, stored.IdProofingCompletedAt);
-        Assert.Equal(expiresAt, stored.IdProofingExpiresAt);
+        Assert.Equal(
+            completedAt.AddDays(TestValiditySettings.Value.ValidityDays),
+            stored.IdProofingExpiresAt);
         Assert.True(stored.IsCoLoaded);
         Assert.Equal(coLoadedUpdated, stored.CoLoadedLastUpdated);
     }

--- a/test/SEBT.Portal.Tests/Unit/Services/OidcLogSanitizerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Services/OidcLogSanitizerTests.cs
@@ -1,0 +1,24 @@
+using SEBT.Portal.Api.Services;
+
+namespace SEBT.Portal.Tests.Unit.Services;
+
+public class OidcLogSanitizerTests
+{
+    [Fact]
+    public void Sanitize_strips_newlines_and_truncates()
+    {
+        var input = new string('x', 600) + "\r\ntail";
+        var result = OidcLogSanitizer.Sanitize(input);
+
+        Assert.DoesNotContain("\r", result);
+        Assert.DoesNotContain("\n", result);
+        Assert.True(result.Length <= OidcLogSanitizer.MaxDescriptionLength + 1);
+        Assert.EndsWith("…", result);
+    }
+
+    [Fact]
+    public void Sanitize_returns_empty_for_null()
+    {
+        Assert.Equal(string.Empty, OidcLogSanitizer.Sanitize(null));
+    }
+}


### PR DESCRIPTION
#### Jira ticket
https://codeforamerica.atlassian.net/browse/DC-498

#### Description

OIDC callback failures that send users to id-proofing off-boarding were hard to diagnose in Datadog because IdP redirect errors never hit the API, and server logs were inconsistent or duplicated.

This PR adds structured, correlated logging for those failures and wires the browser callback path into the API where the failure happens only on the client.

API

- `IOidcCallbackFailureLogger` and `OidcLogSanitizer` produce a single grep-friendly line: `OIDC callback off-boarding` with `Reason`, `PortalUserId` (from JWT when present), `SessionId`, sanitized IdP `error` / `error_description`, and HTTP status where applicable.
- `POST /api/auth/oidc/report-failure` accepts whitelisted client reasons only: `idp_redirect`, `missing_params`. Exchange and complete-login failures are logged on the server only to avoid duplicate entries.
- `OidcExchangeService` logs token exchange failures with `SessionId`, adds `missing_id_token`, and uses the shared failure logger. Exceptions include sanitized messages plus full stack traces via `LogError(ex)`.
- `OidcController` callback and complete-login paths use the shared logger; duplicate exchange logging was removed where the exchange service already logs.

Web

- `reportCallbackFailure` uses `fetch` with `keepalive: true` so logging survives `router.replace` to off-boarding.
- Callback page reports IdP redirect errors and missing `code`/`state`; API failures redirect without a client report.
- MSW handler added for the new endpoint.

Id proofing expiration (build hygiene)

- `IdProofingExpiration` helper computes the legacy DB column from `IdProofingCompletedAt` + validity days.
- `DatabaseUserRepository`, `DataSeeder`, infrastructure `UserFactory`, and seeding no longer read