### PR TITLE
DC-502 - fix enrollment checker title/metadata

### DIFF
--- a/src/SEBT.EnrollmentChecker.Web/src/app/layout.tsx
+++ b/src/SEBT.EnrollmentChecker.Web/src/app/layout.tsx
@@ -3,19 +3,19 @@
 // Server Component would pull react-i18next into the RSC bundle and crash.
 import { primaryFont } from '@/design/fonts'
 import { env } from '@/lib/env'
+import { buildRootMetadata } from '@/lib/metadata'
 import { Providers } from '@/providers/Providers'
 import { AmplitudeAnalytics, MixpanelAnalytics, SiteImproveAnalytics } from '@sebt/analytics'
 import { Footer } from '@sebt/design-system/src/components/layout/Footer'
 import { Header } from '@sebt/design-system/src/components/layout/Header'
 import { HelpSection } from '@sebt/design-system/src/components/layout/HelpSection'
 import { SkipNav } from '@sebt/design-system/src/components/layout/SkipNav'
-import { getState, getStateName } from '@sebt/design-system/src/lib/state'
-import type { Metadata, Viewport } from 'next'
+import { getState } from '@sebt/design-system/src/lib/state'
+import type { Viewport } from 'next'
 import './globals.css'
 import './styles.scss'
 
 const state = getState()
-const stateName = getStateName(state)
 
 const amplitudeApiKey = env.NEXT_PUBLIC_AMPLITUDE_API_KEY
 const mixpanelToken = env.NEXT_PUBLIC_MIXPANEL_TOKEN
@@ -27,14 +27,7 @@ export const viewport: Viewport = {
   maximumScale: 5
 }
 
-export const metadata: Metadata = {
-  title: {
-    default: `${stateName} SUN Bucks Enrollment Checker`,
-    template: `%s | ${stateName} SUN Bucks`
-  },
-  description: `Check if your child is already enrolled in Summer EBT (SUN Bucks) in ${stateName}.`,
-  robots: { index: false, follow: false }
-}
+export const metadata = buildRootMetadata(state)
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/SEBT.EnrollmentChecker.Web/src/lib/metadata.test.ts
+++ b/src/SEBT.EnrollmentChecker.Web/src/lib/metadata.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildRootMetadata } from './metadata'
+
+describe('buildRootMetadata', () => {
+  describe('Colorado', () => {
+    const metadata = buildRootMetadata('co')
+
+    it('titles the app "Colorado Summer EBT Enrollment Checker"', () => {
+      expect(metadata.title).toEqual({
+        default: 'Colorado Summer EBT Enrollment Checker',
+        template: '%s | Colorado Summer EBT'
+      })
+    })
+
+    it('never references "SUN Bucks" anywhere in the metadata', () => {
+      expect(metadata.description).toBe(
+        'Check if your child is already enrolled in Colorado Summer EBT.'
+      )
+      expect(JSON.stringify(metadata)).not.toContain('SUN Bucks')
+    })
+  })
+
+  describe('District of Columbia', () => {
+    const metadata = buildRootMetadata('dc')
+
+    it('keeps the SUN Bucks branding in the title', () => {
+      expect(metadata.title).toEqual({
+        default: 'District of Columbia SUN Bucks Enrollment Checker',
+        template: '%s | District of Columbia SUN Bucks'
+      })
+    })
+
+    it('keeps the SUN Bucks branding in the description', () => {
+      expect(metadata.description).toBe(
+        'Check if your child is already enrolled in District of Columbia SUN Bucks.'
+      )
+    })
+  })
+
+  it('marks the checker as noindex for every state', () => {
+    expect(buildRootMetadata('co').robots).toEqual({ index: false, follow: false })
+    expect(buildRootMetadata('dc').robots).toEqual({ index: false, follow: false })
+  })
+})

--- a/src/SEBT.EnrollmentChecker.Web/src/lib/metadata.ts
+++ b/src/SEBT.EnrollmentChecker.Web/src/lib/metadata.ts
@@ -1,0 +1,28 @@
+import { getSiteDisplayName, type StateCode } from '@sebt/design-system/src/lib/state'
+import type { Metadata } from 'next'
+
+/**
+ * Build the Enrollment Checker's root metadata for a given state.
+ *
+ * The program name in the title and description is state-specific: the District
+ * of Columbia brands Summer EBT as "SUN Bucks", while Colorado uses "Summer EBT"
+ * and never the "SUN Bucks" name. `getSiteDisplayName` is the single source of
+ * truth for that branded, per-state name (e.g. "District of Columbia SUN Bucks",
+ * "Colorado Summer EBT"), so the right string renders for whichever state this
+ * deployment is built for.
+ *
+ * Kept as a pure `state -> Metadata` function so it can be unit-tested for every
+ * state without evaluating the root layout's Server Component module.
+ */
+export function buildRootMetadata(state: StateCode): Metadata {
+  const siteDisplayName = getSiteDisplayName(state)
+
+  return {
+    title: {
+      default: `${siteDisplayName} Enrollment Checker`,
+      template: `%s | ${siteDisplayName}`
+    },
+    description: `Check if your child is already enrolled in ${siteDisplayName}.`,
+    robots: { index: false, follow: false }
+  }
+}


### PR DESCRIPTION
## PR Description

#### 🔗 Jira ticket
[DC-502](https://codeforamerica.atlassian.net/browse/DC-502) / closes https://github.com/codeforamerica/sebt-self-service-portal/issues/369

#### ✍️ Description
The Enrollment Checker's page title and meta description now render the per-state branded program name instead of hardcoding "SUN Bucks" for every state. District of Columbia keeps "District of Columbia SUN Bucks Enrollment Checker"; Colorado now reads "Colorado Summer EBT Enrollment Checker" and no longer surfaces the "SUN Bucks" name anywhere in its metadata. The branded string comes from `getSiteDisplayName(state)`, the existing single source of truth for per-state site naming.

#### 🔗 Links to related PRs
- _none — single-repo change_

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/lib/metadata.ts` | `buildRootMetadata()` | Low | Low | Low | pure state→Metadata function |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/app/layout.tsx` | metadata export | Low | Low | Low | inline metadata → helper call |
| 🟢 | `src/SEBT.EnrollmentChecker.Web/src/lib/metadata.test.ts` | test suite | Low | Low | Low | per-state title/desc/robots |


[DC-502]: https://codeforamerica.atlassian.net/browse/DC-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ