### PR TITLE
DC-522(Bug): Scope HouseholdData by UserId; clear on user change

### DIFF
--- a/src/SEBT.Portal.Web/e2e/fixtures/api-routes.ts
+++ b/src/SEBT.Portal.Web/e2e/fixtures/api-routes.ts
@@ -1,6 +1,11 @@
 import type { Page } from '@playwright/test'
 
-import { DEFAULT_FEATURE_FLAGS, makeHouseholdData, type MockHouseholdData } from './household-data'
+import {
+  DEFAULT_FEATURE_FLAGS,
+  makeHouseholdData,
+  MOCK_USER_ID,
+  type MockHouseholdData
+} from './household-data'
 
 interface ApiRouteOverrides {
   /** Override the household data response. Defaults to makeHouseholdData(). */
@@ -71,6 +76,7 @@ export async function setupApiRoutes(page: Page, overrides: ApiRouteOverrides = 
       contentType: 'application/json',
       body: JSON.stringify({
         isAuthorized: true,
+        userId: MOCK_USER_ID,
         email: 'e2e@example.com',
         ial: '1plus',
         idProofingStatus: 2,

--- a/src/SEBT.Portal.Web/e2e/fixtures/household-data.ts
+++ b/src/SEBT.Portal.Web/e2e/fixtures/household-data.ts
@@ -20,6 +20,9 @@ import { currentState, type StateCode } from './state'
  */
 export const MOCK_JWT = 'e2e-mock-session-token'
 
+/** Stable portal user UUID for E2E auth/status mocks (required for user-scoped household cache). */
+export const MOCK_USER_ID = '018f0000-0000-7000-8000-0000000000e2'
+
 export type IssuanceTypeInt = 0 | 1 | 2 | 3
 export type ApplicationStatusInt = 0 | 1 | 2 | 3 | 4 | 5
 

--- a/src/SEBT.Portal.Web/src/app/layout.tsx
+++ b/src/SEBT.Portal.Web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { BetaBanner } from '@/components/BetaBanner'
 import { primaryFont } from '@/design/fonts'
+import { SessionIdentityCacheSync } from '@/features/auth/components/SessionIdentityCacheSync'
 import { portalRoutes } from '@/lib/analytics-routes'
 import {
   AuthProvider,
@@ -131,6 +132,7 @@ export default async function RootLayout({
         >
           <QueryProvider>
             <AuthProvider>
+              <SessionIdentityCacheSync />
               <FeatureFlagsProvider>
                 <I18nProvider>
                   <SkipNav />

--- a/src/SEBT.Portal.Web/src/features/address/api/client.test.ts
+++ b/src/SEBT.Portal.Web/src/features/address/api/client.test.ts
@@ -2,8 +2,11 @@ import { QueryClient } from '@tanstack/react-query'
 import { describe, expect, it } from 'vitest'
 
 import type { HouseholdData } from '@/features/household/api'
+import { householdDataQueryKey } from '@/features/household/api/queryKeys'
 
 import { patchHouseholdAddressOnFileCache } from './client'
+
+const TEST_USER_ID = '018f0000-0000-7000-8000-000000000001'
 
 const BASE_HOUSEHOLD: HouseholdData = {
   email: 'test@example.com',
@@ -22,7 +25,7 @@ const BASE_HOUSEHOLD: HouseholdData = {
 describe('patchHouseholdAddressOnFileCache', () => {
   it('updates addressOnFile in householdData cache when status is valid', () => {
     const queryClient = new QueryClient()
-    queryClient.setQueryData(['householdData'], BASE_HOUSEHOLD)
+    queryClient.setQueryData(householdDataQueryKey(TEST_USER_ID), BASE_HOUSEHOLD)
 
     patchHouseholdAddressOnFileCache(
       queryClient,
@@ -44,13 +47,13 @@ describe('patchHouseholdAddressOnFileCache', () => {
       }
     )
 
-    const updated = queryClient.getQueryData<HouseholdData>(['householdData'])
+    const updated = queryClient.getQueryData<HouseholdData>(householdDataQueryKey(TEST_USER_ID))
     expect(updated?.addressOnFile?.streetAddress1).toBe('456 Oak Avenue NW')
   })
 
   it('falls back to submitted address when normalizedAddress is missing', () => {
     const queryClient = new QueryClient()
-    queryClient.setQueryData(['householdData'], BASE_HOUSEHOLD)
+    queryClient.setQueryData(householdDataQueryKey(TEST_USER_ID), BASE_HOUSEHOLD)
 
     patchHouseholdAddressOnFileCache(
       queryClient,
@@ -63,13 +66,13 @@ describe('patchHouseholdAddressOnFileCache', () => {
       }
     )
 
-    const updated = queryClient.getQueryData<HouseholdData>(['householdData'])
+    const updated = queryClient.getQueryData<HouseholdData>(householdDataQueryKey(TEST_USER_ID))
     expect(updated?.addressOnFile?.streetAddress1).toBe('789 New St')
   })
 
   it('does not patch cache for non-valid responses', () => {
     const queryClient = new QueryClient()
-    queryClient.setQueryData(['householdData'], BASE_HOUSEHOLD)
+    queryClient.setQueryData(householdDataQueryKey(TEST_USER_ID), BASE_HOUSEHOLD)
 
     patchHouseholdAddressOnFileCache(
       queryClient,
@@ -82,7 +85,7 @@ describe('patchHouseholdAddressOnFileCache', () => {
       }
     )
 
-    const unchanged = queryClient.getQueryData<HouseholdData>(['householdData'])
+    const unchanged = queryClient.getQueryData<HouseholdData>(householdDataQueryKey(TEST_USER_ID))
     expect(unchanged?.addressOnFile?.streetAddress1).toBe('1350 Pennsylvania Ave NW')
   })
 })

--- a/src/SEBT.Portal.Web/src/features/address/api/client.ts
+++ b/src/SEBT.Portal.Web/src/features/address/api/client.ts
@@ -4,13 +4,12 @@ import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-q
 
 import { ApiError, apiFetch } from '@/api/client'
 import type { Address, HouseholdData } from '@/features/household/api'
+import { HOUSEHOLD_DATA_QUERY_KEY_PREFIX } from '@/features/household/api/queryKeys'
 
 import type { AddressResponse, AddressUpdateResponse, UpdateAddressRequest } from './schema'
 import { AddressUpdateResponseSchema } from './schema'
 
 const ADDRESS_ENDPOINT = '/household/address'
-const HOUSEHOLD_DATA_KEY = ['householdData'] as const
-const HOUSEHOLD_CARD_DETAILS_KEY = ['householdData', 'cardDetails'] as const
 
 function addressResponseToOnFile(address: AddressResponse | null | undefined): Address | undefined {
   if (!address?.streetAddress1 || !address.city || !address.state || !address.postalCode) {
@@ -52,8 +51,7 @@ export function patchHouseholdAddressOnFileCache(
   const patch = (existing: HouseholdData | undefined) =>
     existing ? { ...existing, addressOnFile } : existing
 
-  queryClient.setQueryData(HOUSEHOLD_DATA_KEY, patch)
-  queryClient.setQueryData(HOUSEHOLD_CARD_DETAILS_KEY, patch)
+  queryClient.setQueriesData<HouseholdData>({ queryKey: HOUSEHOLD_DATA_QUERY_KEY_PREFIX }, patch)
 }
 
 async function updateAddress(data: UpdateAddressRequest): Promise<AddressUpdateResponse> {

--- a/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.test.tsx
@@ -88,4 +88,51 @@ describe('SessionIdentityCacheSync', () => {
     })
     expect(queryClient.getQueryData(householdDataQueryKey(USER_A_ID))).toBeUndefined()
   })
+
+  it('clears household cache when the user logs out', async () => {
+    let statusCallCount = 0
+    server.use(
+      http.get('/api/auth/status', () => {
+        statusCallCount += 1
+        if (statusCallCount === 1) {
+          return HttpResponse.json({
+            isAuthorized: true,
+            userId: USER_A_ID,
+            email: 'user-a@example.com',
+            ial: '1'
+          })
+        }
+        return HttpResponse.json({ isAuthorized: false }, { status: 401 })
+      })
+    )
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+    queryClient.setQueryData(householdDataQueryKey(USER_A_ID), { email: 'user-a@example.com' })
+
+    const user = userEvent.setup()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <TestHarness />
+        </AuthProvider>
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-id')).toHaveTextContent(USER_A_ID)
+    })
+    expect(queryClient.getQueryData(householdDataQueryKey(USER_A_ID))).toBeDefined()
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /refresh session/i }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-id')).toHaveTextContent('none')
+    })
+    expect(queryClient.getQueryData(householdDataQueryKey(USER_A_ID))).toBeUndefined()
+  })
 })

--- a/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.test.tsx
@@ -1,0 +1,91 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { householdDataQueryKey } from '@/features/household/api/queryKeys'
+import { server } from '@/mocks/server'
+
+import { AuthProvider, useAuth } from '../../context'
+import { SessionIdentityCacheSync } from './SessionIdentityCacheSync'
+
+const USER_A_ID = '018f0000-0000-7000-8000-000000000001'
+const USER_B_ID = '018f0000-0000-7000-8000-000000000002'
+
+function TestHarness() {
+  const { session, login } = useAuth()
+
+  return (
+    <>
+      <SessionIdentityCacheSync />
+      <span data-testid="user-id">{session?.userId ?? 'none'}</span>
+      <button
+        type="button"
+        onClick={() => {
+          void login()
+        }}
+      >
+        Refresh session
+      </button>
+    </>
+  )
+}
+
+describe('SessionIdentityCacheSync', () => {
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  it('clears household cache when portal userId changes', async () => {
+    let statusCallCount = 0
+    server.use(
+      http.get('/api/auth/status', () => {
+        statusCallCount += 1
+        if (statusCallCount === 1) {
+          return HttpResponse.json({
+            isAuthorized: true,
+            userId: USER_A_ID,
+            email: 'user-a@example.com',
+            ial: '1'
+          })
+        }
+        return HttpResponse.json({
+          isAuthorized: true,
+          userId: USER_B_ID,
+          email: 'user-b@example.com',
+          ial: '1'
+        })
+      })
+    )
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+    queryClient.setQueryData(householdDataQueryKey(USER_A_ID), { email: 'user-a@example.com' })
+
+    const user = userEvent.setup()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <TestHarness />
+        </AuthProvider>
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-id')).toHaveTextContent(USER_A_ID)
+    })
+    expect(queryClient.getQueryData(householdDataQueryKey(USER_A_ID))).toBeDefined()
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /refresh session/i }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-id')).toHaveTextContent(USER_B_ID)
+    })
+    expect(queryClient.getQueryData(householdDataQueryKey(USER_A_ID))).toBeUndefined()
+  })
+})

--- a/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
+
+import { clearHouseholdQueryCache } from '@/features/household/api/clearHouseholdQueryCache'
+
+import { useAuth } from '../../context'
+
+/**
+ * Drops cached household data when the authenticated portal user changes
+ * Query keys are also scoped by userId; this clears any stale entries eagerly.
+ */
+export function SessionIdentityCacheSync() {
+  const { session } = useAuth()
+  const queryClient = useQueryClient()
+  const previousUserIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const userId = session?.userId ?? null
+    const previousUserId = previousUserIdRef.current
+
+    if (previousUserId && userId && previousUserId !== userId) {
+      clearHouseholdQueryCache(queryClient)
+    }
+
+    previousUserIdRef.current = userId
+  }, [session?.userId, queryClient])
+
+  return null
+}

--- a/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.tsx
@@ -8,7 +8,7 @@ import { clearHouseholdQueryCache } from '@/features/household/api/clearHousehol
 import { useAuth } from '../../context'
 
 /**
- * Drops cached household data when the authenticated portal user changes
+ * Drops cached household data when portal identity changes (user switch or logout).
  * Query keys are also scoped by userId; this clears any stale entries eagerly.
  */
 export function SessionIdentityCacheSync() {
@@ -20,7 +20,7 @@ export function SessionIdentityCacheSync() {
     const userId = session?.userId ?? null
     const previousUserId = previousUserIdRef.current
 
-    if (previousUserId && userId && previousUserId !== userId) {
+    if (previousUserId !== null && previousUserId !== userId) {
       clearHouseholdQueryCache(queryClient)
     }
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/index.ts
+++ b/src/SEBT.Portal.Web/src/features/auth/components/SessionIdentityCacheSync/index.ts
@@ -1,0 +1,1 @@
+export { SessionIdentityCacheSync } from './SessionIdentityCacheSync'

--- a/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.test.tsx
@@ -27,6 +27,31 @@ vi.mock('@sebt/design-system', async (importOriginal) => {
   }
 })
 
+const TEST_USER_ID = '018f0000-0000-7000-8000-000000000001'
+
+vi.mock('@/features/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/auth')>()
+  return {
+    ...actual,
+    useAuth: () => ({
+      session: {
+        userId: TEST_USER_ID,
+        email: 'test@example.com',
+        ial: '1plus',
+        idProofingStatus: 2,
+        idProofingCompletedAt: null,
+        idProofingExpiresAt: null,
+        isCoLoaded: false,
+        expiresAt: null,
+        absoluteExpiresAt: null
+      },
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn()
+    })
+  }
+})
+
 function createTestQueryClient() {
   return new QueryClient({
     defaultOptions: {

--- a/src/SEBT.Portal.Web/src/features/household/api/clearHouseholdQueryCache.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/clearHouseholdQueryCache.ts
@@ -1,0 +1,8 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+import { HOUSEHOLD_DATA_QUERY_KEY_PREFIX } from './queryKeys'
+
+/** Removes all cached household queries (every userId suffix). Call when portal identity changes. */
+export function clearHouseholdQueryCache(queryClient: QueryClient): void {
+  queryClient.removeQueries({ queryKey: HOUSEHOLD_DATA_QUERY_KEY_PREFIX })
+}

--- a/src/SEBT.Portal.Web/src/features/household/api/index.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/index.ts
@@ -26,5 +26,11 @@ export {
   type UserProfile
 } from './schema'
 
+export { clearHouseholdQueryCache } from './clearHouseholdQueryCache'
+export {
+  HOUSEHOLD_DATA_QUERY_KEY_PREFIX,
+  householdCardDetailsQueryKey,
+  householdDataQueryKey
+} from './queryKeys'
 export { useHouseholdData } from './useHouseholdData'
 export { useRequiredHouseholdData } from './useRequiredHouseholdData'

--- a/src/SEBT.Portal.Web/src/features/household/api/queryKeys.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/queryKeys.ts
@@ -1,0 +1,12 @@
+/** Prefix for all household React Query keys; use for invalidation across users. */
+export const HOUSEHOLD_DATA_QUERY_KEY_PREFIX = ['householdData'] as const
+
+/** Household data cache key scoped to the authenticated portal user. */
+export function householdDataQueryKey(userId: string) {
+  return [...HOUSEHOLD_DATA_QUERY_KEY_PREFIX, userId] as const
+}
+
+/** Deferred card-details fetch key scoped to the authenticated portal user. */
+export function householdCardDetailsQueryKey(userId: string) {
+  return [...HOUSEHOLD_DATA_QUERY_KEY_PREFIX, userId, 'cardDetails'] as const
+}

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
@@ -18,6 +18,33 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() })
 }))
 
+const TEST_USER_ID = '018f0000-0000-7000-8000-000000000001'
+const TEST_USER_B_ID = '018f0000-0000-7000-8000-000000000002'
+
+const mockAuthSession = {
+  userId: TEST_USER_ID,
+  email: 'test@example.com',
+  ial: '1plus' as const,
+  idProofingStatus: 2,
+  idProofingCompletedAt: null,
+  idProofingExpiresAt: null,
+  isCoLoaded: false as boolean | null,
+  expiresAt: null,
+  absoluteExpiresAt: null
+}
+
+vi.mock('@/features/auth', () => ({
+  useAuth: vi.fn(() => ({
+    session: mockAuthSession,
+    isAuthenticated: true,
+    isLoading: false,
+    login: vi.fn()
+  }))
+}))
+
+import { useAuth } from '@/features/auth'
+
+import { householdDataQueryKey } from './queryKeys'
 import { useHouseholdData } from './useHouseholdData'
 
 const TEST_HOUSEHOLD_DATA = {
@@ -57,6 +84,14 @@ function createWrapper() {
 describe('useHouseholdData', () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
+    mockAuthSession.userId = TEST_USER_ID
+    mockAuthSession.email = 'test@example.com'
+    vi.mocked(useAuth).mockReturnValue({
+      session: mockAuthSession,
+      isAuthenticated: true,
+      isLoading: false,
+      login: vi.fn()
+    })
   })
 
   afterEach(() => {
@@ -278,7 +313,7 @@ describe('useHouseholdData', () => {
   })
 
   describe('Query Configuration', () => {
-    it('should use correct query key', async () => {
+    it('should use query key scoped to the authenticated userId', async () => {
       server.use(
         http.get('/api/household/data', () => {
           return HttpResponse.json(TEST_HOUSEHOLD_DATA)
@@ -294,7 +329,7 @@ describe('useHouseholdData', () => {
       })
 
       await waitFor(() => {
-        expect(queryClient.getQueryData(['householdData'])).toBeDefined()
+        expect(queryClient.getQueryData(householdDataQueryKey(TEST_USER_ID))).toBeDefined()
       })
     })
 
@@ -318,8 +353,70 @@ describe('useHouseholdData', () => {
       })
 
       // With staleTime: 0, data should be immediately stale
-      const queryState = queryClient.getQueryState(['householdData'])
+      const queryState = queryClient.getQueryState(householdDataQueryKey(TEST_USER_ID))
       expect(queryState?.isInvalidated || queryState?.dataUpdatedAt).toBeTruthy()
+    })
+  })
+
+  describe('Session identity isolation', () => {
+    it('does not show prior user household data after session userId changes', async () => {
+      vi.useRealTimers()
+
+      const householdA = { ...TEST_HOUSEHOLD_DATA, email: 'user-a@example.com' }
+      const householdB = { ...TEST_HOUSEHOLD_DATA, email: 'user-b@example.com' }
+
+      server.use(
+        http.get('/api/household/data', () => {
+          return HttpResponse.json(householdA)
+        })
+      )
+
+      const queryClient = createTestQueryClient()
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      )
+
+      const { result, rerender } = renderHook(() => useHouseholdData(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+      expect(result.current.data?.email).toBe('user-a@example.com')
+
+      server.use(
+        http.get('/api/household/data', () => {
+          return HttpResponse.json(householdB)
+        })
+      )
+
+      const sessionB = { ...mockAuthSession, userId: TEST_USER_B_ID, email: 'user-b@example.com' }
+      vi.mocked(useAuth).mockReturnValue({
+        session: sessionB,
+        isAuthenticated: true,
+        isLoading: false,
+        login: vi.fn()
+      })
+
+      rerender()
+
+      await waitFor(() => {
+        expect(result.current.data?.email).toBe('user-b@example.com')
+      })
+
+      expect(
+        (
+          queryClient.getQueryData(householdDataQueryKey(TEST_USER_ID)) as
+            | { email: string }
+            | undefined
+        )?.email
+      ).toBe('user-a@example.com')
+      expect(
+        (
+          queryClient.getQueryData(householdDataQueryKey(TEST_USER_B_ID)) as
+            | { email: string }
+            | undefined
+        )?.email
+      ).toBe('user-b@example.com')
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -5,8 +5,10 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useMemo } from 'react'
 
 import { ApiError, apiFetch } from '@/api'
+import { useAuth } from '@/features/auth'
 
 import { mergeHouseholdCardDetails } from './mergeHouseholdCardDetails'
+import { householdCardDetailsQueryKey, householdDataQueryKey } from './queryKeys'
 import { HouseholdDataSchema, type HouseholdData } from './schema'
 
 async function fetchHouseholdData(includeCardDetails = true): Promise<HouseholdData> {
@@ -39,6 +41,8 @@ export interface UseHouseholdDataOptions {
  * Hook to fetch household data for the authenticated user.
  * Uses real-time fetching (staleTime: 0) to ensure data freshness
  * per ticket requirement to mitigate stale household/custody data.
+ * Query keys include the portal userId so a new login in the same tab
+ * cannot render the previous user's cached household.
  *
  * When the API returns 403 with a `requiredIal` extension, the user's IAL is
  * below the minimum required by their cases. By default the hook redirects
@@ -51,10 +55,13 @@ export function useHouseholdData({
 }: UseHouseholdDataOptions = {}) {
   const router = useRouter()
   const queryClient = useQueryClient()
+  const { session } = useAuth()
+  const userId = session?.userId
 
   const query = useQuery({
-    queryKey: ['householdData'],
+    queryKey: userId ? householdDataQueryKey(userId) : householdDataQueryKey('pending'),
     queryFn: () => (deferCardDetailsOnLoad ? fetchHouseholdData(false) : fetchHouseholdData(true)),
+    enabled: !!userId,
     staleTime: 0,
     gcTime: 5 * 60 * 1000, // 5 minutes for back-navigation
     refetchOnWindowFocus: true,
@@ -66,9 +73,11 @@ export function useHouseholdData({
     deferCardDetailsOnLoad && query.isSuccess && (query.data?.summerEbtCases.length ?? 0) > 0
 
   const cardDetailsQuery = useQuery({
-    queryKey: ['householdData', 'cardDetails'],
+    queryKey: userId
+      ? householdCardDetailsQueryKey(userId)
+      : householdCardDetailsQueryKey('pending'),
     queryFn: () => fetchHouseholdData(true),
-    enabled: shouldFetchCardDetails,
+    enabled: !!userId && shouldFetchCardDetails,
     staleTime: 0,
     gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: true,
@@ -93,11 +102,15 @@ export function useHouseholdData({
       return
     }
 
+    if (!userId) {
+      return
+    }
+
     queryClient.setQueryData(
-      ['householdData'],
+      householdDataQueryKey(userId),
       mergeHouseholdCardDetails(query.data, cardDetailsQuery.data)
     )
-  }, [query.data, cardDetailsQuery.data, queryClient])
+  }, [query.data, cardDetailsQuery.data, queryClient, userId])
 
   const requiresProofing =
     query.error instanceof ApiError &&

--- a/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/household/components/DashboardContent/DashboardContent.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { householdDataQueryKey } from '@/features/household/api/queryKeys'
 import { TEST_HOUSEHOLD_DATA } from '@/mocks/handlers'
 import { server } from '@/mocks/server'
 
@@ -43,7 +44,11 @@ vi.mock('next/navigation', () => ({
 // anchor to /api/auth/logout); only DashboardContent itself reads useAuth
 // for the co-loaded analytics branch. Preserve the real SignOutLink by
 // extending the actual module instead of replacing it.
-const mockAuthSession: { isCoLoaded: boolean | null } = { isCoLoaded: false }
+const TEST_USER_ID = '018f0000-0000-7000-8000-000000000001'
+const mockAuthSession: { userId: string; isCoLoaded: boolean | null } = {
+  userId: TEST_USER_ID,
+  isCoLoaded: false
+}
 vi.mock('@/features/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/features/auth')>()
   return {
@@ -201,7 +206,7 @@ describe('DashboardContent', () => {
 
   it('keeps populated dashboard when a background refetch returns 404 but cache still has data', async () => {
     const queryClient = createTestQueryClient()
-    queryClient.setQueryData(['householdData'], TEST_HOUSEHOLD_DATA)
+    queryClient.setQueryData(householdDataQueryKey(TEST_USER_ID), TEST_HOUSEHOLD_DATA)
 
     server.use(
       http.get('/api/household/data', () => {


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-522

#### ✍️ Description
Fixes a cross-user data leak when a second user logs in via OTP in the same browser tab without logging out first (back button from dashboard to login, then new email and OTP).

React Query cached household data under a global `['householdData']` key shared by all users in the tab. After User B authenticated, the dashboard could render User A's cached household while a refetch was in flight or blocked.  

Changes:
- Scope household query keys by portal `userId` via `householdDataQueryKey()` and `householdCardDetailsQueryKey()` in `queryKeys.ts`
- Gate `useHouseholdData` on `!!userId` so queries do not run without a known session
- Add `SessionIdentityCacheSync` in the root layout to `removeQueries` for all household keys when `session.userId` changes
- Add `clearHouseholdQueryCache()` helper and export shared key prefix for invalidation and cache patching
- Update address mutation cache patching to use the key prefix so it still hits user-scoped entries
- Add unit tests for session identity isolation in `useHouseholdData.test.tsx` and `SessionIdentityCacheSync.test.tsx`; update related household and address tests for scoped keys

#### 🔗 Links to related PRs
None

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes: N/A
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

#### Test plan
- [ ] `cd src/SEBT.Portal.Web && pnpm test --run src/features/household/api/useHouseholdData.test.tsx src/features/auth/components/SessionIdentityCacheSync/SessionIdentityCacheSync.test.tsx`
- [ ] Manual (DC mock mode): `UseMockHouseholdData=true STATE=dc pnpm dev`
  - Log in as `sebt.dc+verified@codeforamerica.org`, confirm dashboard shows John R. DoeMOCK
  - Browser back to `/login` without logout
  - Log in as `sebt.dc+singlechild@codeforamerica.org`, confirm dashboard shows Amanda R. TaylorMOCK (not John/Jane Doe)