### PR TITLE
DC-540: Log address-update policy rejections at Error with detail

### DIFF
--- a/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
+++ b/src/SEBT.Portal.UseCases/Household/UpdateAddress/UpdateAddressCommandHandler.cs
@@ -258,10 +258,11 @@ public class UpdateAddressCommandHandler(
 
             if (updateResult.IsPolicyRejection)
             {
-                logger.LogWarning(
-                    "Address update policy rejection for household identifier kind {Kind}: {ErrorCode}",
+                logger.LogError(
+                    "Address update policy rejection for household identifier kind {Kind}: {ErrorCode} - {ErrorDetail}",
                     identifierKind,
-                    updateResult.ErrorCode);
+                    updateResult.ErrorCode,
+                    updateResult.ErrorMessage);
                 return Result<AddressValidationResult>.PreconditionFailed(PreconditionFailedReason.Conflict, updateResult.ErrorMessage);
             }
 

--- a/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/UseCases/Household/UpdateAddressCommandHandlerTests.cs
@@ -1,5 +1,5 @@
 using System.Security.Claims;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SEBT.Portal.Core.Models;
@@ -39,8 +39,8 @@ public class UpdateAddressCommandHandlerTests
         Substitute.For<IIdProofingService>();
     private readonly ISelfServiceEvaluator _selfServiceEvaluator =
         Substitute.For<ISelfServiceEvaluator>();
-    private readonly NullLogger<UpdateAddressCommandHandler> _logger =
-        NullLogger<UpdateAddressCommandHandler>.Instance;
+    private readonly ILogger<UpdateAddressCommandHandler> _logger =
+        Substitute.For<ILogger<UpdateAddressCommandHandler>>();
 
     public UpdateAddressCommandHandlerTests()
     {
@@ -544,6 +544,30 @@ public class UpdateAddressCommandHandlerTests
         Assert.False(result.IsSuccess);
         var preconditionFailed = Assert.IsType<PreconditionFailedResult<AddressValidationResult>>(result);
         Assert.Equal(PreconditionFailedReason.Conflict, preconditionFailed.Reason);
+    }
+
+    [Fact]
+    public async Task Handle_LogsErrorWithDetail_WhenStateConnectorReturnsPolicyRejection()
+    {
+        var handler = CreateHandler();
+        var command = CreateValidCommand();
+
+        SetupResolverReturnsEmail();
+        SetupHouseholdWithCases();
+        _stateAddressUpdateService.UpdateAddressAsync(Arg.Any<AddressUpdateRequest>(), Arg.Any<CancellationToken>())
+            .Returns(AddressUpdateResult.PolicyRejected("HOUSEHOLD_NOT_FOUND", "No enrollment rows for the household."));
+
+        await handler.Handle(command, CancellationToken.None);
+
+        // Policy rejections are logged at Error with both the machine code and the full detail message.
+        _logger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o =>
+                o.ToString()!.Contains("HOUSEHOLD_NOT_FOUND") &&
+                o.ToString()!.Contains("No enrollment rows for the household.")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     [Fact]


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-540](https://codeforamerica.atlassian.net/browse/DC-540?atlOrigin=eyJpIjoiMWI1MWJiYThiNTJlNDFmYzlmZGNhYzBiMDE5YTg5OTUiLCJwIjoiaiJ9)

#### ✍️ Description
Address-update policy rejections were logged at Warning with only the ErrorCode. Bumped to Error and added the full ErrorMessage so the failure reason is visible in logs without a separate code lookup. Scope limited to the state-connector policy-rejection branch in UpdateAddressCommandHandler.

#### 🔗 Links to related PRs
CO connector [feature/co-address-update-error-codes](https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/49)

- [X] Added relevant tests
- [X] Meets acceptance criteria in ticket
- [X] Configuration changes: N/A


[DC-540]: https://codeforamerica.atlassian.net/browse/DC-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ