### PR TITLE
DC-454 - error & validation text changes with translation

### DIFF
--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.test.tsx
@@ -1,12 +1,16 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import amDcValidation from '@/content/locales/am/dc/validation.json'
+import enDcValidation from '@/content/locales/en/dc/validation.json'
+import esDcValidation from '@/content/locales/es/dc/validation.json'
 import type { Address } from '@/features/household/api'
 import { server } from '@/mocks/server'
 import { AnalyticsEvents } from '@sebt/analytics'
+import { i18n } from '@sebt/design-system/client'
 
 import { AddressFlowProvider } from '../../context'
 import { AddressForm } from './AddressForm'
@@ -120,6 +124,38 @@ describe('AddressForm', () => {
       document.body.appendChild(siteAlerts)
     }
     siteAlerts.innerHTML = ''
+  })
+
+  // --- Error language switching (DC-454) ---
+
+  describe('Error language switching (DC-454)', () => {
+    // The i18n instance is a shared singleton; reset to English after each test.
+    afterEach(async () => {
+      await act(async () => {
+        await i18n.changeLanguage('en')
+      })
+    })
+
+    it('re-translates field validation errors across all DC languages', async () => {
+      const { user } = renderForm()
+
+      // Submitting an empty form flags every required field. The errors are stored as
+      // { ns, key } descriptors and resolved at render, so a language switch re-translates
+      // them without re-submitting. Assert against the locale JSON for each DC language.
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+      expect((await screen.findAllByText(enDcValidation.required)).length).toBeGreaterThan(0)
+
+      await act(async () => {
+        await i18n.changeLanguage('es')
+      })
+      expect((await screen.findAllByText(esDcValidation.required)).length).toBeGreaterThan(0)
+
+      await act(async () => {
+        await i18n.changeLanguage('am')
+      })
+      expect((await screen.findAllByText(amDcValidation.required)).length).toBeGreaterThan(0)
+      expect(screen.queryAllByText(enDcValidation.required)).toHaveLength(0)
+    })
   })
 
   // --- Field rendering ---

--- a/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx
@@ -23,11 +23,16 @@ interface AddressFormProps {
   redirectPath?: string
 }
 
+// Field errors store an i18n key + its namespace (not the resolved string) so the messages
+// re-translate at render time when the user switches language (DC-454). Most keys live in the
+// `validation` namespace; the street-address ones live in `confirmInfo`.
+type FieldErrorDescriptor = { ns: 'validation' | 'confirmInfo'; key: string }
+
 interface FieldErrors {
-  streetAddress1?: string
-  city?: string
-  state?: string
-  postalCode?: string
+  streetAddress1?: FieldErrorDescriptor
+  city?: FieldErrorDescriptor
+  state?: FieldErrorDescriptor
+  postalCode?: FieldErrorDescriptor
 }
 
 const STATE_DEFAULTS: Record<string, { city: string; state: string }> = {
@@ -127,7 +132,12 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
   const [postalCode, setPostalCode] = useState(seedAddress?.postalCode ?? '')
 
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
-  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitErrorKey, setSubmitErrorKey] = useState<string | null>(null)
+
+  // Resolve a field-error descriptor at render time: confirmInfo keys via `t`, validation
+  // keys via `tValidation`. Call sites guard on the descriptor being present.
+  const resolveFieldError = (d: FieldErrorDescriptor): string =>
+    d.ns === 'validation' ? tValidation(d.key) : t(d.key)
 
   const isSubmitting = updateAddress.isPending
   const hasErrors = Object.keys(fieldErrors).length > 0
@@ -149,20 +159,20 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
 
   function validate(): FieldErrors {
     const errors: FieldErrors = {}
-    const required = tValidation('required')
+    const required: FieldErrorDescriptor = { ns: 'validation', key: 'required' }
 
     if (!streetAddress1.trim()) {
       errors.streetAddress1 = required
     } else if (streetAddress1.trim().length > 30) {
       // TODO: Backend does not yet enforce this limit — add [MaxLength(30)] when confirmed
-      errors.streetAddress1 = t('helperStreetAddress')
+      errors.streetAddress1 = { ns: 'confirmInfo', key: 'helperStreetAddress' }
     }
     if (!city.trim()) errors.city = required
     if (!stateValue.trim()) errors.state = required
     if (!postalCode.trim()) {
       errors.postalCode = required
     } else if (!isValidZip(postalCode.trim())) {
-      errors.postalCode = tValidation('enterZip')
+      errors.postalCode = { ns: 'validation', key: 'enterZip' }
     }
 
     return errors
@@ -170,7 +180,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setSubmitError(null)
+    setSubmitErrorKey(null)
 
     const errors = validate()
     setFieldErrors(errors)
@@ -201,7 +211,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
       // too_long stays on the form: inline field error + portal banner via showStreetLengthAlert.
       if (result.reason === 'too_long') {
         setFieldErrors({
-          streetAddress1: t('validationStreetAddress')
+          streetAddress1: { ns: 'confirmInfo', key: 'validationStreetAddress' }
         })
         return
       }
@@ -215,7 +225,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
       }
     } catch (err) {
       trackAddressUpdateSubmit({ setPageData, trackEvent }, null, err)
-      setSubmitError(tValidation('globalInternalError'))
+      setSubmitErrorKey('globalInternalError')
     }
   }
 
@@ -252,13 +262,13 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
         onSubmit={handleSubmit}
         noValidate
       >
-        {submitError && (
+        {submitErrorKey && (
           <Alert
             variant="error"
             slim
             className="margin-bottom-2"
           >
-            {submitError}
+            {tValidation(submitErrorKey)}
           </Alert>
         )}
 
@@ -293,7 +303,9 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
           }}
           autoComplete="address-line1"
           isRequired
-          {...(fieldErrors.streetAddress1 ? { error: fieldErrors.streetAddress1 } : {})}
+          {...(fieldErrors.streetAddress1
+            ? { error: resolveFieldError(fieldErrors.streetAddress1) }
+            : {})}
         />
 
         <InputField
@@ -312,7 +324,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
           onChange={(e) => setCity(e.target.value)}
           autoComplete="address-level2"
           isRequired
-          {...(fieldErrors.city ? { error: fieldErrors.city } : {})}
+          {...(fieldErrors.city ? { error: resolveFieldError(fieldErrors.city) } : {})}
         />
 
         <div
@@ -331,7 +343,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
               id="address-state-error"
               role="alert"
             >
-              {fieldErrors.state}
+              {resolveFieldError(fieldErrors.state)}
             </span>
           )}
           <select
@@ -364,7 +376,7 @@ export function AddressForm({ initialAddress, redirectPath }: AddressFormProps) 
           onChange={(e) => setPostalCode(e.target.value)}
           autoComplete="postal-code"
           isRequired
-          {...(fieldErrors.postalCode ? { error: fieldErrors.postalCode } : {})}
+          {...(fieldErrors.postalCode ? { error: resolveFieldError(fieldErrors.postalCode) } : {})}
         />
 
         <div className="margin-top-3 display-flex flex-row gap-2">

--- a/src/SEBT.Portal.Web/src/features/address/components/ReplacementCardPrompt/ReplacementCardPrompt.tsx
+++ b/src/SEBT.Portal.Web/src/features/address/components/ReplacementCardPrompt/ReplacementCardPrompt.tsx
@@ -21,20 +21,22 @@ export function ReplacementCardPrompt({ address }: ReplacementCardPromptProps) {
   const currentState = getState()
 
   const [selection, setSelection] = useState<'yes' | 'no' | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  // Store the i18n key (not the resolved string) so the error re-translates at render
+  // time when the user switches language (DC-454).
+  const [errorKey, setErrorKey] = useState<string | null>(null)
   const errorRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    if (error) {
+    if (errorKey) {
       errorRef.current?.focus()
     }
-  }, [error])
+  }, [errorKey])
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
 
     if (selection === null) {
-      setError(tValidation('selectOption'))
+      setErrorKey('selectOption')
       return
     }
 
@@ -81,14 +83,14 @@ export function ReplacementCardPrompt({ address }: ReplacementCardPromptProps) {
       <fieldset
         className="usa-fieldset"
         aria-label={tCommon('selectOne')}
-        aria-describedby={error ? 'replacement-choice-error' : undefined}
+        aria-describedby={errorKey ? 'replacement-choice-error' : undefined}
       >
         <legend className="usa-legend text-bold">
           {tCommon('selectOne')}
           <span className="text-secondary-dark"> *</span>
         </legend>
 
-        {error && (
+        {errorKey && (
           <span
             ref={errorRef}
             id="replacement-choice-error"
@@ -96,7 +98,7 @@ export function ReplacementCardPrompt({ address }: ReplacementCardPromptProps) {
             role="alert"
             tabIndex={-1}
           >
-            {error}
+            {tValidation(errorKey)}
           </span>
         )}
 
@@ -110,7 +112,7 @@ export function ReplacementCardPrompt({ address }: ReplacementCardPromptProps) {
             checked={selection === 'yes'}
             onChange={() => {
               setSelection('yes')
-              setError(null)
+              setErrorKey(null)
             }}
           />
           <label
@@ -131,7 +133,7 @@ export function ReplacementCardPrompt({ address }: ReplacementCardPromptProps) {
             checked={selection === 'no'}
             onChange={() => {
               setSelection('no')
-              setError(null)
+              setErrorKey(null)
             }}
           />
           <label

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.test.tsx
@@ -13,15 +13,17 @@
  * Missing i18n keys (e.g. optionLabelNone) fall back to the key string itself.
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18n } from '@sebt/design-system/client'
 
+import amDcValidation from '@/content/locales/am/dc/validation.json'
 import enCoStepUpProcessing from '@/content/locales/en/co/step-upProcessing.json'
 import enDcValidation from '@/content/locales/en/dc/validation.json'
+import esDcValidation from '@/content/locales/es/dc/validation.json'
 import { server } from '@/mocks/server'
 
 import {
@@ -143,6 +145,42 @@ describe('IdProofingForm', () => {
     mockSetPageData.mockClear()
     mockSetUserData.mockClear()
     mockTrackEvent.mockClear()
+  })
+
+  describe('Error language switching (DC-454)', () => {
+    // The i18n instance is a shared singleton; reset to English after each test.
+    afterEach(async () => {
+      await act(async () => {
+        await i18n.changeLanguage('en')
+      })
+    })
+
+    it('re-translates required-field errors across all DC languages', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <IdProofingForm
+          idOptions={TEST_ID_OPTIONS}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      // Submitting empty flags the required DOB/ID fields. Those errors use real validation
+      // keys (stored as { ns, key } and resolved at render), so they re-translate on a
+      // language switch. (The hardcoded DOB-invalid / digit-count messages have no key yet.)
+      await user.click(screen.getByRole('button', { name: /continue/i }))
+      expect((await screen.findAllByText(enDcValidation.required)).length).toBeGreaterThan(0)
+
+      await act(async () => {
+        await i18n.changeLanguage('es')
+      })
+      expect((await screen.findAllByText(esDcValidation.required)).length).toBeGreaterThan(0)
+
+      await act(async () => {
+        await i18n.changeLanguage('am')
+      })
+      expect((await screen.findAllByText(amDcValidation.required)).length).toBeGreaterThan(0)
+      expect(screen.queryAllByText(enDcValidation.required)).toHaveLength(0)
+    })
   })
 
   describe('Rendering', () => {

--- a/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx
@@ -74,6 +74,12 @@ interface IdProofingFormProps {
   getDiToken?: () => Promise<string | null>
 }
 
+/**
+ * A field/submit message that defers translation to render time (DC-454): either an i18n key
+ * in a given namespace, or a literal English string for messages that have no key yet.
+ */
+type Msg = { ns: 'validation' | 'dev'; key: string } | { literal: string }
+
 // Generate localized month names using Intl.DateTimeFormat
 function getLocalizedMonths(locale: string) {
   const formatter = new Intl.DateTimeFormat(locale, { month: 'long' })
@@ -101,13 +107,16 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
   const [selectedIdType, setSelectedIdType] = useState<IdOptionValue | null>(null)
   const [idValue, setIdValue] = useState('')
 
-  const [dobErrors, setDobErrors] = useState<{ month?: string; day?: string; year?: string }>({})
+  // Error state holds deferred messages (Msg), not resolved strings, so the keyed ones
+  // re-translate at render time when the user switches language (DC-454). Messages with no
+  // i18n key yet are carried as literals (content gap) and stay English until a key exists.
+  const [dobErrors, setDobErrors] = useState<{ month?: Msg; day?: Msg; year?: Msg }>({})
   // Composite errors that describe the date as a whole (impossible calendar date,
   // future, >120 years ago) belong to the fieldset, not to any single input.
-  const [dobFieldsetError, setDobFieldsetError] = useState<string | null>(null)
-  const [idTypeError, setIdTypeError] = useState<string | null>(null)
-  const [idValueError, setIdValueError] = useState<string | null>(null)
-  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [dobFieldsetError, setDobFieldsetError] = useState<Msg | null>(null)
+  const [idTypeError, setIdTypeError] = useState<Msg | null>(null)
+  const [idValueError, setIdValueError] = useState<Msg | null>(null)
+  const [submitError, setSubmitError] = useState<Msg | null>(null)
   // Covers the full submit flow, not just the mutation. The Socure DI token
   // fetch runs before mutateAsync, so leaning on `submitIdProofing.isPending`
   // alone would leave the form on screen during a slow token call.
@@ -123,37 +132,43 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
   const selectedOption = idOptions.find((opt) => opt.value === selectedIdType)
   const showIdValueInput = selectedIdType !== null && selectedIdType !== NONE_VALUE
 
-  const REQUIRED_FIELD_ERROR = tValidation('required')
-  const SSN_ITIN_SHAPE_ERROR = tValidation('ssn')
-  const SEVEN_OR_EIGHT_DIGITS_ERROR = tValidation('idNumber')
-  // TODO: Use t('validation.dobInvalid') once key is available in dc.csv
-  const DOB_INVALID_ERROR = 'Enter a valid date of birth.'
+  const REQUIRED_FIELD_ERROR: Msg = { ns: 'validation', key: 'required' }
+  const SSN_ITIN_SHAPE_ERROR: Msg = { ns: 'validation', key: 'ssn' }
+  const SEVEN_OR_EIGHT_DIGITS_ERROR: Msg = { ns: 'validation', key: 'idNumber' }
+  // TODO: replace with a keyed message once a DOB-invalid key exists in dc.csv (content gap).
+  const DOB_INVALID_ERROR: Msg = { literal: 'Enter a valid date of birth.' }
 
-  // Pick the user-facing error message that matches the rule's shape. The SSN
-  // and ITIN messages stay verbatim so the existing wording carries through;
-  // [7, 8] rules use a shared message; other shapes fall back to a generic.
-  function digitRuleErrorMessage(rule: IdOptionValidation): string {
+  // Resolve a deferred message at render time so it follows a language switch (DC-454).
+  // Call sites guard on the message being present.
+  const resolveMsg = (m: Msg): string => {
+    if ('literal' in m) return m.literal
+    return m.ns === 'dev' ? tDev(m.key) : tValidation(m.key)
+  }
+
+  // Pick the user-facing error message that matches the rule's shape. SSN/ITIN and [7, 8]
+  // rules reuse existing keys; other shapes have no key yet and stay as literals (content gap).
+  function digitRuleErrorMessage(rule: IdOptionValidation): Msg {
     const [min, max] = digitBounds(rule)
     if (min === max && min === 9) return SSN_ITIN_SHAPE_ERROR
     if (min === 7 && max === 8) return SEVEN_OR_EIGHT_DIGITS_ERROR
-    if (min === max) return `Enter exactly ${min} digits.`
-    return `Enter ${min} or ${max} digits.`
+    if (min === max) return { literal: `Enter exactly ${min} digits.` }
+    return { literal: `Enter ${min} or ${max} digits.` }
   }
 
   function validateFields(): boolean {
-    const newDobErrors: { month?: string; day?: string; year?: string } = {}
-    let newDobFieldsetError: string | null = null
+    const newDobErrors: { month?: Msg; day?: Msg; year?: Msg } = {}
+    let newDobFieldsetError: Msg | null = null
 
     if (!dobMonth) newDobErrors.month = REQUIRED_FIELD_ERROR
     if (!dobDay) newDobErrors.day = REQUIRED_FIELD_ERROR
     if (!dobYear) newDobErrors.year = REQUIRED_FIELD_ERROR
 
-    let idTypeErr: string | null = null
+    let idTypeErr: Msg | null = null
     if (selectedIdType === null) {
       idTypeErr = REQUIRED_FIELD_ERROR
     }
 
-    let idError: string | null = null
+    let idError: Msg | null = null
     if (showIdValueInput && !idValue.trim()) {
       idError = REQUIRED_FIELD_ERROR
     }
@@ -237,7 +252,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
         setUserData('docv_required', true, ['default', 'analytics'])
         trackEvent(AnalyticsEvents.IDV_PRIMARY_RESULT)
         if (!response.challengeId) {
-          setSubmitError(tDev('alertVerificationRetry'))
+          setSubmitError({ ns: 'dev', key: 'alertVerificationRetry' })
           return
         }
         clearChallengeContext()
@@ -289,7 +304,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
       // All errors get the same user-facing message. Raw ApiError.message may contain
       // backend wording not intended for end users — avoid displaying it directly.
       void err
-      setSubmitError(tValidation('globalInternalError'))
+      setSubmitError({ ns: 'validation', key: 'globalInternalError' })
     } finally {
       setIsProcessing(false)
     }
@@ -345,7 +360,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
           slim
           className="margin-bottom-2"
         >
-          {submitError}
+          {resolveMsg(submitError)}
         </Alert>
       )}
 
@@ -361,7 +376,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
             className="usa-error-message"
             role="alert"
           >
-            {dobFieldsetError}
+            {resolveMsg(dobFieldsetError)}
           </span>
         )}
 
@@ -384,7 +399,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
                   className="usa-error-message"
                   role="alert"
                 >
-                  {dobErrors.month}
+                  {resolveMsg(dobErrors.month)}
                 </span>
               )}
               <select
@@ -421,7 +436,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
               onChange={(e) => setDobDay(e.target.value)}
               autoComplete="bday-day"
               isRequired
-              {...(dobErrors.day ? { error: dobErrors.day } : {})}
+              {...(dobErrors.day ? { error: resolveMsg(dobErrors.day) } : {})}
             />
           </div>
 
@@ -437,7 +452,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
               onChange={(e) => setDobYear(e.target.value)}
               autoComplete="bday-year"
               isRequired
-              {...(dobErrors.year ? { error: dobErrors.year } : {})}
+              {...(dobErrors.year ? { error: resolveMsg(dobErrors.year) } : {})}
             />
           </div>
         </div>
@@ -455,7 +470,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
             className="usa-error-message"
             role="alert"
           >
-            {idTypeError}
+            {resolveMsg(idTypeError)}
           </span>
         )}
 
@@ -524,7 +539,7 @@ export function IdProofingForm({ idOptions, contactLink, getDiToken }: IdProofin
                   maxLength: digitBounds(selectedOption.validation)[1]
                 }
               : {})}
-            {...(idValueError ? { error: idValueError } : {})}
+            {...(idValueError ? { error: resolveMsg(idValueError) } : {})}
           />
         </div>
       )}

--- a/src/SEBT.Portal.Web/src/features/auth/components/login/LoginForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/login/LoginForm.test.tsx
@@ -8,10 +8,15 @@
  * - Error handling for various scenarios
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18n } from '@sebt/design-system/client'
+
+import amDcValidation from '@/content/locales/am/dc/validation.json'
+import enDcValidation from '@/content/locales/en/dc/validation.json'
+import esDcValidation from '@/content/locales/es/dc/validation.json'
 import { TEST_EMAILS } from '@/mocks/handlers'
 
 import { LoginForm } from './LoginForm'
@@ -201,6 +206,68 @@ describe('LoginForm', () => {
       await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledWith('otp_request')
       })
+    })
+  })
+
+  describe('Error language switching (DC-454)', () => {
+    // The i18n instance is a shared singleton; reset to English so sibling tests
+    // (which assume English labels) aren't affected by a lingering Spanish switch.
+    afterEach(async () => {
+      await act(async () => {
+        await i18n.changeLanguage('en')
+      })
+    })
+
+    it('re-translates the submit error across all DC languages, without resubmitting', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<LoginForm />)
+
+      const emailInput = screen.getByRole('textbox', { name: /enter your email address/i })
+      const submitButton = screen.getByRole('button', { name: /continue/i })
+
+      // 429 (rate limit) is a client error: the request hook does not retry it, so the error
+      // surfaces deterministically. Any API failure maps to the translatable globalInternalError
+      // copy (not the raw English backend text). Assert against the locale JSON for each DC language.
+      await user.type(emailInput, TEST_EMAILS.rateLimit)
+      await user.click(submitButton)
+
+      expect(await screen.findByText(enDcValidation.globalInternalError)).toBeInTheDocument()
+
+      // Cycle DC languages with the error on screen — no resubmit.
+      await act(async () => {
+        await i18n.changeLanguage('es')
+      })
+      expect(await screen.findByText(esDcValidation.globalInternalError)).toBeInTheDocument()
+
+      await act(async () => {
+        await i18n.changeLanguage('am')
+      })
+      expect(await screen.findByText(amDcValidation.globalInternalError)).toBeInTheDocument()
+      expect(screen.queryByText(enDcValidation.globalInternalError)).toBeNull()
+    })
+
+    it('re-translates the email validation error across all DC languages', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<LoginForm />)
+
+      const emailInput = screen.getByRole('textbox', { name: /enter your email address/i })
+      const submitButton = screen.getByRole('button', { name: /continue/i })
+
+      await user.type(emailInput, 'not-an-email')
+      await user.click(submitButton)
+
+      expect(await screen.findByText(enDcValidation.enterEmail)).toBeInTheDocument()
+
+      await act(async () => {
+        await i18n.changeLanguage('es')
+      })
+      expect(await screen.findByText(esDcValidation.enterEmail)).toBeInTheDocument()
+
+      await act(async () => {
+        await i18n.changeLanguage('am')
+      })
+      expect(await screen.findByText(amDcValidation.enterEmail)).toBeInTheDocument()
+      expect(screen.queryByText(enDcValidation.enterEmail)).toBeNull()
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/login/LoginForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/login/LoginForm.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation'
 import { useState, type FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ApiError } from '@/api/client'
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
 import { Alert, Button, InputField } from '@sebt/design-system'
 
@@ -16,33 +15,36 @@ export function LoginForm() {
   const { t: tLogin } = useTranslation('login')
   const { t: tValidation } = useTranslation('validation')
   const [email, setEmail] = useState('')
-  const [fieldError, setFieldError] = useState<string | null>(null)
-  const [submitError, setSubmitError] = useState<string | null>(null)
+  // Error state holds `validation` namespace keys (not resolved strings) so the messages
+  // re-translate at render time when the user switches language (DC-454).
+  const [fieldErrorKey, setFieldErrorKey] = useState<string | null>(null)
+  const [submitErrorKey, setSubmitErrorKey] = useState<string | null>(null)
 
   const requestOtp = useRequestOtp()
   const { trackEvent } = useDataLayer()
 
+  // Returns a `validation` namespace key (resolved at render), or null when valid.
   function validateEmail(value: string): string | null {
     if (!value.trim()) {
-      return tValidation('required')
+      return 'required'
     }
     const result = RequestOtpRequestSchema.shape.email.safeParse(value)
     if (!result.success) {
-      return tValidation('enterEmail')
+      return 'enterEmail'
     }
     return null
   }
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setSubmitError(null)
+    setSubmitErrorKey(null)
 
-    const error = validateEmail(email)
-    if (error) {
-      setFieldError(error)
+    const errorKey = validateEmail(email)
+    if (errorKey) {
+      setFieldErrorKey(errorKey)
       return
     }
-    setFieldError(null)
+    setFieldErrorKey(null)
 
     trackEvent(AnalyticsEvents.OTP_REQUEST)
 
@@ -50,12 +52,10 @@ export function LoginForm() {
       await requestOtp.mutateAsync({ email, locale: i18n.language })
       sessionStorage.setItem('otp_email', email)
       router.push('/login/verify')
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setSubmitError(err.message)
-      } else {
-        setSubmitError(tValidation('globalInternalError'))
-      }
+    } catch {
+      // Map any failure to a key so the banner follows the active language. Backend
+      // messages are English-only and would freeze on a language switch.
+      setSubmitErrorKey('globalInternalError')
     }
   }
 
@@ -64,13 +64,13 @@ export function LoginForm() {
       className="usa-form maxw-full text-left"
       onSubmit={handleSubmit}
     >
-      {submitError && (
+      {submitErrorKey && (
         <Alert
           variant="error"
           slim
           className="margin-bottom-2"
         >
-          {submitError}
+          {tValidation(submitErrorKey)}
         </Alert>
       )}
 
@@ -82,10 +82,10 @@ export function LoginForm() {
         isRequired
         value={email}
         onChange={(e) => setEmail(e.target.value)}
-        onBlur={() => setFieldError(validateEmail(email))}
+        onBlur={() => setFieldErrorKey(validateEmail(email))}
         disabled={requestOtp.isPending}
         className="maxw-full"
-        {...(fieldError ? { error: fieldError } : {})}
+        {...(fieldErrorKey ? { error: tValidation(fieldErrorKey) } : {})}
       />
 
       <Button

--- a/src/SEBT.Portal.Web/src/features/auth/components/verify/VerifyOtpForm.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/verify/VerifyOtpForm.test.tsx
@@ -14,6 +14,11 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18n } from '@sebt/design-system/client'
+
+import amDcValidation from '@/content/locales/am/dc/validation.json'
+import enDcValidation from '@/content/locales/en/dc/validation.json'
+import esDcValidation from '@/content/locales/es/dc/validation.json'
 import { TEST_EMAILS, TEST_OTP } from '@/mocks/handlers'
 import { server } from '@/mocks/server'
 
@@ -527,9 +532,11 @@ describe('VerifyOtpForm', () => {
       await user.type(otpInput, TEST_OTP.invalid)
       await user.click(confirmButton)
 
+      // A 401 maps to the translatable, actionable otpInvalid copy ("enter a valid code,
+      // tap to send a new code") rather than the raw English backend message (DC-454).
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument()
-        expect(screen.getByText(/invalid otp/i)).toBeInTheDocument()
+        expect(screen.getByText(/enter a valid.*digit code/i)).toBeInTheDocument()
       })
     })
 
@@ -554,10 +561,54 @@ describe('VerifyOtpForm', () => {
       await user.type(otpInput, TEST_OTP.expired)
       await user.click(confirmButton)
 
+      // Expired and invalid 401s share the same actionable "send a new code" copy; the
+      // backend's English-only "expired" wording is no longer surfaced directly (DC-454).
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeInTheDocument()
-        expect(screen.getByText(/expired/i)).toBeInTheDocument()
+        expect(screen.getByText(/enter a valid.*digit code/i)).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('Error language switching (DC-454)', () => {
+    // Real timers: RTL waitFor + the i18n changeLanguage await can exceed the test timeout
+    // under fake timers. The i18n instance is a shared singleton; reset to English after.
+    beforeEach(() => {
+      vi.useRealTimers()
+    })
+
+    afterEach(async () => {
+      await act(async () => {
+        await i18n.changeLanguage('en')
+      })
+    })
+
+    it('re-translates the submit error across all DC languages, without resubmitting', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(
+        <VerifyOtpForm
+          email={TEST_EMAILS.success}
+          contactLink={TEST_CONTACT_LINK}
+        />
+      )
+
+      const otpInput = await screen.findByRole('textbox', { name: /enter.*confirmation code/i })
+      // A wrong 6-digit code reaches the server and returns 401 → the actionable otpInvalid copy.
+      await user.type(otpInput, TEST_OTP.invalid)
+      await user.click(screen.getByRole('button', { name: /confirm/i }))
+
+      expect(await screen.findByText(enDcValidation.otpInvalid)).toBeInTheDocument()
+
+      await act(async () => {
+        await i18n.changeLanguage('es')
+      })
+      expect(await screen.findByText(esDcValidation.otpInvalid)).toBeInTheDocument()
+
+      await act(async () => {
+        await i18n.changeLanguage('am')
+      })
+      expect(await screen.findByText(amDcValidation.otpInvalid)).toBeInTheDocument()
+      expect(screen.queryByText(enDcValidation.otpInvalid)).toBeNull()
     })
   })
 

--- a/src/SEBT.Portal.Web/src/features/auth/components/verify/VerifyOtpForm.tsx
+++ b/src/SEBT.Portal.Web/src/features/auth/components/verify/VerifyOtpForm.tsx
@@ -28,9 +28,11 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
   const { t: tValidation } = useTranslation('validation')
 
   const [otp, setOtp] = useState('')
-  const [fieldError, setFieldError] = useState<string | null>(null)
-  const [submitError, setSubmitError] = useState<string | null>(null)
-  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+  // Error/status state holds `validation` namespace keys (not resolved strings) so the
+  // messages re-translate at render time when the user switches language (DC-454).
+  const [fieldErrorKey, setFieldErrorKey] = useState<string | null>(null)
+  const [submitErrorKey, setSubmitErrorKey] = useState<string | null>(null)
+  const [successMessageKey, setSuccessMessageKey] = useState<string | null>(null)
 
   const [count, { startCountdown, resetCountdown }] = useCountdown({
     countStart: RESEND_COOLDOWN_SECONDS,
@@ -42,31 +44,29 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
   const requestOtp = useRequestOtp()
   const { setPageData, setUserData, trackEvent } = useDataLayer()
 
-  const validateCode = useCallback(
-    (value: string): string | null => {
-      if (!value.trim()) {
-        return tValidation('required')
-      }
-      const result = ValidateOtpRequestSchema.shape.otp.safeParse(value)
-      if (!result.success) {
-        return tValidation('otpInvalid')
-      }
-      return null
-    },
-    [tValidation]
-  )
+  // Returns a `validation` namespace key (resolved at render), or null when valid.
+  const validateCode = useCallback((value: string): string | null => {
+    if (!value.trim()) {
+      return 'required'
+    }
+    const result = ValidateOtpRequestSchema.shape.otp.safeParse(value)
+    if (!result.success) {
+      return 'otpInvalid'
+    }
+    return null
+  }, [])
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    setSubmitError(null)
-    setSuccessMessage(null)
+    setSubmitErrorKey(null)
+    setSuccessMessageKey(null)
 
-    const error = validateCode(otp)
-    if (error) {
-      setFieldError(error)
+    const errorKey = validateCode(otp)
+    if (errorKey) {
+      setFieldErrorKey(errorKey)
       return
     }
-    setFieldError(null)
+    setFieldErrorKey(null)
 
     trackEvent(AnalyticsEvents.OTP_CHALLENGE)
 
@@ -80,7 +80,7 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
         setPageData('otp_status', 'error')
         setUserData('authenticated', false, ['default', 'analytics'])
         trackEvent(AnalyticsEvents.OTP_RESULT)
-        setSubmitError(tValidation('globalInternalError'))
+        setSubmitErrorKey('globalInternalError')
         return
       }
       trackEvent(AnalyticsEvents.OTP_RESULT)
@@ -91,11 +91,13 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
     } catch (err) {
       setPageData('otp_status', 'error')
       trackEvent(AnalyticsEvents.OTP_RESULT)
-      if (err instanceof ApiError) {
-        setSubmitError(err.message)
-      } else {
-        setSubmitError(tValidation('globalInternalError'))
-      }
+      // A 401 means the code was wrong or expired — both resolve to the actionable
+      // "enter a valid code, request a new one" copy. Other failures get the generic
+      // internal-error message. Both are i18n keys resolved at render so they follow a
+      // language switch (DC-454); raw backend messages are English-only and would freeze.
+      setSubmitErrorKey(
+        err instanceof ApiError && err.status === 401 ? 'otpInvalid' : 'globalInternalError'
+      )
     }
   }
 
@@ -106,24 +108,22 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
   async function handleResend() {
     if (isCountdownActive) return
 
-    setSubmitError(null)
-    setSuccessMessage(null)
+    setSubmitErrorKey(null)
+    setSuccessMessageKey(null)
 
     trackEvent(AnalyticsEvents.OTP_REQUEST)
 
     try {
       await requestOtp.mutateAsync({ email, locale: i18n.language })
-      // TODO: "codeSentSuccess" value exists in CSV but under a broken row key ("VALIDATION -" with no key name) — needs CSV fix
-      setSuccessMessage(tLogin('codeSentSuccess', 'A new code has been sent to your email.'))
+      // validation:newCode carries the intended "A new code has been sent" copy in every
+      // language; resolved at render so it follows a language switch (DC-454). The
+      // login:codeSentSuccess row in the content sheet is malformed — tracked separately.
+      setSuccessMessageKey('newCode')
       resetCountdown()
       startCountdown()
       setHasStartedCountdown(true)
-    } catch (err) {
-      if (err instanceof ApiError) {
-        setSubmitError(err.message)
-      } else {
-        setSubmitError(tValidation('globalInternalError'))
-      }
+    } catch {
+      setSubmitErrorKey('globalInternalError')
     }
   }
 
@@ -136,23 +136,23 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
       className="usa-form maxw-full text-left"
       onSubmit={handleSubmit}
     >
-      {submitError && (
+      {submitErrorKey && (
         <Alert
           variant="error"
           slim
           className="margin-bottom-2"
         >
-          {submitError}
+          {tValidation(submitErrorKey)}
         </Alert>
       )}
 
-      {successMessage && (
+      {successMessageKey && (
         <Alert
           variant="success"
           slim
           className="margin-bottom-2"
         >
-          {successMessage}
+          {tValidation(successMessageKey)}
         </Alert>
       )}
 
@@ -166,10 +166,10 @@ export function VerifyOtpForm({ email, contactLink }: VerifyOtpFormProps) {
         maxLength={6}
         value={otp}
         onChange={(e) => setOtp(e.target.value)}
-        onBlur={() => setFieldError(validateCode(otp))}
+        onBlur={() => setFieldErrorKey(validateCode(otp))}
         disabled={isSubmitting}
         className="maxw-full"
-        {...(fieldError ? { error: fieldError } : {})}
+        {...(fieldErrorKey ? { error: tValidation(fieldErrorKey) } : {})}
       />
 
       {/* Confirm button */}

--- a/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.tsx
@@ -55,14 +55,16 @@ export function CardSelection({ confirmPath = 'select/confirm' }: CardSelectionP
   const { data, isLoading, isError } = useHouseholdData()
 
   const [selectedCases, setSelectedCases] = useState<Set<string>>(new Set())
-  const [error, setError] = useState<string | null>(null)
+  // Store the i18n key (not the resolved string) so the error re-translates at render
+  // time when the user switches language (DC-454).
+  const [errorKey, setErrorKey] = useState<string | null>(null)
   const errorRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    if (error) {
+    if (errorKey) {
       errorRef.current?.focus()
     }
-  }, [error])
+  }, [errorKey])
 
   if (isLoading) {
     return <p>{tDev('loading')}</p>
@@ -109,14 +111,14 @@ export function CardSelection({ confirmPath = 'select/confirm' }: CardSelectionP
       }
       return next
     })
-    setError(null)
+    setErrorKey(null)
   }
 
   function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
 
     if (selectedCases.size === 0) {
-      setError(tCommon('helperSelectAtLeastOne'))
+      setErrorKey('helperSelectAtLeastOne')
       return
     }
 
@@ -136,14 +138,14 @@ export function CardSelection({ confirmPath = 'select/confirm' }: CardSelectionP
       <fieldset
         className="usa-fieldset"
         aria-label={tOptional('labelSelectCards')}
-        aria-describedby={error ? 'card-selection-error' : undefined}
+        aria-describedby={errorKey ? 'card-selection-error' : undefined}
       >
         <legend className="usa-legend">
           {tOptional('labelSelectCards')}
           <span className="text-secondary-dark"> *</span>
         </legend>
 
-        {error && (
+        {errorKey && (
           <span
             ref={errorRef}
             id="card-selection-error"
@@ -151,7 +153,7 @@ export function CardSelection({ confirmPath = 'select/confirm' }: CardSelectionP
             role="alert"
             tabIndex={-1}
           >
-            {error}
+            {tCommon(errorKey)}
           </span>
         )}
 

--- a/src/SEBT.Portal.Web/src/features/cards/components/ConfirmAddress/ConfirmAddress.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/ConfirmAddress/ConfirmAddress.test.tsx
@@ -1,7 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { i18n } from '@sebt/design-system/client'
+
+import amDcValidation from '@/content/locales/am/dc/validation.json'
+import enDcValidation from '@/content/locales/en/dc/validation.json'
+import esDcValidation from '@/content/locales/es/dc/validation.json'
 import type { Address, SummerEbtCase } from '@/features/household/api/schema'
 
 import { ConfirmAddress } from './ConfirmAddress'
@@ -69,6 +74,14 @@ describe('ConfirmAddress', () => {
     mockState = 'dc'
   })
 
+  // The i18n instance is a shared singleton; reset to English so sibling tests
+  // (which assume English labels) aren't affected by a lingering Spanish switch.
+  afterEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage('en')
+    })
+  })
+
   it('renders child name subtitle for DC', () => {
     renderConfirmAddress()
     expect(screen.getByText(/Replace Sophia Martinez/)).toBeInTheDocument()
@@ -109,6 +122,26 @@ describe('ConfirmAddress', () => {
     await user.click(screen.getByRole('button', { name: /continue/i }))
 
     expect(mockPush).toHaveBeenCalledWith('/cards/replace/address?case=SEBT-001')
+  })
+
+  it('re-translates the selection error across all DC languages, without resubmitting (DC-454)', async () => {
+    const { user } = renderConfirmAddress()
+
+    await user.click(screen.getByRole('button', { name: /continue/i }))
+    // Scope to the alert: in Spanish/Amharic the legend (common:selectOne) and the error
+    // (validation:selectOption) can render as the same text, so a free-text query would match
+    // multiple elements. toHaveTextContent substring-matches within the alert only.
+    expect(await screen.findByRole('alert')).toHaveTextContent(enDcValidation.selectOption)
+
+    await act(async () => {
+      await i18n.changeLanguage('es')
+    })
+    expect(await screen.findByRole('alert')).toHaveTextContent(esDcValidation.selectOption)
+
+    await act(async () => {
+      await i18n.changeLanguage('am')
+    })
+    expect(await screen.findByRole('alert')).toHaveTextContent(amDcValidation.selectOption)
   })
 
   it('navigates back when back button is clicked', async () => {

--- a/src/SEBT.Portal.Web/src/features/cards/components/ConfirmAddress/ConfirmAddress.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/ConfirmAddress/ConfirmAddress.tsx
@@ -28,14 +28,16 @@ export function ConfirmAddress({
   const router = useRouter()
 
   const [selection, setSelection] = useState<'yes' | 'no' | null>(null)
-  const [error, setError] = useState<string | null>(null)
+  // Store the i18n key (not the resolved string) so the error re-translates at render
+  // time when the user switches language (DC-454).
+  const [errorKey, setErrorKey] = useState<string | null>(null)
   const errorRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    if (error) {
+    if (errorKey) {
       errorRef.current?.focus()
     }
-  }, [error])
+  }, [errorKey])
 
   const currentState = getState()
   const childName =
@@ -53,7 +55,7 @@ export function ConfirmAddress({
     e.preventDefault()
 
     if (selection === null) {
-      setError(t('selectOption'))
+      setErrorKey('selectOption')
       return
     }
 
@@ -94,14 +96,14 @@ export function ConfirmAddress({
       <fieldset
         className="usa-fieldset"
         aria-label={tCommon('selectOne')}
-        aria-describedby={error ? 'confirm-address-error' : undefined}
+        aria-describedby={errorKey ? 'confirm-address-error' : undefined}
       >
         <legend className="usa-legend text-bold">
           {tCommon('selectOne')}
           <span className="text-secondary-dark"> *</span>
         </legend>
 
-        {error && (
+        {errorKey && (
           <span
             ref={errorRef}
             id="confirm-address-error"
@@ -109,7 +111,7 @@ export function ConfirmAddress({
             role="alert"
             tabIndex={-1}
           >
-            {error}
+            {t(errorKey)}
           </span>
         )}
 
@@ -123,7 +125,7 @@ export function ConfirmAddress({
             checked={selection === 'yes'}
             onChange={() => {
               setSelection('yes')
-              setError(null)
+              setErrorKey(null)
             }}
           />
           <label
@@ -144,7 +146,7 @@ export function ConfirmAddress({
             checked={selection === 'no'}
             onChange={() => {
               setSelection('no')
-              setError(null)
+              setErrorKey(null)
             }}
           />
           <label

--- a/src/SEBT.Portal.Web/src/features/cards/components/ConfirmRequest/ConfirmRequest.test.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/ConfirmRequest/ConfirmRequest.test.tsx
@@ -1,12 +1,15 @@
 import { i18n } from '@sebt/design-system/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import amDcDashboard from '@/content/locales/am/dc/dashboard.json'
 import enCoResult from '@/content/locales/en/co/result.json'
+import enDcDashboard from '@/content/locales/en/dc/dashboard.json'
 import enDcResult from '@/content/locales/en/dc/result.json'
+import esDcDashboard from '@/content/locales/es/dc/dashboard.json'
 import type { Address, SummerEbtCase } from '@/features/household/api/schema'
 import { server } from '@/mocks/server'
 import { AnalyticsEvents } from '@sebt/analytics'
@@ -130,6 +133,14 @@ describe('ConfirmRequest', () => {
     i18n.addResourceBundle('en', 'result', enDcResult, true, true)
   })
 
+  // The i18n instance is a shared singleton; reset to English so sibling tests
+  // (which assume English copy) aren't affected by a lingering language switch.
+  afterEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage('en')
+    })
+  })
+
   // --- Content rendering ---
 
   it('renders the state-specific title for DC', () => {
@@ -231,6 +242,30 @@ describe('ConfirmRequest', () => {
     expect(mockSetPageData).toHaveBeenCalledWith('error_code', 'INVALID_INPUT')
     expect(mockTrackEvent).toHaveBeenCalledWith(AnalyticsEvents.CARD_REPLACEMENT_SUBMIT)
     expect(mockTrackEvent).toHaveBeenCalledWith(AnalyticsEvents.CARD_REPLACEMENT_ERROR)
+  })
+
+  it('re-translates the submit error across all DC languages, without resubmitting (DC-454)', async () => {
+    server.use(
+      http.post('/api/household/cards/replace', () =>
+        HttpResponse.json({ error: 'Cooldown active' }, { status: 400 })
+      )
+    )
+    const { user } = renderConfirmRequest()
+
+    await user.click(screen.getByRole('button', { name: /order card/i }))
+    expect(await screen.findByText(enDcDashboard.alertCardReplaceError)).toBeInTheDocument()
+
+    // Cycle DC languages with the error on screen — no resubmit. afterEach resets to English.
+    await act(async () => {
+      await i18n.changeLanguage('es')
+    })
+    expect(await screen.findByText(esDcDashboard.alertCardReplaceError)).toBeInTheDocument()
+
+    await act(async () => {
+      await i18n.changeLanguage('am')
+    })
+    expect(await screen.findByText(amDcDashboard.alertCardReplaceError)).toBeInTheDocument()
+    expect(screen.queryByText(enDcDashboard.alertCardReplaceError)).toBeNull()
   })
 
   it('sends caseRefs with applicationId/applicationStudentId from each case', async () => {

--- a/src/SEBT.Portal.Web/src/features/cards/components/ConfirmRequest/ConfirmRequest.tsx
+++ b/src/SEBT.Portal.Web/src/features/cards/components/ConfirmRequest/ConfirmRequest.tsx
@@ -27,7 +27,9 @@ export function ConfirmRequest({ cases, address, onBack }: ConfirmRequestProps) 
   const currentState = getState()
   const mutation = useRequestCardReplacement()
   const { setPageData, trackEvent } = useDataLayer()
-  const [error, setError] = useState<string | null>(null)
+  // Store the i18n key (not the resolved string) so the banner re-translates at render
+  // time when the user switches language (DC-454).
+  const [errorKey, setErrorKey] = useState<string | null>(null)
 
   const caseRefs = cases
     .filter((c): c is SummerEbtCase & { summerEBTCaseID: string } => c.summerEBTCaseID != null)
@@ -38,7 +40,7 @@ export function ConfirmRequest({ cases, address, onBack }: ConfirmRequestProps) 
     }))
 
   function handleSubmit() {
-    setError(null)
+    setErrorKey(null)
     mutation.mutate(
       { caseRefs },
       {
@@ -48,7 +50,7 @@ export function ConfirmRequest({ cases, address, onBack }: ConfirmRequestProps) 
         },
         onError: (err) => {
           trackCardReplacementSubmit({ setPageData, trackEvent }, err)
-          setError(tDashboard('alertCardReplaceError'))
+          setErrorKey('alertCardReplaceError')
         }
       }
     )
@@ -111,12 +113,12 @@ export function ConfirmRequest({ cases, address, onBack }: ConfirmRequestProps) 
         </div>
       </div>
 
-      {error && (
+      {errorKey && (
         <Alert
           variant="error"
           className="margin-top-3"
         >
-          {error}
+          {tDashboard(errorKey)}
         </Alert>
       )}
 


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-454

#### ✍️ Description
When an error or validation message is on screen and the user changes the language, the message now re-translates into the selected language in place, without resubmitting, and reverts if they switch back. Previously it stayed frozen in the language it was generated in, leaving the page partly in one language and partly in another. Errors are now stored as translation keys and resolved at render time across the login, OTP, ID-proofing, address-update, and card-replacement flows, covering English, Spanish, and Amharic. Auth API failures now map to existing translatable messages instead of surfacing raw backend text.

#### 🔗 Links to related PRs
- _None — frontend-only change in this repo._

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

### Priority Review Table

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `src/SEBT.Portal.Web/src/features/address/components/AddressForm/AddressForm.tsx` | `validate()` / `resolveFieldError()` | Low | Med | Med | ns+key descriptor, resolved at render |
| 🟡 | `src/SEBT.Portal.Web/src/features/auth/components/id-proofing/IdProofingForm.tsx` | `validateFields()` / `resolveMsg()` | Low | Med | Med | Msg union; keyed errors, literals kept |
| 🟡 | `src/SEBT.Portal.Web/src/features/auth/components/login/LoginForm.tsx` | `handleSubmit()` catch | Med | Low | Med | API error→generic key; raw msg dropped |
| 🟡 | `src/SEBT.Portal.Web/src/features/auth/components/verify/VerifyOtpForm.tsx` | `handleSubmit()` / `handleResend()` | Med | Med | Med | 401→otpInvalid; raw msg dropped |
| 🟢 | `src/SEBT.Portal.Web/src/features/address/components/ReplacementCardPrompt/ReplacementCardPrompt.tsx` | selection error | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.Web/src/features/cards/components/CardSelection/CardSelection.tsx` | selection error | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.Web/src/features/cards/components/ConfirmAddress/ConfirmAddress.tsx` | selection error | Low | Low | Low | |
| 🟢 | `src/SEBT.Portal.Web/src/features/cards/components/ConfirmRequest/ConfirmRequest.tsx` | mutation `onError` | Low | Low | Low | |
| 🟢 | 6 `*.test.tsx` (login, verify, id-proofing, AddressForm, ConfirmRequest, ConfirmAddress) | language-flip tests | Low | Low | Low | assert en/es/am |

---

## Coverage & content gaps

**What was addressed (code).** One pattern everywhere: store the i18n key in component state instead of the resolved string, and resolve it with `t()` at render. Applied to 8 components — auth (`LoginForm`, `VerifyOtpForm`, `IdProofingForm`), address (`AddressForm`, `ReplacementCardPrompt`), cards (`ConfirmRequest`, `ConfirmAddress`, `CardSelection`). Auth API failures map to existing translatable keys rather than raw backend strings; a wrong/expired OTP maps to the actionable "enter a valid code" copy.

**Content gaps (need keys added to the content source, not code).** The code resolves these at render like everything else; they display the English fallback in every language until the keys exist in Spanish and Amharic:
- `confirmInfo:formErrorSummary` — address-form error-summary heading ("Please correct the errors below.") stays English in Spanish/Amharic. (Screenshot evidence captured during the walkthrough.)
- `idProofing:docVerifyStartError` and `idProofing:docVerifyResubmitError` — document-verification start/retry failure banners.
- `confirmInfo:addressUpdateError` — suggested-address submit failure banner.
- ID-proofing date-of-birth-invalid and "Enter N digits" messages — hardcoded English, no key exists yet.
- Resolved without new content: the OTP resend success message now uses the existing `validation:newCode` key.
