### PR TITLE
Update OTP bypass logic to support non-production environments for DAST testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,17 @@ For states that use phone number as their primary Household ID and OIDC, local d
 
 The resolver then uses this phone for household lookup instead of the one from the JWT or user record. You can still complete the OIDC flow as usual; the phone number used to satisfy MFA may differ from the one the portal uses for lookups.
 
+### OTP Bypass (DAST scanning, non-production only)
+
+To let SEBT's DAST (Dynamic Application Security Testing) scanner exercise the email login flow without receiving a one-time password, the portal can bypass OTP validation for a single, well-known scanner identity. The bypass is gated by **all** of the following criteria — if any one fails, normal OTP validation applies:
+
+1. The `bypass_otp` feature flag is enabled (`FeatureManagement` in `appsettings.json`; defaults to `false`).
+2. The application is running in a **non-production** environment (`ASPNETCORE_ENVIRONMENT` is anything other than `Production`).
+3. The request email matches the scanner-specific address (`OtpBypassSettings.Email`).
+4. (Validation only) The submitted OTP matches the fixed scanner code (`OtpBypassSettings.OtpCode`).
+
+**Never enable `bypass_otp` in production, and never use the scanner email for a real user account.** The settings live in [`OtpBypassSettings`](src/SEBT.Portal.Core/AppSettings/OtpBypassSettings.cs); the gating is enforced in [`OtpController`](src/SEBT.Portal.Api/Controllers/Auth/OtpController.cs).
+
 ### ID Proofing Requirements
 
 The `IdProofingRequirements` config section controls which IAL (Identity Assurance Level) a user needs to view or modify each type of PII. Keys use a `resource+action` format (e.g. `address+view`, `card+write`). Values can be a uniform level (`"IAL1plus"`) or a per-case-type object for granular control. Unconfigured keys default to `IAL1plus` (fail-safe). Users below the view threshold see masked data (e.g. `****` for street addresses); users below the write threshold are blocked from modifications.

--- a/src/SEBT.Portal.Api/Controllers/Auth/OtpController.cs
+++ b/src/SEBT.Portal.Api/Controllers/Auth/OtpController.cs
@@ -48,7 +48,7 @@ public class OtpController(
         }
 
         var enableOtpBypass = await featureManager.IsEnabledAsync(OtpBypassSettings.FeatureFlagName)
-                && hostEnvironment.IsStaging()
+                && !hostEnvironment.IsProduction()
                 && !string.IsNullOrEmpty(request.Email)
                 && request.Email == OtpBypassSettings.Email;
 
@@ -105,7 +105,7 @@ public class OtpController(
         logger.LogInformation("OTP validation request received for {MaskedEmail}", PiiMasker.MaskEmail(request.Email));
 
         var isOtpByPassEnabled = await featureManager.IsEnabledAsync(OtpBypassSettings.FeatureFlagName)
-                && hostEnvironment.IsStaging()
+                && !hostEnvironment.IsProduction()
                 && !string.IsNullOrEmpty(request.Email)
                 && request.Email == OtpBypassSettings.Email
                 && request.Otp == OtpBypassSettings.OtpCode;

--- a/src/SEBT.Portal.Core/AppSettings/OtpBypassSettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/OtpBypassSettings.cs
@@ -1,8 +1,8 @@
 namespace SEBT.Portal.Core.AppSettings;
 
 /// <summary>
-/// Settings related to bypassing OTP validation for a specific email address in staging environment.
-/// This is intended to facilitate SEBT's DAST scanning in staging, but should be used
+/// Settings related to bypassing OTP validation for a specific email address in non-production environments.
+/// This is intended to facilitate SEBT's DAST scanning, but should be used
 /// with caution and should never be enabled in production or for any real user accounts.
 /// </summary>
 public static class OtpBypassSettings
@@ -15,20 +15,20 @@ public static class OtpBypassSettings
     /// <summary>
     /// Fixed, well-known OTP code used by the DAST scanner to bypass validation.
     /// The value is intentionally predictable; safety is provided by the gating criteria
-    /// (feature flag + staging environment + scanner-specific email).
+    /// (feature flag + non-production environment + scanner-specific email).
     /// </summary>
     public static readonly string OtpCode = "123456";
 
     /// <summary>
     /// Feature flag name to enable OTP bypass. When enabled, requests that meet the bypass criteria will skip OTP validation.
-    /// This should only be enabled in staging and should never be enabled in production.
+    /// This should only be enabled in non-production environments and should never be enabled in production.
     /// The bypass criteria are:
     /// 1. The feature flag named by <see cref="FeatureFlagName"/> is enabled
-    /// 2. The application is running in the staging environment
+    /// 2. The application is running in a non-production environment
     /// 3. The email in the request matches <see cref="Email"/>
     /// 4. The OTP code in the request matches <see cref="OtpCode"/>
     /// When all criteria are met, OTP validation will be bypassed, allowing testing of the login flow without needing to receive an OTP.
-    /// This is intended to facilitate SEBT's DAST scanning in staging, but should be used with caution and should never be enabled in production or for any real user accounts.
+    /// This is intended to facilitate SEBT's DAST scanning, but should be used with caution and should never be enabled in production or for any real user accounts.
     /// </summary>
     public static readonly string FeatureFlagName = "bypass_otp";
 }

--- a/test/SEBT.Portal.Tests/Unit/Controllers/OtpControllerTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Controllers/OtpControllerTests.cs
@@ -224,12 +224,14 @@ public class OtpControllerTests
 
     #region RequestOtp bypass decision tests
 
-    [Fact]
-    public async Task RequestOtp_WhenBypassEnabled_AndStaging_AndMatchingEmail_SetsCommandBypassTrue()
+    [Theory]
+    [InlineData("Staging")]
+    [InlineData("Development")]
+    public async Task RequestOtp_WhenBypassEnabled_AndNonProduction_AndMatchingEmail_SetsCommandBypassTrue(string environmentName)
     {
         // Arrange
         _featureManager.IsEnabledAsync(OtpBypassSettings.FeatureFlagName).Returns(true);
-        _hostEnvironment.EnvironmentName.Returns("Staging");
+        _hostEnvironment.EnvironmentName.Returns(environmentName);
 
         var request = new RequestOtpApiRequest(OtpBypassSettings.Email);
         var handlerMock = Substitute.For<ICommandHandler<RequestOtpCommand>>();
@@ -261,7 +263,7 @@ public class OtpControllerTests
     }
 
     [Fact]
-    public async Task RequestOtp_WhenBypassEnabled_AndStaging_ButWrongEmail_SetsCommandBypassFalse()
+    public async Task RequestOtp_WhenBypassEnabled_AndNonProduction_ButWrongEmail_SetsCommandBypassFalse()
     {
         // Arrange
         _featureManager.IsEnabledAsync(OtpBypassSettings.FeatureFlagName).Returns(true);
@@ -300,12 +302,14 @@ public class OtpControllerTests
 
     #region ValidateOtp bypass decision tests
 
-    [Fact]
-    public async Task ValidateOtp_WhenBypassEnabled_AndStaging_AndMatchingEmail_SetsCommandBypassTrue()
+    [Theory]
+    [InlineData("Staging")]
+    [InlineData("Development")]
+    public async Task ValidateOtp_WhenBypassEnabled_AndNonProduction_AndMatchingEmail_SetsCommandBypassTrue(string environmentName)
     {
         // Arrange
         _featureManager.IsEnabledAsync(OtpBypassSettings.FeatureFlagName).Returns(true);
-        _hostEnvironment.EnvironmentName.Returns("Staging");
+        _hostEnvironment.EnvironmentName.Returns(environmentName);
 
         var request = new ValidateOtpApiRequest(OtpBypassSettings.Email, OtpBypassSettings.OtpCode);
         var handlerMock = Substitute.For<ICommandHandler<ValidateOtpCommand, string>>();
@@ -337,7 +341,7 @@ public class OtpControllerTests
     }
 
     [Fact]
-    public async Task ValidateOtp_WhenBypassEnabled_AndStaging_ButWrongEmail_SetsCommandBypassFalse()
+    public async Task ValidateOtp_WhenBypassEnabled_AndNonProduction_ButWrongEmail_SetsCommandBypassFalse()
     {
         // Arrange
         _featureManager.IsEnabledAsync(OtpBypassSettings.FeatureFlagName).Returns(true);


### PR DESCRIPTION
---
title: "Expand OTP bypass to work in all non-production environments"
---

#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-546

#### ✍️ Description
Update the environment check so the bypass works in any non-production environment (still behind the feature flag)

FYI: Changes in Settings class are comments only

#### ✅ Completion tasks
Tested by validating the email bypass fails in production and is enabled in Development or Staging

- [x ] Updated relevant tests
- [ x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
