### PR TITLE
Add dev-only WAF allow rule for AWS Security Agent pentest

### DIFF
--- a/tofu/modules/sebt_application/locals.tf
+++ b/tofu/modules/sebt_application/locals.tf
@@ -12,4 +12,22 @@ locals {
     database-error = module.database.log_group_names["error"]
     database-agent = module.database.log_group_names["agent"]
   }
+
+  # Allow the AWS Security Agent penetration test to bypass the WAF in the
+  # development environment by matching its unique User-Agent. "allow" is a
+  # terminating action, so matching requests skip all subsequent rules
+  # (including rate limiting). Remove this once the engagement is complete.
+  security_agent_waf_rules = var.environment == "development" && var.security_agent_user_agent != "" ? {
+    security_agent = {
+      paths = [{ constraint = "STARTS_WITH", path = "/" }]
+      criteria = [{
+        type       = "byte"
+        field      = "header"
+        name       = "user-agent"
+        constraint = "EXACTLY"
+        value      = var.security_agent_user_agent
+      }]
+      action = "allow"
+    }
+  } : {}
 }

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -212,6 +212,11 @@ module "cloudfront_waf" {
   passive        = var.passive_waf
   hosted_zone_id = var.hosted_zone_id
 
+  # AWS Security Agent penetration test bypass (development only). Evaluated
+  # before the rate-limit rule so the test's traffic is allowed and terminating.
+  webhooks          = local.security_agent_waf_rules
+  webhooks_priority = 1
+
   rate_limit_rules = var.rate_limit_requests > 0 ? {
     base = {
       action   = var.passive_waf ? "count" : "block"

--- a/tofu/modules/sebt_application/variables.tf
+++ b/tofu/modules/sebt_application/variables.tf
@@ -127,6 +127,20 @@ variable "rate_limit_window" {
   default     = 60
 }
 
+variable "security_agent_user_agent" {
+  type        = string
+  description = <<-EOT
+    User-Agent value used by the AWS Security Agent penetration test. When set in
+    the development environment, requests with this User-Agent are allowed
+    through the WAF and bypass all subsequent rules. Leave empty to disable.
+
+    SECURITY: User-Agent is trivially spoofable and is recorded in WAF/ALB logs,
+    so anyone who learns this value can bypass the WAF. The dev-only guard lives
+    in locals.tf; clear this value once the engagement is complete.
+    EOT
+  default     = "securityagent-0609137"
+}
+
 variable "sender_email" {
   type        = string
   description = "Email address used as the sender for OTP emails."


### PR DESCRIPTION
#### ✍️ Description
Adds a development-only AWS WAF allow rule so the AWS Security Agent penetration test can reach the portal without being blocked by the CloudFront WAF.

When `security_agent_user_agent` is set **and** `environment == "development"`, the `sebt_application` module adds a webhook rule group (priority `1`, ahead of the rate-limit rule and the AWS managed rule groups) that matches requests whose `User-Agent` header exactly equals the configured value. The action is `allow`, a terminating action in WAFv2, so matching requests bypass all subsequent rules.

Implementation mirrors the pattern in [work-requirements-self-advocacy-tool-infra#94](https://github.com/codeforamerica/work-requirements-self-advocacy-tool-infra/pull/94):
- `tofu/modules/sebt_application/variables.tf` — new `security_agent_user_agent` variable (default `securityagent-0609137`).
- `tofu/modules/sebt_application/locals.tf` — `security_agent_waf_rules` local, gated to the development environment.
- `tofu/modules/sebt_application/main.tf` — wires `webhooks` + `webhooks_priority = 1` into the `cloudfront_waf` module.

Applies to both `dev-dc` and `dev-co` (both pass `environment = "development"`); there is no prod config in this `tofu/` tree and the guard fail-closes otherwise.

> ⚠️ **Security note:** `User-Agent` is trivially spoofable and is written to WAF/ALB logs, so anyone who learns this value can bypass the dev WAF. This is intentionally scoped to dev and should be cleared (set `security_agent_user_agent = ""`) once the engagement ends. Note both dev environments currently run `passive_waf = true` (WAF counts, doesn't block) — flip to active if the test needs to verify blocking behavior.

`tofu validate` and `tofu fmt` pass.

#### 🔗 Links to related PRs
- Pattern reference: https://github.com/codeforamerica/work-requirements-self-advocacy-tool-infra/pull/94

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)