### PR TITLE
Consolidate NuGet package bumps (10.0.8 to 10.0.9, nuget-license 4.0.11)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nuget-license": {
-      "version": "4.0.9",
+      "version": "4.0.11",
       "commands": [
         "nuget-license"
       ],

--- a/scripts/ClearSeededData/ClearSeededData.csproj
+++ b/scripts/ClearSeededData/ClearSeededData.csproj
@@ -7,10 +7,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
+++ b/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj
@@ -93,7 +93,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SEBT.Portal.Core/SEBT.Portal.Core.csproj
+++ b/src/SEBT.Portal.Core/SEBT.Portal.Core.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <ProjectReference Include="../SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj" />
     </ItemGroup>
 

--- a/src/SEBT.Portal.Infrastructure.Seeding/SEBT.Portal.Infrastructure.Seeding.csproj
+++ b/src/SEBT.Portal.Infrastructure.Seeding/SEBT.Portal.Infrastructure.Seeding.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     </ItemGroup>
 
 </Project>

--- a/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
+++ b/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
@@ -27,21 +27,21 @@
       <PackageReference Include="DistributedLock.Redis" Version="1.1.1" />
       <PackageReference Include="DistributedLock.SqlServer" Version="1.0.7" />
       <PackageReference Include="MailKit" Version="4.16.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
       <PackageReference Include="Bogus" Version="35.6.5" />
       <PackageReference Include="libphonenumber-csharp" Version="9.0.30" />
-      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
       <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     </ItemGroup>

--- a/src/SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj
+++ b/src/SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj
@@ -11,8 +11,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     </ItemGroup>
 
 </Project>

--- a/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
+++ b/src/SEBT.Portal.UseCases/SEBT.Portal.UseCases.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
       <PackageReference Include="DistributedLock.Core" Version="1.0.9" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
       <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
     </ItemGroup>
 

--- a/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -20,11 +20,11 @@
         <PackageReference Include="coverlet.collector" Version="10.0.1" />
         <PackageReference Include="DistributedLock.Redis" Version="1.1.1" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
         <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />


### PR DESCRIPTION
#### Jira ticket
N/A, these are just Dependabot upgrades.

#### Description

Consolidates four open Dependabot NuGet PRs into a single branch to reduce review and merge overhead.

Supersedes:
- #418 - Microsoft.EntityFrameworkCore 10.0.8 to 10.0.9
- #419 - Microsoft.Extensions.Configuration.Abstractions 10.0.8 to 10.0.9
- #421 - Microsoft.Extensions.DependencyInjection.Abstractions and Microsoft.Extensions.Logging.Abstractions 10.0.8 to 10.0.9
- #422 - nuget-license 4.0.9 to 4.0.11

#### Links to related PRs
- Closes/supersedes: #418, #419, #421, #422

#### Completion tasks

- [x] Added relevant tests - N/A (dependency-only bump); existing suite run locally
- [ ] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu - N/A
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager - N/A
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig - N/A
  - [x] If appsetttings are changed, update in AWS AppConfig - N/A

Test plan (local):
- [x] pnpm api:build - passed
- [x] pnpm api:test - 1419 passed, 2 skipped, 0 failed