### PR TITLE
DO NOT MERGE: Fix CO mock phone lookup and add card replacement mock

### DIFF
--- a/src/SEBT.Portal.Api/Composition/Defaults/MockCardReplacementService.cs
+++ b/src/SEBT.Portal.Api/Composition/Defaults/MockCardReplacementService.cs
@@ -1,0 +1,19 @@
+using SEBT.Portal.StatesPlugins.Interfaces;
+using SEBT.Portal.StatesPlugins.Interfaces.Models.Household;
+
+namespace SEBT.Portal.Api.Composition.Defaults;
+
+/// <summary>
+/// Mock implementation of the card replacement plugin for development/testing.
+/// Used when UseMockHouseholdData is enabled so that card replacement requests
+/// succeed without calling the real state backend.
+/// </summary>
+internal class MockCardReplacementService : ICardReplacementService
+{
+    public Task<CardReplacementResult> RequestCardReplacementAsync(
+        CardReplacementRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(CardReplacementResult.Success());
+    }
+}

--- a/src/SEBT.Portal.Api/Composition/ServiceCollectionPluginExtensions.cs
+++ b/src/SEBT.Portal.Api/Composition/ServiceCollectionPluginExtensions.cs
@@ -141,14 +141,15 @@ internal static class ServiceCollectionPluginExtensions
 
         // When mock household data is enabled, state connector write operations should also
         // be mocked — the real state backend is unavailable. Override any plugin-provided
-        // IAddressUpdateService with an in-memory mock that updates the MockHouseholdRepository
-        // so subsequent reads reflect the change.
+        // write services with in-memory mocks so address updates and card replacement
+        // requests succeed without calling the real state backend.
         var useMockHouseholdData = configuration.GetValue<bool>("UseMockHouseholdData", false);
         if (useMockHouseholdData)
         {
             services.AddSingleton<IAddressUpdateService>(sp =>
                 new Defaults.MockStateAddressUpdateService(
                     sp.GetRequiredService<MockHouseholdRepository>()));
+            services.AddSingleton<ICardReplacementService, Defaults.MockCardReplacementService>();
         }
 
         // Register in-process defaults only for services no connector plugin provided.

--- a/src/SEBT.Portal.Api/appsettings.Development.example.json
+++ b/src/SEBT.Portal.Api/appsettings.Development.example.json
@@ -39,7 +39,7 @@
     "PreferredHouseholdIdTypes": ["Phone"]
   },
   "DevelopmentPhoneOverride": {
-    "Phone": "8185558437"
+    "Phone": "18185558437"
   },
   "DCConnector": {
     "ConnectionString": "Server=localhost,1434;Database=DcSource;User Id=sa;Password=YOUR_PASSWORD;TrustServerCertificate=True;"

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -388,6 +388,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         verified.Email = verifiedEmail;
+        verified.Phone = "17192595068";
         verified.UserProfile = new UserProfile { FirstName = "John", MiddleName = "Robert", LastName = "DoeMOCK" };
         _households[verifiedEmail] = verified;
         IndexByPhone(verified);
@@ -420,6 +421,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         pending.Email = pendingEmail;
+        pending.Phone = "17196627895";
         pending.UserProfile = new UserProfile { FirstName = "Jane", MiddleName = "Marie", LastName = "SmithMOCK" };
         _households[pendingEmail] = pending;
         IndexByPhone(pending);
@@ -436,6 +438,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             }
         });
         denied.Email = deniedEmail;
+        denied.Phone = "17192833113";
         denied.UserProfile = new UserProfile { FirstName = "Robert", MiddleName = null, LastName = "JohnsonMOCK" };
         _households[deniedEmail] = denied;
         IndexByPhone(denied);
@@ -469,6 +472,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         review.Email = reviewEmail;
+        review.Phone = "17197518675";
         review.UserProfile = new UserProfile { FirstName = "Susan", MiddleName = "Lee", LastName = "WilliamsMOCK" };
         _households[reviewEmail] = review;
         IndexByPhone(review);
@@ -555,6 +559,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             }
         });
         cancelled.Email = cancelledEmail;
+        cancelled.Phone = "17207073837";
         cancelled.UserProfile = new UserProfile { FirstName = "David", MiddleName = "James", LastName = "DavisMOCK" };
         _households[cancelledEmail] = cancelled;
         IndexByPhone(cancelled);
@@ -594,6 +599,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         singleChild.Email = singleChildEmail;
+        singleChild.Phone = "17197671993";
         singleChild.UserProfile = new UserProfile { FirstName = "Amanda", MiddleName = "Rose", LastName = "TaylorMOCK" };
         _households[singleChildEmail] = singleChild;
         IndexByPhone(singleChild);
@@ -645,7 +651,7 @@ public class MockHouseholdRepository : IHouseholdRepository
         var minimal = HouseholdFactory.CreateHouseholdDataWithStatus(ApplicationStatus.Pending, h =>
         {
             h.BenefitIssuanceType = BenefitIssuanceType.Unknown;
-            h.Phone = null;
+            h.Phone = "17209289672";
             var app = h.Applications.FirstOrDefault();
             if (app != null)
             {
@@ -685,6 +691,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         expired.Email = expiredEmail;
+        expired.Phone = "17193564665";
         expired.UserProfile = new UserProfile { FirstName = "Patricia", MiddleName = "Ann", LastName = "GarciaMOCK" };
         _households[expiredEmail] = expired;
         IndexByPhone(expired);
@@ -701,6 +708,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             }
         });
         unknown.Email = unknownEmail;
+        unknown.Phone = "17207593371";
         unknown.UserProfile = new UserProfile { FirstName = "Unknown", MiddleName = null, LastName = "UserMOCK" };
         _households[unknownEmail] = unknown;
         IndexByPhone(unknown);

--- a/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
+++ b/src/SEBT.Portal.Infrastructure/Repositories/MockHouseholdRepository.cs
@@ -283,7 +283,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         coLoaded.Email = coLoadedEmail;
-        coLoaded.Phone = "8185558437"; // Matches default DevelopmentPhoneOverride for mock + phone lookup in dev
+        coLoaded.Phone = "18185558437"; // E.164 digits without '+': NormalizePhone strips '+' so PingOne's +18185558437 → 18185558437
         coLoaded.UserProfile = new UserProfile { FirstName = "Maria", MiddleName = "Elena", LastName = "MartinezMOCK" };
         _households[coLoadedEmail] = coLoaded;
         IndexByPhone(coLoaded);
@@ -306,7 +306,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             var coLoadedNoChildren = HouseholdFactory.CreateHouseholdData(h =>
             {
                 h.Email = coLoadedNoChildrenEmail;
-                h.Phone = "8185558439";
+                h.Phone = "18185558439";
                 h.BenefitIssuanceType = BenefitIssuanceType.SnapEbtCard;
                 h.SummerEbtCases = new List<SummerEbtCase>();
                 h.Applications = new List<Application>();
@@ -496,7 +496,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         nonCoLoaded.Email = nonCoLoadedEmail;
-        nonCoLoaded.Phone = "8185558439";
+        nonCoLoaded.Phone = "18185558439";
         nonCoLoaded.UserProfile = new UserProfile { FirstName = "Carlos", MiddleName = "Miguel", LastName = "GarciaMOCK" };
         _households[nonCoLoadedEmail] = nonCoLoaded;
         IndexByPhone(nonCoLoaded);
@@ -506,7 +506,7 @@ public class MockHouseholdRepository : IHouseholdRepository
         var idProofInProgressHousehold = CreateCopy(nonCoLoaded, idProofFullPii) with
         {
             Email = idProofInProgressEmail,
-            Phone = "5552223344"
+            Phone = "15552223344"
         };
         _households[idProofInProgressEmail] = idProofInProgressHousehold;
         IndexByPhone(idProofInProgressHousehold);
@@ -538,7 +538,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         notStarted.Email = notStartedEmail;
-        notStarted.Phone = "8185558440";
+        notStarted.Phone = "18185558440";
         notStarted.UserProfile = new UserProfile { FirstName = "Jordan", MiddleName = "Lee", LastName = "AndersonMOCK" };
         _households[notStartedEmail] = notStarted;
         IndexByPhone(notStarted);
@@ -636,6 +636,7 @@ public class MockHouseholdRepository : IHouseholdRepository
         });
         largeFamily.Email = largeFamilyEmail;
         largeFamily.UserProfile = new UserProfile { FirstName = "Christopher", MiddleName = "Michael", LastName = "BrownMOCK" };
+        largeFamily.Phone = "17198004382";
         _households[largeFamilyEmail] = largeFamily;
         IndexByPhone(largeFamily);
 
@@ -783,7 +784,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         coUndeliverable.Email = coUndeliverableEmail;
-        coUndeliverable.Phone = "3035551005"; // Deterministic phone so CO DevelopmentPhoneOverride can route to this persona in dev
+        coUndeliverable.Phone = "13035551005"; // E.164 digits without '+': matches PingOne's +13035551005 after NormalizePhone stripping
         coUndeliverable.UserProfile = new UserProfile { FirstName = "Sandra", MiddleName = "Maria", LastName = "TorresMOCK" };
         _households[coUndeliverableEmail] = coUndeliverable;
         IndexByPhone(coUndeliverable);
@@ -820,7 +821,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         coFrozen.Email = coFrozenEmail;
-        coFrozen.Phone = "3035551006"; // Deterministic phone so CO DevelopmentPhoneOverride can route to this persona in dev
+        coFrozen.Phone = "13035551006"; // E.164 digits without '+': matches PingOne's +13035551006 after NormalizePhone stripping
         coFrozen.UserProfile = new UserProfile { FirstName = "Miguel", MiddleName = "Angel", LastName = "RiveraMOCK" };
         _households[coFrozenEmail] = coFrozen;
         IndexByPhone(coFrozen);
@@ -859,7 +860,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         coNotActivated.Email = coNotActivatedEmail;
-        coNotActivated.Phone = "3035551007"; // Deterministic phone so CO DevelopmentPhoneOverride can route to this persona in dev
+        coNotActivated.Phone = "13035551007"; // E.164 digits without '+': matches PingOne's +13035551007 after NormalizePhone stripping
         coNotActivated.UserProfile = new UserProfile { FirstName = "Teresa", MiddleName = "Luz", LastName = "MoralesMOCK" };
         _households[coNotActivatedEmail] = coNotActivated;
         IndexByPhone(coNotActivated);
@@ -898,7 +899,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         coDeactivatedByState.Email = coDeactivatedByStateEmail;
-        coDeactivatedByState.Phone = "3035551008"; // Deterministic phone so CO DevelopmentPhoneOverride can route to this persona in dev
+        coDeactivatedByState.Phone = "13035551008"; // E.164 digits without '+': matches PingOne's +13035551008 after NormalizePhone stripping
         coDeactivatedByState.UserProfile = new UserProfile { FirstName = "Ana", MiddleName = "Sol", LastName = "NavarroMOCK" };
         _households[coDeactivatedByStateEmail] = coDeactivatedByState;
         IndexByPhone(coDeactivatedByState);
@@ -939,7 +940,7 @@ public class MockHouseholdRepository : IHouseholdRepository
             };
         });
         coActive.Email = coActiveEmail;
-        coActive.Phone = "3035551009"; // Deterministic phone so CO DevelopmentPhoneOverride can route to this persona in dev
+        coActive.Phone = "13035551009"; // E.164 digits without '+': matches PingOne's +13035551009 after NormalizePhone stripping
         coActive.UserProfile = new UserProfile { FirstName = "Lorena", MiddleName = "Paz", LastName = "OrtizMOCK" };
         _households[coActiveEmail] = coActive;
         IndexByPhone(coActive);


### PR DESCRIPTION
## Summary

- **Fix phone lookup in mock repo**: all mock phone numbers updated to E.164 digit format (e.g. `13035551009`) so `NormalizePhone` produces a key matching what PingOne sends (`+13035551009` → strips `+` → `13035551009`). Root cause was 10-digit stored keys never matching 11-digit lookup keys from real OIDC tokens.
- **Mock card replacement**: added `MockCardReplacementService` (returns `Success()`) registered alongside `MockStateAddressUpdateService` when `UseMockHouseholdData=true`, so card replacement no longer falls through to `DefaultCardReplacementService` which errors with `NOT_CONFIGURED`.
- **Phone coverage**: added PingOne test account phones to all remaining CO mock personas.

> ⚠️ **DO NOT MERGE** — draft for testing in progress.

## Test plan

- [ ] `UseMockHouseholdData=true`, remove `DevelopmentPhoneOverride`, log in with a CO PingOne test account — household resolves correctly via phone
- [ ] Card replacement flow completes successfully in mock mode without hitting CBMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)