### PR TITLE
[DC-395] Document configurable CBMS match-confidence threshold for CO

### DIFF
--- a/src/SEBT.Portal.Api/appsettings.co.example.json
+++ b/src/SEBT.Portal.Api/appsettings.co.example.json
@@ -7,6 +7,10 @@
     "ApiBaseUrl": "https://test-ch2-api.state.co.us/ext-uat-c-cbms-cfa-eapi/api",
     "TokenEndpointUrl": "https://test-ch2-api.state.co.us/ext-uat-c-cbms-oauth-app/token",
     "Return404ForGetAccountDetails": false,
+    // Minimum CBMS match confidence (mtchCnfd, 0-100) a row must EXCEED to be eligible for a Match
+    // in the CO enrollment checker (strict greater-than). Defaults to 90.0 when unset; tunable per
+    // environment and editable at runtime via AWS AppConfig.
+    "MatchConfidenceThreshold": 90.0,
     // Values below match the in-code defaults in CbmsHouseholdCacheOptions; configurable per-environment.
     "Cache": {
       "SoftExpirationMinutes": 15,

--- a/src/SEBT.Portal.Api/appsettings.co.example.json
+++ b/src/SEBT.Portal.Api/appsettings.co.example.json
@@ -8,8 +8,9 @@
     "TokenEndpointUrl": "https://test-ch2-api.state.co.us/ext-uat-c-cbms-oauth-app/token",
     "Return404ForGetAccountDetails": false,
     // Minimum CBMS match confidence (mtchCnfd, 0-100) a row must EXCEED to be eligible for a Match
-    // in the CO enrollment checker (strict greater-than). Defaults to 90.0 when unset; tunable per
-    // environment and editable at runtime via AWS AppConfig.
+    // in the CO enrollment checker (strict greater-than). Defaults to 90.0 when unset; a value
+    // outside 0-100 is rejected (the connector throws) so a typo can't silently skew matching.
+    // Tunable per environment and editable at runtime via AWS AppConfig.
     "MatchConfidenceThreshold": 90.0,
     // Values below match the in-code defaults in CbmsHouseholdCacheOptions; configurable per-environment.
     "Cache": {


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-395

#### ✍️ Description
Companion to the CO connector PR for DC-395. Documents the new `Cbms:MatchConfidenceThreshold` appsetting (default `90.0`) in `appsettings.co.example.json`, so the Colorado Enrollment Checker's minimum match-confidence is discoverable and tunable per environment. The connector reads this key from the portal's merged configuration; when unset it defaults to `90.0`, so this PR is documentation-only with no behavior change.

#### 🔗 Links to related PRs
- CO connector (implements the configurable threshold): https://github.com/codeforamerica/sebt-self-service-portal-co-connector/pull/50

#### ✅ Completion tasks
- [ ] Added relevant tests — N/A (config documentation; tests live in the connector PR)
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu — N/A
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — N/A
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — added to `appsettings.co.example.json`; ⚠️ no AppConfig change required (90.0 default preserves behavior) — set in CO AppConfig only to tune
  - [x] If appsettings are changed, update in AWS AppConfig — only when overriding the default
