### PR TITLE
Grant the github_actions deploy user elasticache permissions

### DIFF
--- a/tofu/config/dev-co/bootstrap/main.tf
+++ b/tofu/config/dev-co/bootstrap/main.tf
@@ -28,6 +28,7 @@ resource "aws_iam_policy" "github_actions" {
           "ec2:*",
           "ecr:*",
           "ecs:*",
+          "elasticache:*",
           "elasticloadbalancing:*",
           "iam:*",
           "kms:*",

--- a/tofu/config/dev-dc/bootstrap/main.tf
+++ b/tofu/config/dev-dc/bootstrap/main.tf
@@ -28,6 +28,7 @@ resource "aws_iam_policy" "github_actions" {
           "ec2:*",
           "ecr:*",
           "ecs:*",
+          "elasticache:*",
           "elasticloadbalancing:*",
           "iam:*",
           "kms:*",


### PR DESCRIPTION
#### 🔗 Jira ticket
DC-528 follow up

#### ✍️ Description
The Redis module added in #433 (DC-528) introduced a new AWS service `ElastiCache`
but the CI deploy user's IAM policy was never granted access to it. As a result,
`deploy-ecr`'s `tofu apply` failed in both `deploy-dc` and `deploy-co` with:

> AccessDenied: User ...github-actions is not authorized to perform:
> elasticache:CreateCacheSubnetGroup ... no identity-based policy allows the action

This adds `elasticache:*` to the `github_actions` deployment policy in both the
`dev-co` and `dev-dc` bootstrap configs, consistent with the existing `service:*`
allowlist style.
