### PR TITLE
Scale CO back up to 2 containers

### DIFF
--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -114,7 +114,7 @@ module "app" {
   image_tags_mutable     = true
   enable_execute_command = true
   enable_appconfig       = true
-  desired_containers     = 1
+  desired_containers     = 2
 
   state_api_environment_variables = {
     "Oidc__DiscoveryEndpoint"                        = var.oidc_discovery_endpoint


### PR DESCRIPTION
#### 🔗 Jira ticket
DC-528 follow up

#### ✍️ Description
This PR scales back CO to 2 instances which is what proves adding Redis/ElastiCache to our AWS environments fixed the `missing_session` OIDC errors we were seeing before Redis was deployed.
