### PR TITLE
DC-565 Enable Otel logging log forwarding at the application level

### DIFF
--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -43,26 +43,51 @@ var builder = WebApplication.CreateBuilder(args);
 var useJsonLogs = string.Equals(
     Environment.GetEnvironmentVariable("LOG_FORMAT"), "json", StringComparison.OrdinalIgnoreCase);
 
-var logConfig = new LoggerConfiguration()
-    .ReadFrom.Configuration(builder.Configuration)
-    .Enrich.FromLogContext()
-    .Enrich.WithOtelTracingSpanId()
-    .Enrich.WithPortalUserInfo();
-
-if (useJsonLogs)
+// Shared Serilog configuration, applied to both the bootstrap logger (so configuration
+// providers can log during startup) and the host logger rebuilt once the host is built.
+// Keeping a single definition guarantees the Console sink format is identical in both,
+// so the stdout -> CloudWatch path is unchanged.
+void ConfigureSerilog(LoggerConfiguration configuration)
 {
-    logConfig.WriteTo.Console(new ExpressionTemplate(
-        "{ {date: @t, timestamp: @t, status: @l, level: @l, message: @m, exception: @x, ..@p} }\n"));
-}
-else
-{
-    logConfig.WriteTo.Console(
-        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+    configuration
+        .ReadFrom.Configuration(builder.Configuration)
+        .Enrich.FromLogContext()
+        .Enrich.WithOtelTracingSpanId()
+        .Enrich.WithPortalUserInfo();
+
+    if (useJsonLogs)
+    {
+        configuration.WriteTo.Console(new ExpressionTemplate(
+            "{ {date: @t, timestamp: @t, status: @l, level: @l, message: @m, exception: @x, ..@p} }\n"));
+    }
+    else
+    {
+        configuration.WriteTo.Console(
+            outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
+    }
 }
 
-Log.Logger = logConfig.CreateLogger();
+var bootstrapConfig = new LoggerConfiguration();
+ConfigureSerilog(bootstrapConfig);
 
-builder.Host.UseSerilog();
+// CreateBootstrapLogger (not CreateLogger): produces a logger that works immediately for
+// startup logging AND is reconfigured in place by the UseSerilog(...) call below once the host
+// is built. A plain CreateLogger() would be a final logger that UseSerilog replaces outright,
+// which forfeits the two-stage handoff — the point of a bootstrap logger is a seamless swap
+// with no lost early logs and no window where Log.Logger is stale.
+Log.Logger = bootstrapConfig.CreateBootstrapLogger();
+
+// writeToProviders forwards log events to other registered ILogger providers (in addition to
+// Serilog's own sinks) so the OpenTelemetry logger provider set up in SetupOpenTelemetry can
+// export logs over OTLP. It is enabled ONLY when OTLP log export is turned on (Otel:UseLogExporter
+// =otlp); otherwise it stays false and behavior is identical to a plain UseSerilog(). Serilog does
+// not write to MEL providers by default, and this parameter only exists on the lambda-based
+// UseSerilog overloads — hence the bootstrap-logger pattern above.
+var otlpLogExportEnabled = string.Equals(
+    builder.Configuration["Otel:UseLogExporter"], "otlp", StringComparison.OrdinalIgnoreCase);
+builder.Host.UseSerilog(
+    (context, configuration) => ConfigureSerilog(configuration),
+    writeToProviders: otlpLogExportEnabled);
 builder.SetupOpenTelemetry();
 
 builder.Services.AddHttpContextAccessor();

--- a/src/SEBT.Portal.Api/Program.cs
+++ b/src/SEBT.Portal.Api/Program.cs
@@ -43,51 +43,29 @@ var builder = WebApplication.CreateBuilder(args);
 var useJsonLogs = string.Equals(
     Environment.GetEnvironmentVariable("LOG_FORMAT"), "json", StringComparison.OrdinalIgnoreCase);
 
-// Shared Serilog configuration, applied to both the bootstrap logger (so configuration
-// providers can log during startup) and the host logger rebuilt once the host is built.
-// Keeping a single definition guarantees the Console sink format is identical in both,
-// so the stdout -> CloudWatch path is unchanged.
-void ConfigureSerilog(LoggerConfiguration configuration)
-{
-    configuration
-        .ReadFrom.Configuration(builder.Configuration)
-        .Enrich.FromLogContext()
-        .Enrich.WithOtelTracingSpanId()
-        .Enrich.WithPortalUserInfo();
+var logConfig = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .Enrich.FromLogContext()
+    .Enrich.WithOtelTracingSpanId()
+    .Enrich.WithPortalUserInfo();
 
-    if (useJsonLogs)
-    {
-        configuration.WriteTo.Console(new ExpressionTemplate(
-            "{ {date: @t, timestamp: @t, status: @l, level: @l, message: @m, exception: @x, ..@p} }\n"));
-    }
-    else
-    {
-        configuration.WriteTo.Console(
-            outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
-    }
+if (useJsonLogs)
+{
+    logConfig.WriteTo.Console(new ExpressionTemplate(
+        "{ {date: @t, timestamp: @t, status: @l, level: @l, message: @m, exception: @x, ..@p} }\n"));
+}
+else
+{
+    logConfig.WriteTo.Console(
+        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j}{NewLine}{Exception}");
 }
 
-var bootstrapConfig = new LoggerConfiguration();
-ConfigureSerilog(bootstrapConfig);
-
-// CreateBootstrapLogger (not CreateLogger): produces a logger that works immediately for
-// startup logging AND is reconfigured in place by the UseSerilog(...) call below once the host
-// is built. A plain CreateLogger() would be a final logger that UseSerilog replaces outright,
-// which forfeits the two-stage handoff — the point of a bootstrap logger is a seamless swap
-// with no lost early logs and no window where Log.Logger is stale.
-Log.Logger = bootstrapConfig.CreateBootstrapLogger();
-
-// writeToProviders forwards log events to other registered ILogger providers (in addition to
-// Serilog's own sinks) so the OpenTelemetry logger provider set up in SetupOpenTelemetry can
-// export logs over OTLP. It is enabled ONLY when OTLP log export is turned on (Otel:UseLogExporter
-// =otlp); otherwise it stays false and behavior is identical to a plain UseSerilog(). Serilog does
-// not write to MEL providers by default, and this parameter only exists on the lambda-based
-// UseSerilog overloads — hence the bootstrap-logger pattern above.
-var otlpLogExportEnabled = string.Equals(
-    builder.Configuration["Otel:UseLogExporter"], "otlp", StringComparison.OrdinalIgnoreCase);
-builder.Host.UseSerilog(
-    (context, configuration) => ConfigureSerilog(configuration),
-    writeToProviders: otlpLogExportEnabled);
+Log.Logger = logConfig.CreateLogger();
+builder.Host.UseSerilog((cntx, lc) =>
+    lc.ReadFrom.Configuration(cntx.Configuration)
+        .Enrich.FromLogContext()
+        .Enrich.WithOtelTracingSpanId()
+        .Enrich.WithPortalUserInfo(), writeToProviders: true);
 builder.SetupOpenTelemetry();
 
 builder.Services.AddHttpContextAccessor();

--- a/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
+++ b/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
@@ -25,7 +25,7 @@ internal static class OpenTelemetrySetup
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
-        // Use IConfiguration binding for AspNetCore instrumentation and OTLP Exorter options.
+        // Use IConfiguration binding for AspNetCore instrumentation and OTLP Exporter options.
         builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(configSection.GetSection("AspNetCoreInstrumentation"));
         builder.Services.Configure<OtlpExporterOptions>(configSection.GetSection("OtlpExporter"));
 

--- a/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
+++ b/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AspNetCore;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -7,24 +10,10 @@ using SEBT.Portal.Kernel.Telemetry;
 
 internal static class OpenTelemetrySetup
 {
-    private const string ServiceName = "sebt-portal-api";
+    internal const string ServiceName = "sebt-portal-api";
 
     public static void SetupOpenTelemetry(this WebApplicationBuilder builder)
     {
-        /* 
-         * OTEL Logging is supported by .NET packages, but we are not currently
-         * going to set this up. We're using Serilog for semantic logging, which
-         * writes to stdout -> cloudwatch -> etc.
-         *
-         * If we ever move to OTEL-based logging, we'll set it up here.
-         */
-        // builder.Logging.AddOpenTelemetry(options =>
-        // {
-        //     options.SetResourceBuilder(
-        //         ResourceBuilder.CreateDefault()
-        //             .AddService(ServiceName));
-        // });
-
         var configSection = builder.Configuration.GetSection("Otel");
 
         // Use IConfiguration binding for AspNetCore instrumentation options.
@@ -39,8 +28,59 @@ internal static class OpenTelemetrySetup
             .WithTracing(tracingBuilder => ConfigureTracing(tracingBuilder, configSection))
             .WithMetrics(metricsBuilder => ConfigureMetrics(metricsBuilder, configSection));
 
+        // OTLP log export is opt-in (Otel:UseLogExporter=otlp). When disabled we register no
+        // OpenTelemetry logging provider at all and Serilog runs writeToProviders: false, so the
+        // Serilog -> stdout -> CloudWatch path is completely unaffected by deploying this code.
+        // When enabled, clear the framework's default logger providers first so that — with
+        // Serilog's writeToProviders on — events are forwarded only to the OTLP exporter and are
+        // not also duplicated onto stdout by the default console provider.
+        if (GetConfiguredLogExporter(configSection) == "OTLP")
+        {
+            builder.Logging.ClearProviders();
+            builder.Logging.AddOpenTelemetry(ConfigureLogging);
+        }
+
         builder.Services.AddSingleton<IInstrumentationSource, InstrumentationSource>();
     }
+
+    private static void ConfigureLogging(OpenTelemetryLoggerOptions options)
+    {
+        ConfigureLoggingCommon(options);
+
+        // Endpoint, protocol, and auth headers are supplied by the standard
+        // OTEL_EXPORTER_OTLP_* / OTEL_EXPORTER_OTLP_LOGS_* environment variables, which the
+        // exporter reads by default. This keeps secrets (e.g. an Authorization token) out of
+        // appsettings and lets each environment point logs at its own OTLP target without a
+        // code change.
+        options.AddOtlpExporter();
+    }
+
+    /// <summary>
+    /// Applies the log-exporter-agnostic OpenTelemetry logging options: the shared service
+    /// resource and the record-content flags. Kept separate so the exporter can be swapped
+    /// (e.g. for an in-memory exporter under test) without duplicating this configuration.
+    /// </summary>
+    internal static void ConfigureLoggingCommon(OpenTelemetryLoggerOptions options)
+    {
+        options.SetResourceBuilder(BuildLogsResourceBuilder());
+        options.IncludeScopes = true;
+        options.IncludeFormattedMessage = true;
+    }
+
+    /// <summary>
+    /// Builds the resource that tags every exported log record, using the same
+    /// <see cref="ServiceName"/> as traces and metrics so all three signals correlate.
+    /// </summary>
+    internal static ResourceBuilder BuildLogsResourceBuilder() =>
+        ResourceBuilder.CreateDefault()
+            .AddService(serviceName: ServiceName, serviceInstanceId: Environment.MachineName);
+
+    /// <summary>
+    /// Reads the configured log exporter. Defaults to <c>CONSOLE</c> so OTLP export is strictly
+    /// opt-in and the CloudWatch logging path is never disrupted by merely deploying this code.
+    /// </summary>
+    internal static string GetConfiguredLogExporter(IConfiguration configSection) =>
+        configSection.GetValue("UseLogExporter", defaultValue: "CONSOLE").ToUpperInvariant();
 
     private static void ConfigureTracing(TracerProviderBuilder tracingBuilder, IConfiguration configSection)
     {

--- a/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
+++ b/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
@@ -1,12 +1,14 @@
 using System.Diagnostics.Metrics;
-using Microsoft.Extensions.Logging;
-using OpenTelemetry;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Kernel.Telemetry;
+
+using static SEBT.Portal.Core.AppSettings.OpenTelemetrySettings;
 
 internal static class OpenTelemetrySetup
 {
@@ -14,10 +16,22 @@ internal static class OpenTelemetrySetup
 
     public static void SetupOpenTelemetry(this WebApplicationBuilder builder)
     {
-        var configSection = builder.Configuration.GetSection("Otel");
+        var configSection =
+            builder.Configuration.GetSection(OpenTelemetrySettings.SectionName);
 
-        // Use IConfiguration binding for AspNetCore instrumentation options.
+        builder.Services
+            .AddOptions<OpenTelemetrySettings>()
+            .Bind(configSection)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        // Use IConfiguration binding for AspNetCore instrumentation and OTLP Exorter options.
         builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(configSection.GetSection("AspNetCoreInstrumentation"));
+        builder.Services.Configure<OtlpExporterOptions>(configSection.GetSection("OtlpExporter"));
+
+        // Get the OtelSettings instance from configuration, or use defaults if not present.
+        var otelSettings = configSection
+            .Get<OpenTelemetrySettings>() ?? new OpenTelemetrySettings();
 
         builder.Services.AddOpenTelemetry()
             .ConfigureResource(r => r.AddService(
@@ -25,18 +39,14 @@ internal static class OpenTelemetrySetup
                 serviceInstanceId: Environment.MachineName
             // TODO serviceVersion: ???
             ))
-            .WithTracing(tracingBuilder => ConfigureTracing(tracingBuilder, configSection))
-            .WithMetrics(metricsBuilder => ConfigureMetrics(metricsBuilder, configSection));
+            .WithTracing(tracingBuilder => ConfigureTracing(tracingBuilder, otelSettings))
+            .WithMetrics(metricsBuilder => ConfigureMetrics(metricsBuilder, otelSettings));
 
         // OTLP log export is opt-in (Otel:UseLogExporter=otlp). When disabled we register no
         // OpenTelemetry logging provider at all and Serilog runs writeToProviders: false, so the
         // Serilog -> stdout -> CloudWatch path is completely unaffected by deploying this code.
-        // When enabled, clear the framework's default logger providers first so that — with
-        // Serilog's writeToProviders on — events are forwarded only to the OTLP exporter and are
-        // not also duplicated onto stdout by the default console provider.
-        if (GetConfiguredLogExporter(configSection) == "OTLP")
+        if (otelSettings.UseLogExporter == ExporterKind.Otlp)
         {
-            builder.Logging.ClearProviders();
             builder.Logging.AddOpenTelemetry(ConfigureLogging);
         }
 
@@ -75,14 +85,7 @@ internal static class OpenTelemetrySetup
         ResourceBuilder.CreateDefault()
             .AddService(serviceName: ServiceName, serviceInstanceId: Environment.MachineName);
 
-    /// <summary>
-    /// Reads the configured log exporter. Defaults to <c>CONSOLE</c> so OTLP export is strictly
-    /// opt-in and the CloudWatch logging path is never disrupted by merely deploying this code.
-    /// </summary>
-    internal static string GetConfiguredLogExporter(IConfiguration configSection) =>
-        configSection.GetValue("UseLogExporter", defaultValue: "CONSOLE").ToUpperInvariant();
-
-    private static void ConfigureTracing(TracerProviderBuilder tracingBuilder, IConfiguration configSection)
+    private static void ConfigureTracing(TracerProviderBuilder tracingBuilder, OpenTelemetrySettings otelSettings)
     {
         tracingBuilder
             .AddSource(InstrumentationSource.ActivitySourceName)
@@ -90,17 +93,10 @@ internal static class OpenTelemetrySetup
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation();
 
-        // Note: Switch between OTLP/Console by setting UseTracingExporter in appsettings.json.
-        var tracingExporter = configSection.GetValue("UseTracingExporter", defaultValue: "CONSOLE").ToUpperInvariant();
-
-        switch (tracingExporter)
+        switch (otelSettings.UseTracingExporter)
         {
-            case "OTLP":
-                tracingBuilder.AddOtlpExporter(otlpOptions =>
-                {
-                    // Use IConfiguration directly for Otlp exporter endpoint option.
-                    otlpOptions.Endpoint = new Uri(configSection.GetValue("Otlp:Endpoint", defaultValue: "http://localhost:4317"));
-                });
+            case ExporterKind.Otlp:
+                tracingBuilder.AddOtlpExporter();
                 break;
 
             default:
@@ -109,7 +105,7 @@ internal static class OpenTelemetrySetup
         }
     }
 
-    private static void ConfigureMetrics(MeterProviderBuilder metricsBuilder, IConfigurationSection configSection)
+    private static void ConfigureMetrics(MeterProviderBuilder metricsBuilder, OpenTelemetrySettings otelSettings)
     {
         metricsBuilder
             .AddMeter(InstrumentationSource.MeterName)
@@ -118,12 +114,9 @@ internal static class OpenTelemetrySetup
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation();
 
-        // Note: Switch between Explicit/Exponential by setting HistogramAggregation in appsettings.json
-        var histogramAggregation = configSection.GetValue("HistogramAggregation", defaultValue: "EXPLICIT").ToUpperInvariant();
-
-        switch (histogramAggregation)
+        switch (otelSettings.HistogramAggregation)
         {
-            case "EXPONENTIAL":
+            case HistogramAggregationKind.Exponential:
                 metricsBuilder.AddView(instrument =>
                 {
                     return instrument.GetType().GetGenericTypeDefinition() == typeof(Histogram<>)
@@ -138,16 +131,10 @@ internal static class OpenTelemetrySetup
         }
 
         // Note: Switch between Prometheus/OTLP/Console by setting UseMetricsExporter in appsettings.json.
-        var metricsExporter = configSection.GetValue("UseMetricsExporter", defaultValue: "CONSOLE").ToUpperInvariant();
-
-        switch (metricsExporter)
+        switch (otelSettings.UseMetricsExporter)
         {
-            case "OTLP":
-                metricsBuilder.AddOtlpExporter(otlpOptions =>
-                {
-                    // Use IConfiguration directly for Otlp exporter endpoint option.
-                    otlpOptions.Endpoint = new Uri(configSection.GetValue("Otlp:Endpoint", defaultValue: "http://localhost:4317"));
-                });
+            case ExporterKind.Otlp:
+                metricsBuilder.AddOtlpExporter();
                 break;
             default:
                 metricsBuilder.AddConsoleExporter();

--- a/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
+++ b/src/SEBT.Portal.Api/Telemetry/OpenTelemetrySetup.cs
@@ -8,8 +8,6 @@ using OpenTelemetry.Trace;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Kernel.Telemetry;
 
-using static SEBT.Portal.Core.AppSettings.OpenTelemetrySettings;
-
 internal static class OpenTelemetrySetup
 {
     internal const string ServiceName = "sebt-portal-api";

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -38,7 +38,7 @@
     // OTEL_EXPORTER_OTLP_HEADERS environment variables (keeps the auth token out of config).
     "UseLogExporter": "console",
     "HistogramAggregation": "explicit",
-    "Otlp": {
+    "OtlpExporter": {
       "Endpoint": "http://localhost:4317"
     },
     "AspNetCoreInstrumentation": {

--- a/src/SEBT.Portal.Api/appsettings.json
+++ b/src/SEBT.Portal.Api/appsettings.json
@@ -31,7 +31,12 @@
   "Otel": {
     "UseTracingExporter": "otlp",
     "UseMetricsExporter": "otlp",
-    "UseLogExporter": "otlp",
+    // Log export is opt-in and OFF by default so logs flow only via Serilog -> stdout ->
+    // CloudWatch. To ship logs over OTLP (e.g. to Splunk), set UseLogExporter to "otlp" for the
+    // target environment (env var Otel__UseLogExporter=otlp) and supply the destination via the
+    // standard OTEL_EXPORTER_OTLP_LOGS_ENDPOINT / OTEL_EXPORTER_OTLP_PROTOCOL /
+    // OTEL_EXPORTER_OTLP_HEADERS environment variables (keeps the auth token out of config).
+    "UseLogExporter": "console",
     "HistogramAggregation": "explicit",
     "Otlp": {
       "Endpoint": "http://localhost:4317"

--- a/src/SEBT.Portal.Core/AppSettings/OpenTelemetrySettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/OpenTelemetrySettings.cs
@@ -27,7 +27,7 @@ public class OpenTelemetrySettings
     /// </summary>
     public HistogramAggregationKind HistogramAggregation { get; set; } = HistogramAggregationKind.Explicit;
 
-    public enum ExporterKind { None, Console, Otlp }
-    public enum HistogramAggregationKind { Explicit, Exponential }
-
 }
+
+public enum ExporterKind { None, Console, Otlp }
+public enum HistogramAggregationKind { Explicit, Exponential }

--- a/src/SEBT.Portal.Core/AppSettings/OpenTelemetrySettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/OpenTelemetrySettings.cs
@@ -1,0 +1,48 @@
+
+namespace SEBT.Portal.Core.AppSettings;
+/// <summary>
+/// Represents the "Otel" section of appsettings.json, which configures OpenTelemetry exporters and options.
+/// </summary>
+/// <remarks>
+/// This appsettings section is used by OpenTelemetrySetup to configure the OpenTelemetry SDK. 
+/// It is also used by the OpenTelemetrySetupTests to verify that the appsettings.json configuration is valid and consistent with the SDK's expectations.
+/// </remarks>
+public class OpenTelemetrySettings
+{
+    public const string SectionName = "Otel";
+    /// <summary>
+    /// Gets or sets the kind of exporter to use for tracing. Valid values are "None", "Console", or "Otlp". Default is "Otlp".
+    /// </summary>
+    public ExporterKind UseTracingExporter { get; set; } = ExporterKind.Otlp;
+    /// <summary>
+    /// Gets or sets the kind of exporter to use for metrics. Valid values are "None", "Console", or "Otlp". Default is "Otlp".
+    /// </summary>
+    public ExporterKind UseMetricsExporter { get; set; } = ExporterKind.Otlp;
+    /// <summary>
+    /// Gets or sets the kind of exporter to use for logs. Valid values are "None", "Console", or "Otlp". Default is "Console".
+    /// </summary>
+    public ExporterKind UseLogExporter { get; set; } = ExporterKind.Console;
+    /// <summary>
+    /// Gets or sets the kind of histogram aggregation to use for metrics. Valid values are "Explicit" or "Exponential". Default is "Explicit".
+    /// </summary>
+    public HistogramAggregationKind HistogramAggregation { get; set; } = HistogramAggregationKind.Explicit;
+
+    #region "Nested OpenTelemetry SDK Settings Classes"
+    public OtlpExporterSettings OtlpExporter { get; set; } = new();
+    public AspNetCoreInstrumentationSettings AspNetCoreInstrumentation { get; set; } = new();
+    #endregion
+
+    public class OtlpExporterSettings
+    {
+        public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
+    }
+
+    public class AspNetCoreInstrumentationSettings
+    {
+        public bool RecordException { get; set; } = true;   // binder coerces "true" string -> bool
+    }
+
+    public enum ExporterKind { None, Console, Otlp }
+    public enum HistogramAggregationKind { Explicit, Exponential }
+
+}

--- a/src/SEBT.Portal.Core/AppSettings/OpenTelemetrySettings.cs
+++ b/src/SEBT.Portal.Core/AppSettings/OpenTelemetrySettings.cs
@@ -27,21 +27,6 @@ public class OpenTelemetrySettings
     /// </summary>
     public HistogramAggregationKind HistogramAggregation { get; set; } = HistogramAggregationKind.Explicit;
 
-    #region "Nested OpenTelemetry SDK Settings Classes"
-    public OtlpExporterSettings OtlpExporter { get; set; } = new();
-    public AspNetCoreInstrumentationSettings AspNetCoreInstrumentation { get; set; } = new();
-    #endregion
-
-    public class OtlpExporterSettings
-    {
-        public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
-    }
-
-    public class AspNetCoreInstrumentationSettings
-    {
-        public bool RecordException { get; set; } = true;   // binder coerces "true" string -> bool
-    }
-
     public enum ExporterKind { None, Console, Otlp }
     public enum HistogramAggregationKind { Explicit, Exponential }
 

--- a/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Microsoft.FeatureManagement" Version="4.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
         <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />

--- a/test/SEBT.Portal.Tests/Unit/Api/Telemetry/OpenTelemetrySetupTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Api/Telemetry/OpenTelemetrySetupTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
+using SEBT.Portal.Core.AppSettings;
 
 namespace SEBT.Portal.Tests.Unit.Api.Telemetry;
 
@@ -74,20 +75,29 @@ public class OpenTelemetrySetupTests
     }
 
     [Fact]
-    public void GetConfiguredLogExporter_DefaultsToConsole_SoOtlpIsOptIn()
+    public void UseLogExporter_DefaultsToConsole_SoOtlpIsOptIn()
     {
-        var emptyConfig = new ConfigurationBuilder().Build();
-
-        Assert.Equal("CONSOLE", OpenTelemetrySetup.GetConfiguredLogExporter(emptyConfig));
+        // OTLP log export must be opt-in: with no configuration the CloudWatch/Console path
+        // is left untouched, so a plain OtelSettings instance defaults the log exporter off.
+        Assert.Equal(OpenTelemetrySettings.ExporterKind.Console, new OpenTelemetrySettings().UseLogExporter);
     }
 
     [Fact]
-    public void GetConfiguredLogExporter_SelectsOtlp_WhenConfigured()
+    public void UseLogExporter_BindsToOtlp_WhenConfigured()
     {
+        // Mirrors the binding path in OpenTelemetrySetup.SetupOpenTelemetry: the "Otel" section
+        // is bound onto OtelSettings, and the config binder maps the string case-insensitively
+        // onto the ExporterKind enum.
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?> { ["UseLogExporter"] = "otlp" })
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{OpenTelemetrySettings.SectionName}:{nameof(OpenTelemetrySettings.UseLogExporter)}"] = "otlp",
+            })
             .Build();
 
-        Assert.Equal("OTLP", OpenTelemetrySetup.GetConfiguredLogExporter(config));
+        var settings = config.GetSection(OpenTelemetrySettings.SectionName).Get<OpenTelemetrySettings>();
+
+        Assert.NotNull(settings);
+        Assert.Equal(OpenTelemetrySettings.ExporterKind.Otlp, settings.UseLogExporter);
     }
 }

--- a/test/SEBT.Portal.Tests/Unit/Api/Telemetry/OpenTelemetrySetupTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Api/Telemetry/OpenTelemetrySetupTests.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace SEBT.Portal.Tests.Unit.Api.Telemetry;
+
+/// <summary>
+/// Verifies the OTLP log-export wiring in <see cref="OpenTelemetrySetup"/>: the exporter
+/// is gated off by default (so the CloudWatch/Console path is never disrupted) and, when the
+/// OTel logging pipeline is active, records carry the shared service resource and correlate
+/// with the active trace/span.
+/// </summary>
+public class OpenTelemetrySetupTests
+{
+    [Fact]
+    public void BuildLogsResourceBuilder_TagsRecordsWithServiceName()
+    {
+        var resource = OpenTelemetrySetup.BuildLogsResourceBuilder().Build();
+
+        Assert.Contains(
+            resource.Attributes,
+            attribute => attribute.Key == "service.name"
+                         && (string)attribute.Value == OpenTelemetrySetup.ServiceName);
+    }
+
+    [Fact]
+    public void ConfigureLoggingCommon_EmitsFormattedRecordsToExporter()
+    {
+        var exported = new List<LogRecord>();
+
+        var loggerFactory = LoggerFactory.Create(logging =>
+            logging.AddOpenTelemetry(options =>
+            {
+                // Apply the exact production common config, then swap the OTLP exporter
+                // for an in-memory exporter so we can assert on what would be shipped.
+                OpenTelemetrySetup.ConfigureLoggingCommon(options);
+                options.AddInMemoryExporter(exported);
+            }));
+
+        loggerFactory.CreateLogger("Test").LogInformation("hello otlp");
+        loggerFactory.Dispose();
+
+        var record = Assert.Single(exported);
+        Assert.Equal("hello otlp", record.FormattedMessage);
+    }
+
+    [Fact]
+    public void ConfigureLoggingCommon_CorrelatesRecordsWithActiveTraceSpan()
+    {
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+
+        var exported = new List<LogRecord>();
+
+        var loggerFactory = LoggerFactory.Create(logging =>
+            logging.AddOpenTelemetry(options =>
+            {
+                OpenTelemetrySetup.ConfigureLoggingCommon(options);
+                options.AddInMemoryExporter(exported);
+            }));
+
+        using (var activity = new Activity("test-operation").Start())
+        {
+            loggerFactory.CreateLogger("Test").LogInformation("correlated");
+
+            var record = Assert.Single(exported);
+            Assert.Equal(activity.TraceId, record.TraceId);
+            Assert.Equal(activity.SpanId, record.SpanId);
+        }
+
+        loggerFactory.Dispose();
+    }
+
+    [Fact]
+    public void GetConfiguredLogExporter_DefaultsToConsole_SoOtlpIsOptIn()
+    {
+        var emptyConfig = new ConfigurationBuilder().Build();
+
+        Assert.Equal("CONSOLE", OpenTelemetrySetup.GetConfiguredLogExporter(emptyConfig));
+    }
+
+    [Fact]
+    public void GetConfiguredLogExporter_SelectsOtlp_WhenConfigured()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["UseLogExporter"] = "otlp" })
+            .Build();
+
+        Assert.Equal("OTLP", OpenTelemetrySetup.GetConfiguredLogExporter(config));
+    }
+}

--- a/test/SEBT.Portal.Tests/Unit/Api/Telemetry/OpenTelemetrySetupTests.cs
+++ b/test/SEBT.Portal.Tests/Unit/Api/Telemetry/OpenTelemetrySetupTests.cs
@@ -79,7 +79,7 @@ public class OpenTelemetrySetupTests
     {
         // OTLP log export must be opt-in: with no configuration the CloudWatch/Console path
         // is left untouched, so a plain OtelSettings instance defaults the log exporter off.
-        Assert.Equal(OpenTelemetrySettings.ExporterKind.Console, new OpenTelemetrySettings().UseLogExporter);
+        Assert.Equal(ExporterKind.Console, new OpenTelemetrySettings().UseLogExporter);
     }
 
     [Fact]
@@ -98,6 +98,6 @@ public class OpenTelemetrySetupTests
         var settings = config.GetSection(OpenTelemetrySettings.SectionName).Get<OpenTelemetrySettings>();
 
         Assert.NotNull(settings);
-        Assert.Equal(OpenTelemetrySettings.ExporterKind.Otlp, settings.UseLogExporter);
+        Assert.Equal(ExporterKind.Otlp, settings.UseLogExporter);
     }
 }


### PR DESCRIPTION
## Jira
[DC-565](https://<your-jira>/browse/DC-565)

## Description
Adds **OTLP log export** as an opt-in, config-driven path so logs can be shipped to any OTLP endpoint (e.g. Splunk) alongside the existing pipeline. Follows the same pattern as the existing OTLP tracing/metrics setup.

- **Off by default** (`Otel:UseLogExporter` defaults to `console`) — the Serilog → stdout → CloudWatch path is unchanged. Enable per environment with `Otel__UseLogExporter=otlp`.
- When enabled, the OTel logger provider is registered and Serilog forwards to it via `writeToProviders: true`; `ClearProviders()` ensures events go **only** to OTLP (no duplicate stdout lines).
- Destination/protocol/auth come from the standard `OTEL_EXPORTER_OTLP_LOGS_*` env vars — **no secrets in config**.
- Serilog uses the bootstrap-logger pattern so startup logs are preserved and the console format is identical in both states.

Enabling Splunk in a given environment (setting the env vars + credentials) is a follow-up ops step.

## Related PRs
N/A

## How to test
1. **Unit:** `pnpm claude:api:test:unit --filter "FullyQualifiedName~OpenTelemetrySetupTests"` → 5 green (resource `service.name`, formatted message, trace correlation, default=CONSOLE, otlp selection).
2. **OTLP works (on):** run a local `otel/opentelemetry-collector` (OTLP/HTTP :4318, `debug` exporter), start API with `Otel__UseLogExporter=otlp` + `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` + `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:4318/v1/logs` → collector shows records with `service.name=sebt-portal-api` and `trace_id`/`span_id`.
3. **CloudWatch unaffected (off):** `LOG_FORMAT=json dotnet run` with defaults → stdout JSON (Datadog-reserved `date`/`status`/`message`) is byte-compatible with `main`, one line per event, no OTLP attempts.
4. **No double logging (on):** repeat #2 with `LOG_FORMAT=json`, pipe the API's stdout → each event still appears **exactly once** (validates `ClearProviders`).
5. **Dev deploy:** deploy with defaults → CloudWatch output unchanged; per-request log volume unchanged.

## Checklist
- [ ] Unit tests green (`pnpm claude:api:test:unit`)
- [ ] OTLP export verified against a local collector (on)
- [ ] stdout/CloudWatch format unchanged when off; no duplicate lines when on
- [ ] Clean startup / no OTLP calls when off
- [ ] No secrets in `appsettings*.json` (OTLP auth via `OTEL_EXPORTER_OTLP_*` only)
- [ ] Per-environment enablement documented as the ops step to activate Splunk


[DC-565]: https://codeforamerica.atlassian.net/browse/DC-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ