### PR TITLE
Harden GitHub Actions workflows against script injection

### DIFF
--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -118,9 +118,15 @@ jobs:
 
       - name: Compute image tag
         id: tag
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          if [ -n "${{ inputs.image_tag }}" ]; then
-            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            if [[ ! "$INPUT_IMAGE_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+              echo "::error::Invalid image tag: $INPUT_IMAGE_TAG"
+              exit 1
+            fi
+            echo "tag=${INPUT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -52,6 +52,20 @@ jobs:
         with:
           tofu_version: "1.10.0"
 
+      - name: Validate inputs
+        env:
+          CONFIG: ${{ inputs.config }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [[ ! "$CONFIG" =~ ^[a-z0-9-]+$ ]]; then
+            echo "::error::Invalid config: $CONFIG"
+            exit 1
+          fi
+          if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid image_tag: $IMAGE_TAG"
+            exit 1
+          fi
+
       - name: OpenTofu Init
         working-directory: tofu/config/${{ inputs.config }}
         run: tofu init -upgrade
@@ -59,7 +73,7 @@ jobs:
       - name: OpenTofu Plan
         id: plan
         continue-on-error: true
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
         working-directory: tofu/config/${{ inputs.config }}
-        run: |
-          tofu plan -no-color -input=false \
-            -var="image_tag=${{ inputs.image_tag }}"
+        run: tofu plan -no-color -input=false -var="image_tag=${IMAGE_TAG}"

--- a/.github/workflows/playwright-e2e.yaml
+++ b/.github/workflows/playwright-e2e.yaml
@@ -97,10 +97,26 @@ jobs:
 
       - name: Determine state connector ref
         id: connector-ref
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          BRANCH="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          FALLBACK="${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}"
-          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/sebt-self-service-portal-state-connector.git"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
+            FALLBACK="$BASE_REF"
+          else
+            BRANCH="$REF_NAME"
+            FALLBACK="main"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ ! "$FALLBACK" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH fallback=$FALLBACK"
+            exit 1
+          fi
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"
           if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then
             echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release-iis-dc.yaml
+++ b/.github/workflows/release-iis-dc.yaml
@@ -77,17 +77,21 @@ jobs:
           CONNECTOR_PAT: ${{ secrets.SEBT_CONNECTOR_REPOSITORY_PAT }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then  
-            BRANCH="$HEAD_REF"  
-          else  
-            BRANCH="$REF_NAME"  
-          fi  
-          FALLBACK="main"  
-          REPO_URL="https://x-access-token:${CONNECTOR_PAT}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"  
-          if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then  
-            echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"  
-          else  
-            echo "ref=${FALLBACK}" >> "$GITHUB_OUTPUT"  
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
+          else
+            BRANCH="$REF_NAME"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH"
+            exit 1
+          fi
+          FALLBACK="main"
+          REPO_URL="https://x-access-token:${CONNECTOR_PAT}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"
+          if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then
+            echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${FALLBACK}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine dc-connector ref
@@ -103,6 +107,10 @@ jobs:
             BRANCH="$HEAD_REF"
           else
             BRANCH="$REF_NAME"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH"
+            exit 1
           fi
           FALLBACK="main"
           REPO_URL="https://x-access-token:${CONNECTOR_PAT}@github.com/${REPO_OWNER}/sebt-self-service-portal-dc-connector.git"

--- a/.github/workflows/state-ci.yaml
+++ b/.github/workflows/state-ci.yaml
@@ -31,13 +31,20 @@ jobs:
 
       - name: Discover state configurations
         id: set-matrix
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_STATE: ${{ github.event.inputs.state }}
         run: |
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="$REF_NAME"
 
           # Priority 1: Manual workflow_dispatch with specific state
-          if [ -n "${{ github.event.inputs.state }}" ]; then
-            echo "Manual trigger for state: ${{ github.event.inputs.state }}"
-            echo "matrix={\"state\":[\"${{ github.event.inputs.state }}\"]}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_STATE" ]; then
+            if [[ ! "$INPUT_STATE" =~ ^[a-z]{2}$ ]]; then
+              echo "::error::Invalid state code: $INPUT_STATE"
+              exit 1
+            fi
+            echo "Manual trigger for state: $INPUT_STATE"
+            echo "matrix={\"state\":[\"${INPUT_STATE}\"]}" >> $GITHUB_OUTPUT
 
           # Priority 2: Branch name pattern (deploy/STATE or deploy/STATE-feature)
           elif [[ "$BRANCH" =~ ^deploy/([a-z]{2})(-.*)?$ ]]; then
@@ -104,12 +111,27 @@ jobs:
 
       - name: Determine state connector ref
         id: connector-ref
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           # Same-named branch as this run (PR head branch or push branch)
-          BRANCH="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          # Fallback when that branch does not exist in the state connector repo
-          FALLBACK="${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}"
-          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/sebt-self-service-portal-state-connector.git"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
+            FALLBACK="$BASE_REF"
+          else
+            BRANCH="$REF_NAME"
+            FALLBACK="main"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ ! "$FALLBACK" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH fallback=$FALLBACK"
+            exit 1
+          fi
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"
           if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then
             echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
             echo "Using state connector branch: ${BRANCH}"


### PR DESCRIPTION
## Summary
- Pass untrusted GitHub context (`head_ref`, `workflow_dispatch` inputs) through `env:` blocks instead of interpolating directly into `run:` shell scripts
- Add allowlist validation for git refs, state codes, image tags, and tofu config names
- Aligns `state-ci.yaml` and `playwright-e2e.yaml` with the pattern already used in `release-iis-dc.yaml`

Addresses Aikido supply-chain findings for:
- `.github/workflows/state-ci.yaml`
- `.github/workflows/playwright-e2e.yaml`
- `.github/workflows/deploy-ecr.yaml`
- `.github/workflows/plan.yaml`

## Test plan
- [ ] Open a PR from a normal feature branch — State CI and Playwright E2E should still resolve the state-connector ref correctly
- [ ] `workflow_dispatch` deploy with a custom `image_tag` still works (alphanumeric/dots/dashes/underscores only)
- [ ] `workflow_dispatch` State CI with `state=dc` or `state=co` still builds only that state
- [ ] Re-scan in Aikido and confirm findings are resolved

#### 🔗 Jira ticket
N/A — security hygiene / Aikido remediation

#### ✅ Completion tasks
- [x] Added relevant tests — workflow-only change; validation is inline in shell steps
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes: none


Made with [Cursor](https://cursor.com)