### PR TITLE
DC-527(Fix): Address template injection exploit hole in workflows

### DIFF
--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -118,9 +118,15 @@ jobs:
 
       - name: Compute image tag
         id: tag
+        env:
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          if [ -n "${{ inputs.image_tag }}" ]; then
-            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_IMAGE_TAG" ]; then
+            if [[ ! "$INPUT_IMAGE_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+              echo "::error::Invalid image tag: $INPUT_IMAGE_TAG"
+              exit 1
+            fi
+            echo "tag=${INPUT_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -52,6 +52,20 @@ jobs:
         with:
           tofu_version: "1.10.0"
 
+      - name: Validate inputs
+        env:
+          CONFIG: ${{ inputs.config }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [[ ! "$CONFIG" =~ ^[a-z0-9-]+$ ]]; then
+            echo "::error::Invalid config: $CONFIG"
+            exit 1
+          fi
+          if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::Invalid image_tag: $IMAGE_TAG"
+            exit 1
+          fi
+
       - name: OpenTofu Init
         working-directory: tofu/config/${{ inputs.config }}
         run: tofu init -upgrade
@@ -59,7 +73,7 @@ jobs:
       - name: OpenTofu Plan
         id: plan
         continue-on-error: true
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag }}
         working-directory: tofu/config/${{ inputs.config }}
-        run: |
-          tofu plan -no-color -input=false \
-            -var="image_tag=${{ inputs.image_tag }}"
+        run: tofu plan -no-color -input=false -var="image_tag=${IMAGE_TAG}"

--- a/.github/workflows/playwright-e2e.yaml
+++ b/.github/workflows/playwright-e2e.yaml
@@ -97,10 +97,26 @@ jobs:
 
       - name: Determine state connector ref
         id: connector-ref
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          BRANCH="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          FALLBACK="${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}"
-          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/sebt-self-service-portal-state-connector.git"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
+            FALLBACK="$BASE_REF"
+          else
+            BRANCH="$REF_NAME"
+            FALLBACK="main"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ ! "$FALLBACK" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH fallback=$FALLBACK"
+            exit 1
+          fi
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"
           if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then
             echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release-iis-dc.yaml
+++ b/.github/workflows/release-iis-dc.yaml
@@ -77,17 +77,21 @@ jobs:
           CONNECTOR_PAT: ${{ secrets.SEBT_CONNECTOR_REPOSITORY_PAT }}
           REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then  
-            BRANCH="$HEAD_REF"  
-          else  
-            BRANCH="$REF_NAME"  
-          fi  
-          FALLBACK="main"  
-          REPO_URL="https://x-access-token:${CONNECTOR_PAT}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"  
-          if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then  
-            echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"  
-          else  
-            echo "ref=${FALLBACK}" >> "$GITHUB_OUTPUT"  
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
+          else
+            BRANCH="$REF_NAME"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH"
+            exit 1
+          fi
+          FALLBACK="main"
+          REPO_URL="https://x-access-token:${CONNECTOR_PAT}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"
+          if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then
+            echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${FALLBACK}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Determine dc-connector ref
@@ -103,6 +107,10 @@ jobs:
             BRANCH="$HEAD_REF"
           else
             BRANCH="$REF_NAME"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH"
+            exit 1
           fi
           FALLBACK="main"
           REPO_URL="https://x-access-token:${CONNECTOR_PAT}@github.com/${REPO_OWNER}/sebt-self-service-portal-dc-connector.git"

--- a/.github/workflows/state-ci.yaml
+++ b/.github/workflows/state-ci.yaml
@@ -31,13 +31,20 @@ jobs:
 
       - name: Discover state configurations
         id: set-matrix
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_STATE: ${{ github.event.inputs.state }}
         run: |
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="$REF_NAME"
 
           # Priority 1: Manual workflow_dispatch with specific state
-          if [ -n "${{ github.event.inputs.state }}" ]; then
-            echo "Manual trigger for state: ${{ github.event.inputs.state }}"
-            echo "matrix={\"state\":[\"${{ github.event.inputs.state }}\"]}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_STATE" ]; then
+            if [[ ! "$INPUT_STATE" =~ ^[a-z]{2}$ ]]; then
+              echo "::error::Invalid state code: $INPUT_STATE"
+              exit 1
+            fi
+            echo "Manual trigger for state: $INPUT_STATE"
+            echo "matrix={\"state\":[\"${INPUT_STATE}\"]}" >> $GITHUB_OUTPUT
 
           # Priority 2: Branch name pattern (deploy/STATE or deploy/STATE-feature)
           elif [[ "$BRANCH" =~ ^deploy/([a-z]{2})(-.*)?$ ]]; then
@@ -104,12 +111,27 @@ jobs:
 
       - name: Determine state connector ref
         id: connector-ref
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           # Same-named branch as this run (PR head branch or push branch)
-          BRANCH="${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
-          # Fallback when that branch does not exist in the state connector repo
-          FALLBACK="${{ github.event_name == 'pull_request' && github.base_ref || 'main' }}"
-          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/sebt-self-service-portal-state-connector.git"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BRANCH="$HEAD_REF"
+            FALLBACK="$BASE_REF"
+          else
+            BRANCH="$REF_NAME"
+            FALLBACK="main"
+          fi
+          if [[ ! "$BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ ! "$FALLBACK" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Invalid git ref: branch=$BRANCH fallback=$FALLBACK"
+            exit 1
+          fi
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO_OWNER}/sebt-self-service-portal-state-connector.git"
           if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${BRANCH}" 1>/dev/null 2>&1; then
             echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
             echo "Using state connector branch: ${BRANCH}"


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-527](https://codeforamerica.atlassian.net/browse/DC-527)

#### ✍️ Description
Addresses Aikido findings for GitHub Actions script injection in workflow shell steps.

Untrusted GitHub context is no longer interpolated directly into `run: scripts`. This PR changes things to have values being passed through env blocks and validated with allowlists before use, following [GitHub Security Lab](https://docs.github.com/en/actions/reference/security/secure-use) guidance.

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig


[DC-527]: https://codeforamerica.atlassian.net/browse/DC-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ