### PR TITLE
DC-601(Task) Wire PII encryption keys into DC Dev via Tofu / Secrets Manager

### DIFF
--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -70,6 +70,10 @@ module "state_secrets" {
       description     = "Socure API credentials for identity verification."
       recovery_window = 7
     }
+    "pii_encryption" = {
+      description     = "PII encryption key ring for the SEBT Portal API (AES-256-GCM)."
+      recovery_window = 7
+    }
   }
 }
 
@@ -118,8 +122,10 @@ module "app" {
   }
 
   state_api_environment_secrets = {
-    "Socure__ApiKey"        = "${module.state_secrets.secrets["socure"].secret_arn}:api_key"
-    "Socure__WebhookSecret" = "${module.state_secrets.secrets["socure"].secret_arn}:webhook_secret"
+    "Socure__ApiKey"                            = "${module.state_secrets.secrets["socure"].secret_arn}:api_key"
+    "Socure__WebhookSecret"                     = "${module.state_secrets.secrets["socure"].secret_arn}:webhook_secret"
+    "PiiEncryption__Keys__0__KeyId"             = "${module.state_secrets.secrets["pii_encryption"].secret_arn}:key_id"
+    "PiiEncryption__Keys__0__KeyMaterialBase64" = "${module.state_secrets.secrets["pii_encryption"].secret_arn}:key_material_base64"
   }
 
   state_web_environment_variables = {}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-601](https://codeforamerica.atlassian.net/browse/DC-601)

#### ✍️ Description
DC Dev turns on PiiEncryption via AppConfig, but key values never reaches the API container. This work focuses on creating the secrets and mapping it into the ECS task.

This is done in `main.tf` since we'd want to apply for all states (mainly future ones) even though it's currently off for Colorado.  

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig


[DC-601]: https://codeforamerica.atlassian.net/browse/DC-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ