### PR TITLE
[DC-602] Disable household data refetch on window focus

### DIFF
--- a/apps/portal/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.test.tsx
@@ -7,7 +7,7 @@
  * - Custom retry logic (no retry on 4xx, retry on 5xx)
  * - Exponential backoff retry delay
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -355,6 +355,40 @@ describe('useHouseholdData', () => {
       // With staleTime: 0, data should be immediately stale
       const queryState = queryClient.getQueryState(householdDataQueryKey(TEST_USER_ID))
       expect(queryState?.isInvalidated || queryState?.dataUpdatedAt).toBeTruthy()
+    })
+
+    it('does not refetch when the window regains focus', async () => {
+      let fetchCount = 0
+      server.use(
+        http.get('/api/household/data', () => {
+          fetchCount++
+          return HttpResponse.json(TEST_HOUSEHOLD_DATA)
+        })
+      )
+
+      // A bare QueryClient carries React Query's library default of
+      // refetchOnWindowFocus: true, so this pins the hook's own explicit
+      // opt-out rather than the app provider's default.
+      const queryClient = new QueryClient()
+
+      const { result } = renderHook(() => useHouseholdData(), {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        )
+      })
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true)
+      })
+      expect(fetchCount).toBe(1)
+
+      focusManager.setFocused(false)
+      focusManager.setFocused(true)
+
+      // Give any wrongly-triggered refetch time to hit the mock server
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(fetchCount).toBe(1)
+      focusManager.setFocused(undefined)
     })
   })
 

--- a/apps/portal/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
+++ b/apps/portal/src/SEBT.Portal.Web/src/features/household/api/useHouseholdData.ts
@@ -40,7 +40,12 @@ export interface UseHouseholdDataOptions {
 /**
  * Hook to fetch household data for the authenticated user.
  * Uses real-time fetching (staleTime: 0) to ensure data freshness
- * per ticket requirement to mitigate stale household/custody data.
+ * per ticket requirement to mitigate stale household/custody data:
+ * every page mount refetches, so navigation always shows fresh data.
+ * Focus refetches are explicitly disabled — `/household/data` fans out
+ * to state agency APIs, so refetching on every tab switch risks rate
+ * limiting and adds load without a freshness benefit beyond what
+ * mount-time refetches already provide.
  * Query keys include the portal userId so a new login in the same tab
  * cannot render the previous user's cached household.
  *
@@ -64,7 +69,8 @@ export function useHouseholdData({
     enabled: !!userId,
     staleTime: 0,
     gcTime: 5 * 60 * 1000, // 5 minutes for back-navigation
-    refetchOnWindowFocus: true,
+    // Explicit (not just the provider default): focus refetches hit state APIs.
+    refetchOnWindowFocus: false,
     retry: householdRetry,
     retryDelay: householdRetryDelay
   })
@@ -80,7 +86,7 @@ export function useHouseholdData({
     enabled: !!userId && shouldFetchCardDetails,
     staleTime: 0,
     gcTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: false,
     retry: householdRetry,
     retryDelay: householdRetryDelay
   })
@@ -120,7 +126,7 @@ export function useHouseholdData({
   const isRedirecting = query.error instanceof ApiError && query.error.isRedirecting
   const isError = query.isError && !isRedirecting
   const isLoading = query.isLoading || isRedirecting
-  // Initial card fetch only; background refetches (refetchOnWindowFocus) keep showing merged card data.
+  // Initial card fetch only; background refetches keep showing merged card data.
   const isLoadingCardDetails = shouldFetchCardDetails && cardDetailsQuery.isLoading
 
   useEffect(() => {


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-602

#### ✍️ Description
Removes the `refetchOnWindowFocus: true` opt-in from `useHouseholdData` — previously, every tab switch back to the portal fired `/household/data` (twice in Colorado's deferred-card mode), fanning out to state agency APIs and risking rate limiting.

**Investigation findings:**
- The flag dates to the dashboard's original commit (PR #41, DC-85) as part of the initial "always fresh" posture alongside `staleTime: 0`; no later work depends on it.
- Freshness is preserved: `staleTime: 0` + default refetch-on-mount means every page navigation still fetches fresh data, which covers the original custody-staleness requirement.
- The app-wide `QueryProvider` default is already `refetchOnWindowFocus: false`; this hook was the only opt-in.
- Session expiry does not rely on it (`TokenRefresher`/`useSessionRefresh` timers own that). One edge-case change: a session that expires while the user is in another tab now redirects to `/login` on their next interaction rather than instantly on refocus.

Both queries now set `refetchOnWindowFocus: false` explicitly (with a comment on the state-API cost) rather than inheriting the provider default, so the behavior is pinned at the hook even if the provider default changes. A new red-first test flips `focusManager` against a bare `QueryClient` (which carries React Query's library default of `true`) and asserts no refetch occurs.

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig