### PR TITLE
[DC-341] Instrument the web apps with OpenTelemetry

### DIFF
--- a/apps/portal/src/SEBT.EnrollmentChecker.Web/package.json
+++ b/apps/portal/src/SEBT.EnrollmentChecker.Web/package.json
@@ -26,6 +26,7 @@
     "@amplitude/analytics-browser": "^2.40.0",
     "@sebt/analytics": "workspace:*",
     "@sebt/design-system": "workspace:*",
+    "@sebt/observability": "workspace:*",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tanstack/react-query": "^5.100.10",
     "@uswds/uswds": "^3.13.0",

--- a/apps/portal/src/SEBT.EnrollmentChecker.Web/src/instrumentation.node.ts
+++ b/apps/portal/src/SEBT.EnrollmentChecker.Web/src/instrumentation.node.ts
@@ -1,0 +1,11 @@
+/**
+ * Node-runtime OpenTelemetry bootstrap for the enrollment checker server.
+ *
+ * Starts the shared SDK, which emits OTLP to the collector configured via the
+ * standard OTEL_* environment variables. With no endpoint configured it is a
+ * no-op, so this is safe to ship dark and safe to run during a static export
+ * build. The service name can be overridden with OTEL_SERVICE_NAME.
+ */
+import { startOtel } from '@sebt/observability'
+
+startOtel({ defaultServiceName: 'sebt-enrollment-checker-web' })

--- a/apps/portal/src/SEBT.EnrollmentChecker.Web/src/instrumentation.ts
+++ b/apps/portal/src/SEBT.EnrollmentChecker.Web/src/instrumentation.ts
@@ -1,0 +1,17 @@
+/**
+ * Next.js instrumentation hook. `register()` runs once per runtime before any
+ * app code. OpenTelemetry's Node SDK is not compatible with the edge runtime,
+ * so the heavy setup is isolated in instrumentation.node.ts and imported only
+ * when running under Node.
+ *
+ * This app ships in two shapes: an SSR standalone server (where this provides
+ * live server telemetry) and a static export (where there is no server, so
+ * register only runs once at build time and — with no endpoint — is a no-op).
+ *
+ * See https://nextjs.org/docs/app/guides/open-telemetry
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./instrumentation.node')
+  }
+}

--- a/apps/portal/src/SEBT.Portal.Web/Dockerfile
+++ b/apps/portal/src/SEBT.Portal.Web/Dockerfile
@@ -29,6 +29,9 @@ COPY packages/design-system/ ./packages/design-system/
 # Copy analytics workspace package (required by web imports of @sebt/analytics)
 COPY packages/analytics/ ./packages/analytics/
 
+# Copy observability workspace package (required by web imports of @sebt/observability)
+COPY packages/observability/ ./packages/observability/
+
 # Copy web workspace
 COPY apps/portal/src/SEBT.Portal.Web/ ./apps/portal/src/SEBT.Portal.Web/
 

--- a/apps/portal/src/SEBT.Portal.Web/package.json
+++ b/apps/portal/src/SEBT.Portal.Web/package.json
@@ -35,8 +35,10 @@
   "dependencies": {
     "@amplitude/analytics-browser": "^2.42.3",
     "@next/third-parties": "^16.2.6",
+    "@opentelemetry/api": "^1.9.1",
     "@sebt/analytics": "workspace:*",
     "@sebt/design-system": "workspace:*",
+    "@sebt/observability": "workspace:*",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tanstack/react-query": "^5.100.10",
     "@uswds/uswds": "^3.13.0",
@@ -53,6 +55,7 @@
     "@axe-core/react": "^4.11.3",
     "@lhci/cli": "^0.15.1",
     "@next/bundle-analyzer": "^16.2.6",
+    "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@playwright/test": "^1.60.0",
     "@size-limit/file": "^12.1.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/portal/src/SEBT.Portal.Web/src/instrumentation.node.ts
+++ b/apps/portal/src/SEBT.Portal.Web/src/instrumentation.node.ts
@@ -1,0 +1,12 @@
+/**
+ * Node-runtime OpenTelemetry bootstrap for the portal web server.
+ *
+ * Starts the shared SDK, which emits OTLP to the collector configured via the
+ * standard OTEL_* environment variables. With no endpoint configured it is a
+ * no-op, so this is safe to ship dark. The service name can be overridden with
+ * OTEL_SERVICE_NAME; the default below matches the backend's "sebt-portal-api"
+ * naming.
+ */
+import { startOtel } from '@sebt/observability'
+
+startOtel({ defaultServiceName: 'sebt-portal-web' })

--- a/apps/portal/src/SEBT.Portal.Web/src/instrumentation.ts
+++ b/apps/portal/src/SEBT.Portal.Web/src/instrumentation.ts
@@ -1,0 +1,13 @@
+/**
+ * Next.js instrumentation hook. `register()` runs once per runtime before any
+ * app code. OpenTelemetry's Node SDK is not compatible with the edge runtime,
+ * so the heavy setup is isolated in instrumentation.node.ts and imported only
+ * when running under Node.
+ *
+ * See https://nextjs.org/docs/app/guides/open-telemetry
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./instrumentation.node')
+  }
+}

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@sebt/observability",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./src/*": "./src/*"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.6"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.14.4",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.220.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.220.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.220.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.220.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.220.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.220.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
+    "@opentelemetry/instrumentation-undici": "^0.30.0",
+    "@opentelemetry/resources": "^2.9.0",
+    "@opentelemetry/sdk-logs": "^0.220.0",
+    "@opentelemetry/sdk-metrics": "^2.9.0",
+    "@opentelemetry/sdk-node": "^0.220.0",
+    "@opentelemetry/sdk-trace-node": "^2.9.0"
+  }
+}

--- a/packages/observability/src/config.test.ts
+++ b/packages/observability/src/config.test.ts
@@ -28,13 +28,15 @@ describe('resolveOtelConfig', () => {
     expect(config.logs).toBe('otlp')
   })
 
-  it('treats a signal-specific endpoint as enough to default that signal to otlp', () => {
+  it('enables only the signal whose signal-specific endpoint is set', () => {
     const config = resolveOtelConfig(
       { OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: 'http://localhost:4318/v1/traces' },
       options
     )
 
     expect(config.traces).toBe('otlp')
+    expect(config.metrics).toBe('none')
+    expect(config.logs).toBe('none')
   })
 
   it('uses the default service name when OTEL_SERVICE_NAME is unset', () => {

--- a/packages/observability/src/config.test.ts
+++ b/packages/observability/src/config.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildResourceAttributes,
+  isFullyDisabled,
+  resolveOtelConfig,
+  type OtelConfig
+} from './config'
+
+const options = { defaultServiceName: 'sebt-test-web' }
+
+describe('resolveOtelConfig', () => {
+  it('disables every signal when no OTLP endpoint is configured', () => {
+    const config = resolveOtelConfig({}, options)
+
+    expect(config.traces).toBe('none')
+    expect(config.metrics).toBe('none')
+    expect(config.logs).toBe('none')
+  })
+
+  it('defaults every signal to otlp when a general endpoint is set', () => {
+    const config = resolveOtelConfig(
+      { OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318' },
+      options
+    )
+
+    expect(config.traces).toBe('otlp')
+    expect(config.metrics).toBe('otlp')
+    expect(config.logs).toBe('otlp')
+  })
+
+  it('treats a signal-specific endpoint as enough to default that signal to otlp', () => {
+    const config = resolveOtelConfig(
+      { OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: 'http://localhost:4318/v1/traces' },
+      options
+    )
+
+    expect(config.traces).toBe('otlp')
+  })
+
+  it('uses the default service name when OTEL_SERVICE_NAME is unset', () => {
+    expect(resolveOtelConfig({}, options).serviceName).toBe('sebt-test-web')
+  })
+
+  it('prefers OTEL_SERVICE_NAME over the default', () => {
+    const config = resolveOtelConfig({ OTEL_SERVICE_NAME: 'sebt-portal-web' }, options)
+
+    expect(config.serviceName).toBe('sebt-portal-web')
+  })
+
+  it('reads service version and deployment environment when present', () => {
+    const config = resolveOtelConfig(
+      {
+        OTEL_SERVICE_VERSION: '1.2.3',
+        OTEL_DEPLOYMENT_ENVIRONMENT: 'dev-dc'
+      },
+      options
+    )
+
+    expect(config.serviceVersion).toBe('1.2.3')
+    expect(config.deploymentEnvironment).toBe('dev-dc')
+  })
+
+  it('falls back to NODE_ENV for deployment environment', () => {
+    const config = resolveOtelConfig({ NODE_ENV: 'production' }, options)
+
+    expect(config.deploymentEnvironment).toBe('production')
+  })
+
+  it('honors per-signal exporter overrides', () => {
+    const config = resolveOtelConfig(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        OTEL_TRACES_EXPORTER: 'console',
+        OTEL_LOGS_EXPORTER: 'none'
+      },
+      options
+    )
+
+    expect(config.traces).toBe('console')
+    expect(config.metrics).toBe('otlp')
+    expect(config.logs).toBe('none')
+  })
+
+  it('can enable a single signal to the console with no endpoint', () => {
+    const config = resolveOtelConfig({ OTEL_TRACES_EXPORTER: 'console' }, options)
+
+    expect(config.traces).toBe('console')
+    expect(config.metrics).toBe('none')
+    expect(config.logs).toBe('none')
+  })
+
+  it('ignores an unrecognized exporter value and falls back to the default', () => {
+    const config = resolveOtelConfig(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        OTEL_TRACES_EXPORTER: 'nonsense'
+      },
+      options
+    )
+
+    expect(config.traces).toBe('otlp')
+  })
+
+  it('trims and case-folds exporter values and treats blank as unset', () => {
+    const config = resolveOtelConfig(
+      {
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        OTEL_METRICS_EXPORTER: '  Console  ',
+        OTEL_SERVICE_NAME: '   '
+      },
+      options
+    )
+
+    expect(config.metrics).toBe('console')
+    expect(config.serviceName).toBe('sebt-test-web')
+  })
+
+  it('defaults the protocol to grpc (matching the backend)', () => {
+    expect(resolveOtelConfig({}, options).protocol).toBe('grpc')
+  })
+
+  it('selects http/protobuf from OTEL_EXPORTER_OTLP_PROTOCOL (incl. the "http" shorthand)', () => {
+    expect(
+      resolveOtelConfig({ OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf' }, options).protocol
+    ).toBe('http/protobuf')
+    expect(resolveOtelConfig({ OTEL_EXPORTER_OTLP_PROTOCOL: 'http' }, options).protocol).toBe(
+      'http/protobuf'
+    )
+  })
+
+  it('falls back to grpc for an unrecognized protocol', () => {
+    expect(
+      resolveOtelConfig({ OTEL_EXPORTER_OTLP_PROTOCOL: 'carrier-pigeon' }, options).protocol
+    ).toBe('grpc')
+  })
+})
+
+describe('isFullyDisabled', () => {
+  it('is true only when all three signals are none', () => {
+    const base: OtelConfig = {
+      serviceName: 's',
+      protocol: 'grpc',
+      traces: 'none',
+      metrics: 'none',
+      logs: 'none'
+    }
+
+    expect(isFullyDisabled(base)).toBe(true)
+    expect(isFullyDisabled({ ...base, traces: 'otlp' })).toBe(false)
+  })
+})
+
+describe('buildResourceAttributes', () => {
+  it('always includes the service name', () => {
+    const attributes = buildResourceAttributes({
+      serviceName: 'sebt-portal-web',
+      protocol: 'grpc',
+      traces: 'otlp',
+      metrics: 'otlp',
+      logs: 'otlp'
+    })
+
+    expect(attributes['service.name']).toBe('sebt-portal-web')
+  })
+
+  it('omits version and environment when absent', () => {
+    const attributes = buildResourceAttributes({
+      serviceName: 'sebt-portal-web',
+      protocol: 'grpc',
+      traces: 'none',
+      metrics: 'none',
+      logs: 'none'
+    })
+
+    expect(attributes).not.toHaveProperty('service.version')
+    expect(attributes).not.toHaveProperty('deployment.environment.name')
+  })
+
+  it('includes version and environment when present', () => {
+    const attributes = buildResourceAttributes({
+      serviceName: 'sebt-portal-web',
+      protocol: 'grpc',
+      serviceVersion: '1.2.3',
+      deploymentEnvironment: 'dev-dc',
+      traces: 'otlp',
+      metrics: 'otlp',
+      logs: 'otlp'
+    })
+
+    expect(attributes['service.version']).toBe('1.2.3')
+    expect(attributes['deployment.environment.name']).toBe('dev-dc')
+  })
+})

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -68,11 +68,26 @@ function parseProtocol(value: string | undefined): OtlpProtocol {
 }
 
 /**
+ * Default mode for a single signal. A signal is exported over OTLP when the
+ * general endpoint is set (which enables all signals) or when its own
+ * signal-specific endpoint is set; otherwise it stays dark ('none'). This keeps
+ * a lone signal-specific endpoint from silently enabling the other two.
+ */
+function signalDefault(
+  hasGeneralEndpoint: boolean,
+  signalEndpoint: string | undefined
+): ExporterMode {
+  return hasGeneralEndpoint || cleanString(signalEndpoint) !== undefined ? 'otlp' : 'none'
+}
+
+/**
  * Resolve OpenTelemetry configuration from the environment.
  *
- * The default per-signal mode is driven by whether any OTLP endpoint is
- * configured: endpoint present -> 'otlp'; absent -> 'none'. "None" is the
- * inert/dark state — e.g. a deployed environment not yet pointed at a collector.
+ * Each signal's default mode is driven per-signal: the general
+ * OTEL_EXPORTER_OTLP_ENDPOINT enables all three, while a signal-specific
+ * endpoint (OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT) enables only that
+ * signal. Absent any applicable endpoint a signal defaults to 'none' — the
+ * inert/dark state, e.g. a deployed environment not yet pointed at a collector.
  *
  * Each signal can be overridden independently with the standard
  * OTEL_{TRACES,METRICS,LOGS}_EXPORTER variables (otlp | console | none), which
@@ -82,20 +97,20 @@ export function resolveOtelConfig(
   env: NodeJS.ProcessEnv,
   options: ResolveOtelConfigOptions
 ): OtelConfig {
-  const hasEndpoint =
-    cleanString(env.OTEL_EXPORTER_OTLP_ENDPOINT) !== undefined ||
-    cleanString(env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) !== undefined ||
-    cleanString(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) !== undefined ||
-    cleanString(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) !== undefined
-
-  const defaultMode: ExporterMode = hasEndpoint ? 'otlp' : 'none'
+  const hasGeneralEndpoint = cleanString(env.OTEL_EXPORTER_OTLP_ENDPOINT) !== undefined
 
   const config: OtelConfig = {
     serviceName: cleanString(env.OTEL_SERVICE_NAME) ?? options.defaultServiceName,
     protocol: parseProtocol(env.OTEL_EXPORTER_OTLP_PROTOCOL),
-    traces: parseMode(env.OTEL_TRACES_EXPORTER) ?? defaultMode,
-    metrics: parseMode(env.OTEL_METRICS_EXPORTER) ?? defaultMode,
-    logs: parseMode(env.OTEL_LOGS_EXPORTER) ?? defaultMode
+    traces:
+      parseMode(env.OTEL_TRACES_EXPORTER) ??
+      signalDefault(hasGeneralEndpoint, env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT),
+    metrics:
+      parseMode(env.OTEL_METRICS_EXPORTER) ??
+      signalDefault(hasGeneralEndpoint, env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT),
+    logs:
+      parseMode(env.OTEL_LOGS_EXPORTER) ??
+      signalDefault(hasGeneralEndpoint, env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)
   }
 
   const serviceVersion = cleanString(env.OTEL_SERVICE_VERSION)

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -1,0 +1,138 @@
+/**
+ * Vendor-neutral OpenTelemetry configuration, resolved from the standard OTEL_*
+ * environment variables.
+ *
+ * This module is pure: no SDK imports, no side effects. It only reads an
+ * environment bag and returns a plain description of what to export. That keeps
+ * it trivially unit-testable and lets the SDK layer stay a thin wiring shell.
+ *
+ * The web apps emit OTLP to a collector (an ADOT sidecar in ECS, Jaeger in local
+ * dev); the collector routes to Datadog and/or Splunk. Nothing here is
+ * vendor-specific — the same binary points anywhere via environment alone.
+ */
+
+/** How a single signal (traces, metrics, or logs) is exported. */
+export type ExporterMode = 'otlp' | 'console' | 'none'
+
+/**
+ * OTLP wire protocol. gRPC (:4317) is the default to match the .NET backend;
+ * http/protobuf (:4318) is available for environments where gRPC is awkward
+ * (e.g. behind an HTTP-only proxy or load balancer).
+ */
+export type OtlpProtocol = 'grpc' | 'http/protobuf'
+
+export interface OtelConfig {
+  serviceName: string
+  serviceVersion?: string
+  deploymentEnvironment?: string
+  protocol: OtlpProtocol
+  traces: ExporterMode
+  metrics: ExporterMode
+  logs: ExporterMode
+}
+
+export interface ResolveOtelConfigOptions {
+  /** Service name to use when OTEL_SERVICE_NAME is not set. */
+  defaultServiceName: string
+}
+
+const VALID_MODES: readonly ExporterMode[] = ['otlp', 'console', 'none']
+
+/**
+ * Parse a standard OTEL_*_EXPORTER value. Returns undefined for unset or
+ * unrecognized values so the caller can fall back to the endpoint-derived
+ * default rather than silently disabling a signal.
+ */
+function parseMode(value: string | undefined): ExporterMode | undefined {
+  const normalized = value?.trim().toLowerCase()
+  return VALID_MODES.find((mode) => mode === normalized)
+}
+
+/** Trim to a non-empty string, or undefined. */
+function cleanString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+/**
+ * Parse the standard OTEL_EXPORTER_OTLP_PROTOCOL value. Accepts the "http"
+ * shorthand for "http/protobuf". Anything unset or unrecognized defaults to
+ * gRPC, matching the backend.
+ */
+function parseProtocol(value: string | undefined): OtlpProtocol {
+  const normalized = value?.trim().toLowerCase()
+  if (normalized === 'http/protobuf' || normalized === 'http' || normalized === 'http/proto') {
+    return 'http/protobuf'
+  }
+  return 'grpc'
+}
+
+/**
+ * Resolve OpenTelemetry configuration from the environment.
+ *
+ * The default per-signal mode is driven by whether any OTLP endpoint is
+ * configured: endpoint present -> 'otlp'; absent -> 'none'. "None" is the
+ * inert/dark state — e.g. a deployed environment not yet pointed at a collector.
+ *
+ * Each signal can be overridden independently with the standard
+ * OTEL_{TRACES,METRICS,LOGS}_EXPORTER variables (otlp | console | none), which
+ * is how local dev flips a signal to the console exporter for quick inspection.
+ */
+export function resolveOtelConfig(
+  env: NodeJS.ProcessEnv,
+  options: ResolveOtelConfigOptions
+): OtelConfig {
+  const hasEndpoint =
+    cleanString(env.OTEL_EXPORTER_OTLP_ENDPOINT) !== undefined ||
+    cleanString(env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT) !== undefined ||
+    cleanString(env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT) !== undefined ||
+    cleanString(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT) !== undefined
+
+  const defaultMode: ExporterMode = hasEndpoint ? 'otlp' : 'none'
+
+  const config: OtelConfig = {
+    serviceName: cleanString(env.OTEL_SERVICE_NAME) ?? options.defaultServiceName,
+    protocol: parseProtocol(env.OTEL_EXPORTER_OTLP_PROTOCOL),
+    traces: parseMode(env.OTEL_TRACES_EXPORTER) ?? defaultMode,
+    metrics: parseMode(env.OTEL_METRICS_EXPORTER) ?? defaultMode,
+    logs: parseMode(env.OTEL_LOGS_EXPORTER) ?? defaultMode
+  }
+
+  // Assign optional attributes only when present so they stay absent (not
+  // explicitly undefined) under exactOptionalPropertyTypes — the strict TS
+  // flag, enabled in our tsconfig, that forbids `undefined` on an optional prop.
+  const serviceVersion = cleanString(env.OTEL_SERVICE_VERSION)
+  if (serviceVersion) {
+    config.serviceVersion = serviceVersion
+  }
+  const deploymentEnvironment =
+    cleanString(env.OTEL_DEPLOYMENT_ENVIRONMENT) ?? cleanString(env.NODE_ENV)
+  if (deploymentEnvironment) {
+    config.deploymentEnvironment = deploymentEnvironment
+  }
+
+  return config
+}
+
+/** True when no signal is being exported — the SDK need not start at all. */
+export function isFullyDisabled(config: OtelConfig): boolean {
+  return config.traces === 'none' && config.metrics === 'none' && config.logs === 'none'
+}
+
+/**
+ * Build OpenTelemetry Resource attributes from resolved config. Keys are OTEL
+ * semantic-convention names; literal strings are used (rather than importing
+ * the semantic-conventions package) to keep this module dependency-free.
+ */
+export function buildResourceAttributes(config: OtelConfig): Record<string, string> {
+  const attributes: Record<string, string> = {
+    'service.name': config.serviceName
+  }
+  if (config.serviceVersion) {
+    attributes['service.version'] = config.serviceVersion
+  }
+  if (config.deploymentEnvironment) {
+    attributes['deployment.environment.name'] = config.deploymentEnvironment
+  }
+  return attributes
+}

--- a/packages/observability/src/config.ts
+++ b/packages/observability/src/config.ts
@@ -98,9 +98,6 @@ export function resolveOtelConfig(
     logs: parseMode(env.OTEL_LOGS_EXPORTER) ?? defaultMode
   }
 
-  // Assign optional attributes only when present so they stay absent (not
-  // explicitly undefined) under exactOptionalPropertyTypes — the strict TS
-  // flag, enabled in our tsconfig, that forbids `undefined` on an optional prop.
   const serviceVersion = cleanString(env.OTEL_SERVICE_VERSION)
   if (serviceVersion) {
     config.serviceVersion = serviceVersion

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  buildResourceAttributes,
+  isFullyDisabled,
+  resolveOtelConfig,
+  type ExporterMode,
+  type OtelConfig,
+  type ResolveOtelConfigOptions
+} from './config'
+export { buildSdkComponents, startOtel, type SdkComponents } from './sdk'

--- a/packages/observability/src/sdk.test.ts
+++ b/packages/observability/src/sdk.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { buildInstrumentations, buildSdkComponents } from './sdk'
+import type { OtelConfig } from './config'
+
+function config(overrides: Partial<OtelConfig>): OtelConfig {
+  return {
+    serviceName: 'sebt-test-web',
+    protocol: 'grpc',
+    traces: 'none',
+    metrics: 'none',
+    logs: 'none',
+    ...overrides
+  }
+}
+
+describe('buildSdkComponents', () => {
+  it('builds nothing when all signals are disabled', () => {
+    const components = buildSdkComponents(config({}))
+
+    expect(components.spanProcessors).toHaveLength(0)
+    expect(components.metricReader).toBeUndefined()
+    expect(components.logRecordProcessors).toHaveLength(0)
+  })
+
+  it('builds a span processor when traces are enabled', () => {
+    expect(buildSdkComponents(config({ traces: 'otlp' })).spanProcessors).toHaveLength(1)
+    expect(buildSdkComponents(config({ traces: 'console' })).spanProcessors).toHaveLength(1)
+  })
+
+  it('builds a metric reader when metrics are enabled', () => {
+    expect(buildSdkComponents(config({ metrics: 'otlp' })).metricReader).toBeDefined()
+    expect(buildSdkComponents(config({ metrics: 'console' })).metricReader).toBeDefined()
+  })
+
+  it('builds a log record processor when logs are enabled', () => {
+    expect(buildSdkComponents(config({ logs: 'otlp' })).logRecordProcessors).toHaveLength(1)
+    expect(buildSdkComponents(config({ logs: 'console' })).logRecordProcessors).toHaveLength(1)
+  })
+
+  it('builds only the enabled signals independently', () => {
+    const components = buildSdkComponents(config({ traces: 'otlp', logs: 'none', metrics: 'none' }))
+
+    expect(components.spanProcessors).toHaveLength(1)
+    expect(components.metricReader).toBeUndefined()
+    expect(components.logRecordProcessors).toHaveLength(0)
+  })
+
+  it('builds OTLP exporters for either protocol without throwing', () => {
+    expect(
+      buildSdkComponents(config({ traces: 'otlp', metrics: 'otlp', logs: 'otlp', protocol: 'grpc' }))
+        .spanProcessors
+    ).toHaveLength(1)
+    expect(
+      buildSdkComponents(
+        config({ traces: 'otlp', metrics: 'otlp', logs: 'otlp', protocol: 'http/protobuf' })
+      ).spanProcessors
+    ).toHaveLength(1)
+  })
+})
+
+describe('buildInstrumentations', () => {
+  it('includes undici (fetch) instrumentation when traces are enabled', () => {
+    expect(buildInstrumentations(config({ traces: 'otlp' }))).toHaveLength(1)
+    expect(buildInstrumentations(config({ traces: 'console' }))).toHaveLength(1)
+  })
+
+  it('includes nothing when traces are disabled', () => {
+    expect(buildInstrumentations(config({ traces: 'none', metrics: 'otlp' }))).toHaveLength(0)
+  })
+})

--- a/packages/observability/src/sdk.ts
+++ b/packages/observability/src/sdk.ts
@@ -1,0 +1,187 @@
+/**
+ * Thin OpenTelemetry Node SDK wiring.
+ *
+ * This is Node-only: it pulls in OpenTelemetry packages that depend on
+ * async_hooks / perf_hooks. Import it exclusively from a Node runtime entry
+ * point (Next.js `instrumentation.node.ts`) — never from client or edge code.
+ *
+ * All decisions about *what* to export live in ./config. This file only turns
+ * a resolved config into exporters/processors and starts the SDK.
+ */
+import { OTLPLogExporter as OTLPLogExporterGrpc } from '@opentelemetry/exporter-logs-otlp-grpc'
+import { OTLPLogExporter as OTLPLogExporterProto } from '@opentelemetry/exporter-logs-otlp-proto'
+import { OTLPMetricExporter as OTLPMetricExporterGrpc } from '@opentelemetry/exporter-metrics-otlp-grpc'
+import { OTLPMetricExporter as OTLPMetricExporterProto } from '@opentelemetry/exporter-metrics-otlp-proto'
+import { OTLPTraceExporter as OTLPTraceExporterGrpc } from '@opentelemetry/exporter-trace-otlp-grpc'
+import { OTLPTraceExporter as OTLPTraceExporterProto } from '@opentelemetry/exporter-trace-otlp-proto'
+import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import {
+  BatchLogRecordProcessor,
+  ConsoleLogRecordExporter,
+  type LogRecordProcessor,
+  SimpleLogRecordProcessor
+} from '@opentelemetry/sdk-logs'
+import {
+  ConsoleMetricExporter,
+  type MetricReader,
+  PeriodicExportingMetricReader
+} from '@opentelemetry/sdk-metrics'
+import {
+  BatchSpanProcessor,
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  type SpanProcessor
+} from '@opentelemetry/sdk-trace-node'
+import {
+  buildResourceAttributes,
+  type ExporterMode,
+  isFullyDisabled,
+  type OtelConfig,
+  type OtlpProtocol,
+  resolveOtelConfig,
+  type ResolveOtelConfigOptions
+} from './config'
+
+/**
+ * The SDK building blocks derived from a config. Constructing exporters is
+ * side-effect-free — no network connection opens until the first export — so
+ * this is safe to build (and assert on) in a test without starting the SDK.
+ */
+export interface SdkComponents {
+  spanProcessors: SpanProcessor[]
+  metricReader?: MetricReader
+  logRecordProcessors: LogRecordProcessor[]
+}
+
+function traceProcessor(mode: ExporterMode, protocol: OtlpProtocol): SpanProcessor | undefined {
+  switch (mode) {
+    case 'otlp':
+      return new BatchSpanProcessor(
+        protocol === 'grpc' ? new OTLPTraceExporterGrpc() : new OTLPTraceExporterProto()
+      )
+    case 'console':
+      return new SimpleSpanProcessor(new ConsoleSpanExporter())
+    case 'none':
+      return undefined
+  }
+}
+
+function metricReader(mode: ExporterMode, protocol: OtlpProtocol): MetricReader | undefined {
+  switch (mode) {
+    case 'otlp':
+      return new PeriodicExportingMetricReader({
+        exporter: protocol === 'grpc' ? new OTLPMetricExporterGrpc() : new OTLPMetricExporterProto()
+      })
+    case 'console':
+      return new PeriodicExportingMetricReader({ exporter: new ConsoleMetricExporter() })
+    case 'none':
+      return undefined
+  }
+}
+
+function logProcessor(mode: ExporterMode, protocol: OtlpProtocol): LogRecordProcessor | undefined {
+  switch (mode) {
+    case 'otlp':
+      return new BatchLogRecordProcessor({
+        exporter: protocol === 'grpc' ? new OTLPLogExporterGrpc() : new OTLPLogExporterProto()
+      })
+    case 'console':
+      return new SimpleLogRecordProcessor({ exporter: new ConsoleLogRecordExporter() })
+    case 'none':
+      return undefined
+  }
+}
+
+/**
+ * Node's `fetch` (undici) instrumentation. This is what injects the W3C
+ * traceparent header on the proxy's outbound fetch to the .NET backend, so the
+ * backend continues the same trace. Without it the web spans wouldn't connect
+ * to the API. Only meaningful when traces are exported.
+ */
+export function buildInstrumentations(config: OtelConfig): UndiciInstrumentation[] {
+  return config.traces === 'none' ? [] : [new UndiciInstrumentation()]
+}
+
+/** Turn a resolved config into the SDK's exporters/processors. */
+export function buildSdkComponents(config: OtelConfig): SdkComponents {
+  const span = traceProcessor(config.traces, config.protocol)
+  const reader = metricReader(config.metrics, config.protocol)
+  const log = logProcessor(config.logs, config.protocol)
+
+  const components: SdkComponents = {
+    spanProcessors: span ? [span] : [],
+    logRecordProcessors: log ? [log] : []
+  }
+  if (reader) {
+    components.metricReader = reader
+  }
+  return components
+}
+
+let started: NodeSDK | undefined
+
+/**
+ * Flush telemetry best-effort on shutdown so the final batch isn't lost when a
+ * container receives SIGTERM. This does not block process exit — Next owns the
+ * lifecycle — so a very late batch can still be dropped; that's an acceptable
+ * trade for not interfering with the server's own shutdown.
+ */
+function registerGracefulShutdown(sdk: NodeSDK): void {
+  const flush = (): void => {
+    void sdk.shutdown().catch((error) => {
+      console.error('[otel] error during shutdown', error)
+    })
+  }
+  process.once('SIGTERM', flush)
+  process.once('SIGINT', flush)
+}
+
+/**
+ * Start the OpenTelemetry Node SDK from the environment.
+ *
+ * Idempotent: a second call returns the already-started SDK. Returns undefined
+ * when every signal is disabled (nothing to export) — the "dark" state — so an
+ * unconfigured environment pays no cost.
+ *
+ * Call once, as early as possible, from the Node runtime.
+ */
+export function startOtel(options: ResolveOtelConfigOptions): NodeSDK | undefined {
+  if (started) {
+    return started
+  }
+
+  const config = resolveOtelConfig(process.env, options)
+  if (isFullyDisabled(config)) {
+    return undefined
+  }
+
+  const { spanProcessors, metricReader, logRecordProcessors } = buildSdkComponents(config)
+
+  // Assemble options conditionally: only pass a key when its signal is enabled.
+  // This keeps us honest under exactOptionalPropertyTypes and avoids handing the
+  // SDK an empty processor array for a disabled signal.
+  const sdkConfig: ConstructorParameters<typeof NodeSDK>[0] = {
+    resource: resourceFromAttributes(buildResourceAttributes(config))
+  }
+  if (spanProcessors.length > 0) {
+    sdkConfig.spanProcessors = spanProcessors
+  }
+  if (metricReader) {
+    sdkConfig.metricReader = metricReader
+  }
+  if (logRecordProcessors.length > 0) {
+    sdkConfig.logRecordProcessors = logRecordProcessors
+  }
+  const instrumentations = buildInstrumentations(config)
+  if (instrumentations.length > 0) {
+    sdkConfig.instrumentations = instrumentations
+  }
+
+  const sdk = new NodeSDK(sdkConfig)
+  sdk.start()
+  registerGracefulShutdown(sdk)
+  started = sdk
+  return sdk
+}

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/observability/vitest.config.ts
+++ b/packages/observability/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,10 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/analytics:
+    dependencies:
+      web-vitals:
+        specifier: ^5.3.0
+        version: 5.3.0
     devDependencies:
       '@amplitude/analytics-browser':
         specifier: ^2.40.0
@@ -438,92 +442,6 @@ importers:
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
-
-  packages/analytics:
-    dependencies:
-      web-vitals:
-        specifier: ^5.3.0
-        version: 5.3.0
-    devDependencies:
-      '@amplitude/analytics-browser':
-        specifier: ^2.40.0
-        version: 2.42.3
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.15
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
-      next:
-        specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
-      react:
-        specifier: 19.2.6
-        version: 19.2.6
-      react-dom:
-        specifier: 19.2.6
-        version: 19.2.6(react@19.2.6)
-      vite:
-        specifier: '>=8.0.16'
-        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
-
-  packages/design-system:
-    dependencies:
-      markdown-to-jsx:
-        specifier: ^9.8.0
-        version: 9.8.0(react@19.2.6)
-    devDependencies:
-      '@testing-library/jest-dom':
-        specifier: ^6.9.1
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@testing-library/user-event':
-        specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/node':
-        specifier: ^25.8.0
-        version: 25.9.1
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.15
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.15)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
-      i18next:
-        specifier: ^26.1.0
-        version: 26.2.0(typescript@6.0.3)
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
-      next:
-        specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
-      react:
-        specifier: 19.2.6
-        version: 19.2.6
-      react-dom:
-        specifier: 19.2.6
-        version: 19.2.6(react@19.2.6)
-      react-i18next:
-        specifier: ^17.0.7
-        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      vite:
-        specifier: '>=8.0.16'
-        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -3087,8 +3005,8 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -8159,7 +8077,7 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
-  es-module-lexer@2.3.0: {}
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -8900,7 +8818,7 @@ snapshots:
   import-in-the-middle@3.3.1:
     dependencies:
       cjs-module-lexer: 2.2.0
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
@@ -10977,7 +10895,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.17
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@sebt/design-system':
         specifier: workspace:*
         version: link:../../../../packages/design-system
+      '@sebt/observability':
+        specifier: workspace:*
+        version: link:../../../../packages/observability
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
         version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
@@ -61,7 +64,7 @@ importers:
         version: 26.2.0(typescript@6.0.3)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -140,7 +143,7 @@ importers:
         version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
 
   apps/portal/src/SEBT.Portal.Web:
     dependencies:
@@ -149,13 +152,19 @@ importers:
         version: 2.42.3
       '@next/third-parties':
         specifier: ^16.2.6
-        version: 16.2.6(next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@sebt/analytics':
         specifier: workspace:*
         version: link:../../../../packages/analytics
       '@sebt/design-system':
         specifier: workspace:*
         version: link:../../../../packages/design-system
+      '@sebt/observability':
+        specifier: workspace:*
+        version: link:../../../../packages/observability
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
         version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
@@ -173,7 +182,7 @@ importers:
         version: 6.2.3
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -199,6 +208,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^16.2.6
         version: 16.2.6
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.1)
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -282,7 +294,150 @@ importers:
         version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/analytics:
+    devDependencies:
+      '@amplitude/analytics-browser':
+        specifier: ^2.40.0
+        version: 2.42.3
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.15
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/design-system:
+    dependencies:
+      markdown-to-jsx:
+        specifier: ^9.8.0
+        version: 9.8.0(react@19.2.6)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^25.8.0
+        version: 25.9.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+      i18next:
+        specifier: ^26.1.0
+        version: 26.2.0(typescript@6.0.3)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+      react-i18next:
+        specifier: ^17.0.7
+        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/observability:
+    dependencies:
+      '@grpc/grpc-js':
+        specifier: ^1.14.4
+        version: 1.14.4
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.220.0
+        version: 0.220.0
+      '@opentelemetry/exporter-logs-otlp-grpc':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici':
+        specifier: ^0.30.0
+        version: 0.30.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.9.0
+        version: 2.9.0(@opentelemetry/api@1.9.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.8.0
+        version: 25.9.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/analytics:
     dependencies:
@@ -809,6 +964,15 @@ packages:
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1033,6 +1197,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@lhci/cli@0.15.1':
     resolution: {integrity: sha512-yhC0oXnXqGHYy1xl4D8YqaydMZ/khFAnXGY/o2m/J3PqPa/D0nj3V6TLoH02oVMFeEF2AQim7UbmdXMiXx2tOw==}
     hasBin: true
@@ -1156,6 +1323,186 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.220.0':
+    resolution: {integrity: sha512-glfIVKnZevRin8fY/9uES/mhRtMT1lGINLHc9MIo5fTQZXswEEHamJtgjv4MTtzgnhHGC92mIS/0lzAUZMyE0w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.9.0':
+    resolution: {integrity: sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.220.0':
+    resolution: {integrity: sha512-s0sRPCSlXYqlgObOpCftomJllp3LfUL9FobQ5csg2172ydVhSEnu1ptpsVBJadazs5nUNp7vDuLE03FAFWTLOQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.220.0':
+    resolution: {integrity: sha512-8186thl+pTw64iz/qEEen5oJZoZ/gO73XruChdaGlYdWOdBIQ42r+vHLf6a7vIDqTD4b8ZOoMlyxptanECaI9A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.220.0':
+    resolution: {integrity: sha512-8LZAxdJ0ENDAFwr4j0oY35mHBltiSzvlhdQAPGiC7p9VnxtuSq4SW1gfBAdW6t6hiQG6OwUl8w7KHaOdJPKHWg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.220.0':
+    resolution: {integrity: sha512-U128izvJfX/dW9jRGP0gIfadR1Hg7ft3UEGIeRxLFK70m2BWw6AtNCOnsUygpw2zCgR/ygdWbGpcL6TmhW0ZGw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.220.0':
+    resolution: {integrity: sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.220.0':
+    resolution: {integrity: sha512-lyO+IQBdSvqHN/ZOW/OzrSWemtfD+HgWngn+HBNLhjy0YrCQQTz0OE/kSekH2Pl340dn9DWzhqHdz5Eftr+HLA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.220.0':
+    resolution: {integrity: sha512-JZD5DL/NBpVd2BHefvYosm3G40UZ/KzExLv5tc0eZe0CtrsHHtcOk3YPUxR2EINmUeBf8+w5UReTV8fFPn95lA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.220.0':
+    resolution: {integrity: sha512-bv1xmNhmNwIM6MdUBw4yYuJeVcEViVLk3uD69vOQMwueHBnfyl/u0HnBlB1FNY/Te0UOzJzvcbyR8wN6b+iGbA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.220.0':
+    resolution: {integrity: sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.220.0':
+    resolution: {integrity: sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.9.0':
+    resolution: {integrity: sha512-RwINoce2BH8T4obT5pMcAla2sWma1YZvYuaktWmTluQ0PkQdvv5D060rWI1+kawX+J2qBRcMbwrZJJNcMJUauQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-undici@0.30.0':
+    resolution: {integrity: sha512-VgxMzeR14uPEVqEC5b55m4KijEe+gQAgJ4jjWCE7h5i2Q76nS4y7OWDk8V+XkD4zK9bbJyWEK+a2DqtGP/fCuw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.220.0':
+    resolution: {integrity: sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.220.0':
+    resolution: {integrity: sha512-/eIkBPMBTIvM3x/0mDX4aJeSkYifYClnBPr68PL1h5LV4VQv4+SV6CGrpiZ4fIWDnobVmhTWCm1J/QRdAWUfvA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.220.0':
+    resolution: {integrity: sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.9.0':
+    resolution: {integrity: sha512-WrOT1WsOUG+B7hstD2RYoMPIOK76G8E9AQHhMjUvrQaGx/oA7rPWQvvr1Rqv7+yy4R0ZMVwWLC4vW2xnkgWPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.9.0':
+    resolution: {integrity: sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.9.0':
+    resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.220.0':
+    resolution: {integrity: sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.9.0':
+    resolution: {integrity: sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.220.0':
+    resolution: {integrity: sha512-wHtGyHhSKHNH3fym33xRu4Ef/HXTFvX8eQ42xdQdEO9LYx9Y2qNyBDJytyqVlvmo6abWZlNYTUthuAGUMYqYnQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.9.0':
+    resolution: {integrity: sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.9.0':
+    resolution: {integrity: sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.9.0':
+    resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     resolution: {integrity: sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==}
@@ -1500,6 +1847,33 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@puppeteer/browsers@2.13.2':
     resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
@@ -2362,6 +2736,9 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   cli-cursor@2.1.0:
     resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
     engines: {node: '>=4'}
@@ -2709,6 +3086,9 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3225,6 +3605,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.3.1:
+    resolution: {integrity: sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -3658,6 +4042,9 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -3670,6 +4057,9 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lookup-closest-locale@6.2.0:
     resolution: {integrity: sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==}
@@ -3809,6 +4199,9 @@ packages:
   modern-tar@0.7.6:
     resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
     engines: {node: '>=18.0.0'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -4168,6 +4561,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   protocolify@3.0.0:
     resolution: {integrity: sha512-PuvDJOkKJMVQx8jSNf8E5g0bJw/UTKm30mTjFHg4N30c8sefgA5Qr/f8INKqYBKfvP/MUSJrj+z1Smjbq4/3rQ==}
     engines: {node: '>=8'}
@@ -4287,6 +4684,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
@@ -5744,6 +6145,18 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.2
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5903,6 +6316,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@lhci/cli@0.15.1':
     dependencies:
       '@lhci/utils': 0.15.1
@@ -6025,9 +6440,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)':
+  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0))(react@19.2.6)':
     dependencies:
-      next: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
       react: 19.2.6
       third-party-capital: 1.0.20
 
@@ -6055,6 +6470,256 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/configuration@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      yaml: 2.9.0
+
+  '@opentelemetry/context-async-hooks@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation-undici@0.30.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-b3@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/configuration': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-node@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.130.0':
     optional: true
@@ -6262,6 +6927,26 @@ snapshots:
       playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@puppeteer/browsers@2.13.2':
     dependencies:
@@ -6672,7 +7357,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -7088,6 +7773,8 @@ snapshots:
       mitt: 3.0.1
       zod: 3.25.76
 
+  cjs-module-lexer@2.2.0: {}
+
   cli-cursor@2.1.0:
     dependencies:
       restore-cursor: 2.0.0
@@ -7471,6 +8158,8 @@ snapshots:
       math-intrinsics: 1.1.0
 
   es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -8208,6 +8897,12 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.3.1:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.0
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -8694,6 +9389,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.debounce@4.0.8: {}
 
   lodash.merge@4.6.2: {}
@@ -8707,6 +9404,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  long@5.3.2: {}
 
   lookup-closest-locale@6.2.0: {}
 
@@ -8803,6 +9502,8 @@ snapshots:
 
   modern-tar@0.7.6: {}
 
+  module-details-from-path@1.0.4: {}
+
   mrmime@2.0.1: {}
 
   ms@2.0.0: {}
@@ -8856,7 +9557,7 @@ snapshots:
 
   netmask@2.1.1: {}
 
-  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0):
+  next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -8875,6 +9576,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.60.0
       babel-plugin-react-compiler: 1.0.0
       sass: 1.99.0
@@ -9234,6 +9936,20 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 25.9.1
+      long: 5.3.2
+
   protocolify@3.0.0:
     dependencies:
       file-url: 3.0.0
@@ -9404,6 +10120,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   require-main-filename@2.0.0: {}
 
@@ -10236,7 +10959,7 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -10254,11 +10977,12 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       jsdom: 29.1.1


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-341

#### ✍️ Description
First of a two-PR stack for DC-341 — OpenTelemetry on the Next.js web tier.

Adds `@sebt/observability`: a shared, server-only OTEL Node SDK bootstrap. It emits OTLP (traces, metrics, logs) to a collector, configured entirely from standard `OTEL_*` env vars — gRPC by default (matches the backend), `http/protobuf` switchable, console fallback. It's inert when no endpoint is set, so this ships dark. Config resolution is pure and unit-tested (26 tests).

Both Next apps register it via `instrumentation.ts` (Node-runtime guarded). Nothing deployed changes yet — PR B sets the endpoint and turns it on.

Two deliberate gaps:
- The logs pipeline is wired but dark until a pino retrofit gives it an emit source.
- The enrollment checker is instrumented but deploys as a static export, so its server OTEL is a build-time no-op. Kept SSR-ready.

#### 🔗 Links to related PRs
- #469

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes: none deployed here — the `OTEL_*` vars land in PR B (Tofu + `web.config`)
