### PR TITLE
[DC-341] Web OTLP: proxy span, ECS sidecar, IIS, ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ When neither is configured, the application falls back to in-memory caching only
 
 [Jaeger](https://github.com/jaegertracing/jaeger) acts as a local OTLP collector for OpenTelemetry tracing. The default configuration for the portal sends traces and metrics via OTLP over gRPC to http://localhost:4317, which is the standard port. Local traces can be viewed in the Jaeger UI at [http://localhost:16686](http://localhost:16686).
 
+The Next.js web apps (`SEBT.Portal.Web`, `SEBT.EnrollmentChecker.Web`) also emit OTLP here, but only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — they stay inert otherwise. `.env.example` points it at `http://localhost:4317`; copy that into `.env.local` to see web-tier traces alongside the API's.
+
 ### Local Build & Test (Debug mode)
 
 ```bash

--- a/apps/portal/src/SEBT.Portal.Web/.env.example
+++ b/apps/portal/src/SEBT.Portal.Web/.env.example
@@ -33,6 +33,9 @@ OIDC_REDIRECT_URI=http://localhost:3000/callback
 # OIDC_LANGUAGE_PARAM=en
 OIDC_COMPLETE_LOGIN_SIGNING_KEY=
 
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+OTEL_SERVICE_NAME=sebt-portal-web
+
 # =============================================================================
 # Client-side (exposed to browser)
 # =============================================================================

--- a/apps/portal/src/SEBT.Portal.Web/src/app/api/[[...path]]/route.test.ts
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/api/[[...path]]/route.test.ts
@@ -1,21 +1,62 @@
+// @vitest-environment node
+import { server } from '@/mocks/server'
+import { context as otelContext, SpanStatusCode, trace } from '@opentelemetry/api'
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor
+} from '@opentelemetry/sdk-trace-base'
+import { http, HttpResponse } from 'msw'
 import { NextRequest } from 'next/server'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // t3-env does not apply the schema default for BACKEND_URL under test; stub it so
 // the proxy has a valid backend base. The exact value is irrelevant to these tests.
 vi.mock('@/env', () => ({ env: { BACKEND_URL: 'http://localhost:5280' } }))
 
-import { GET } from './route'
+import { GET, POST } from './route'
+
+// Matches env.BACKEND_URL's default (see src/env.ts) under test.
+const BACKEND_URL = 'http://localhost:5280'
 
 function context(path: string[]) {
   return { params: Promise.resolve({ path }) }
 }
 
-describe('/api/[[...path]] proxy route', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+function makeRequest(method = 'GET', path = '/api/households/me') {
+  return new NextRequest(`http://localhost:3000${path}`, { method })
+}
 
+function makeContext(segments: string[]) {
+  return { params: Promise.resolve({ path: segments }) }
+}
+
+let exporter: InMemorySpanExporter
+
+beforeAll(() => {
+  // A real (in-memory) tracer provider so route.ts's tracer produces spans we
+  // can assert on. The ProxyTracer created at module load delegates here.
+  exporter = new InMemorySpanExporter()
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)]
+  })
+  trace.setGlobalTracerProvider(provider)
+})
+
+beforeEach(() => {
+  exporter.reset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterAll(() => {
+  trace.disable()
+  otelContext.disable()
+})
+
+describe('/api/[[...path]] proxy route', () => {
   it('rejects URL-encoded path traversal with 400 and never proxies', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
     const request = new NextRequest('http://localhost:3000/api/auth%2F..%2F..%2Fhealth')
@@ -50,5 +91,131 @@ describe('/api/[[...path]] proxy route', () => {
       'http://localhost:5280/api/features?state=dc',
       expect.objectContaining({ method: 'GET' })
     )
+  })
+})
+
+describe('proxyRequest OTel instrumentation', () => {
+  describe('successful backend response', () => {
+    it('records a span named http.proxy with method and path attributes', async () => {
+      server.use(
+        http.get(`${BACKEND_URL}/api/households/me`, () => HttpResponse.json({ ok: true }))
+      )
+
+      await GET(makeRequest('GET'), makeContext(['households', 'me']))
+
+      const spans = exporter.getFinishedSpans()
+      expect(spans).toHaveLength(1)
+      expect(spans[0]!.name).toBe('http.proxy')
+      expect(spans[0]!.attributes['http.request.method']).toBe('GET')
+      expect(spans[0]!.attributes['url.path']).toBe('/api/households/me')
+    })
+
+    it('records the response status code on the span', async () => {
+      server.use(
+        http.get(`${BACKEND_URL}/api/households/me`, () =>
+          HttpResponse.json({ ok: true }, { status: 200 })
+        )
+      )
+
+      await GET(makeRequest('GET'), makeContext(['households', 'me']))
+
+      expect(exporter.getFinishedSpans()[0]!.attributes['http.response.status_code']).toBe(200)
+    })
+
+    it('does not set span status to ERROR for a 2xx response', async () => {
+      server.use(
+        http.get(`${BACKEND_URL}/api/households/me`, () => HttpResponse.json({ ok: true }))
+      )
+
+      await GET(makeRequest('GET'), makeContext(['households', 'me']))
+
+      expect(exporter.getFinishedSpans()[0]!.status.code).toBe(SpanStatusCode.UNSET)
+    })
+  })
+
+  describe('backend error response', () => {
+    it('sets span status to ERROR for a 4xx response', async () => {
+      server.use(
+        http.get(`${BACKEND_URL}/api/households/me`, () =>
+          HttpResponse.json({ error: 'Not found' }, { status: 404 })
+        )
+      )
+
+      await GET(makeRequest('GET'), makeContext(['households', 'me']))
+
+      const span = exporter.getFinishedSpans()[0]!
+      expect(span.status.code).toBe(SpanStatusCode.ERROR)
+      expect(span.attributes['http.response.status_code']).toBe(404)
+    })
+
+    it('sets span status to ERROR for a 5xx response', async () => {
+      server.use(
+        http.get(`${BACKEND_URL}/api/households/me`, () =>
+          HttpResponse.json({ error: 'Server error' }, { status: 503 })
+        )
+      )
+
+      await GET(makeRequest('GET'), makeContext(['households', 'me']))
+
+      const span = exporter.getFinishedSpans()[0]!
+      expect(span.status.code).toBe(SpanStatusCode.ERROR)
+      expect(span.attributes['http.response.status_code']).toBe(503)
+    })
+  })
+
+  describe('backend unreachable', () => {
+    it('sets span status to ERROR and records exception on timeout', async () => {
+      const abortError = Object.assign(new Error('The operation was aborted'), {
+        name: 'AbortError'
+      })
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = async () => {
+        throw abortError
+      }
+
+      try {
+        const response = await GET(makeRequest('GET'), makeContext(['households', 'me']))
+        expect(response.status).toBe(504)
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+
+      const span = exporter.getFinishedSpans()[0]!
+      expect(span.status.code).toBe(SpanStatusCode.ERROR)
+      expect(span.events.some((e) => e.name === 'exception')).toBe(true)
+    })
+
+    it('sets span status to ERROR and records exception when backend is unavailable', async () => {
+      const networkError = new Error('Network failure')
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = async () => {
+        throw networkError
+      }
+
+      try {
+        const response = await GET(makeRequest('GET'), makeContext(['households', 'me']))
+        expect(response.status).toBe(502)
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+
+      const span = exporter.getFinishedSpans()[0]!
+      expect(span.status.code).toBe(SpanStatusCode.ERROR)
+      expect(span.events.some((e) => e.name === 'exception')).toBe(true)
+    })
+  })
+
+  describe('POST request', () => {
+    it('records method as POST on the span', async () => {
+      server.use(
+        http.post(`${BACKEND_URL}/api/cards/replace`, () => new HttpResponse(null, { status: 204 }))
+      )
+
+      await POST(makeRequest('POST', '/api/cards/replace'), makeContext(['cards', 'replace']))
+
+      const span = exporter.getFinishedSpans()[0]!
+      expect(span.attributes['http.request.method']).toBe('POST')
+      expect(span.attributes['url.path']).toBe('/api/cards/replace')
+    })
   })
 })

--- a/apps/portal/src/SEBT.Portal.Web/src/app/api/[[...path]]/route.ts
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/api/[[...path]]/route.ts
@@ -1,9 +1,17 @@
 import { env } from '@/env'
 import { resolveApiProxyUrl } from '@/lib/apiProxyPath'
+import { context as otelContext, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api'
 import { NextRequest, NextResponse } from 'next/server'
 
 const BACKEND_URL = env.BACKEND_URL
 const REQUEST_TIMEOUT_MS = 30000
+
+// Manual span around the backend proxy — the single server-side choke point for
+// all API traffic. UndiciInstrumentation already traces the raw fetch and
+// propagates trace context to the backend; this span adds proxy-level semantics
+// (timeout -> 504, backend unreachable -> 502) as span status and recorded
+// exceptions, so those failures are visible in traces.
+const tracer = trace.getTracer('sebt-portal-web')
 
 type RouteContext = {
   params: Promise<{ path?: string[] }>
@@ -27,49 +35,69 @@ async function proxyRequest(request: NextRequest, context: RouteContext): Promis
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
 
-  try {
-    const headers = new Headers(request.headers)
-    // Remove Next.js specific headers
-    headers.delete('host')
-    headers.delete('connection')
-
-    // Forward the request to the backend
-    const response = await fetch(url.toString(), {
-      method: request.method,
-      headers,
-      body: request.body,
-      signal: controller.signal,
-      // Pass backend redirects (e.g., OIDC authorize 302) through to the browser
-      // instead of following them within the proxy.
-      redirect: 'manual',
-      // @ts-expect-error - duplex is required for streaming request bodies
-      duplex: 'half'
-    })
-
-    // Create response with backend headers
-    const responseHeaders = new Headers(response.headers)
-    // Remove hop-by-hop headers
-    responseHeaders.delete('transfer-encoding')
-    responseHeaders.delete('connection')
-
-    return new NextResponse(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: responseHeaders
-    })
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      return NextResponse.json({ error: 'Request timeout' }, { status: 504 })
+  const span = tracer.startSpan('http.proxy', {
+    kind: SpanKind.CLIENT,
+    attributes: {
+      'http.request.method': request.method,
+      'url.path': url.pathname
     }
+  })
 
-    // Only log detailed errors in development to avoid exposing sensitive information
-    if (process.env.NODE_ENV === 'development') {
-      console.error('Proxy error:', error)
+  return otelContext.with(trace.setSpan(otelContext.active(), span), async () => {
+    try {
+      const headers = new Headers(request.headers)
+      // Remove Next.js specific headers
+      headers.delete('host')
+      headers.delete('connection')
+
+      // Forward the request to the backend
+      const response = await fetch(url.toString(), {
+        method: request.method,
+        headers,
+        body: request.body,
+        signal: controller.signal,
+        // Pass backend redirects (e.g., OIDC authorize 302) through to the browser
+        // instead of following them within the proxy.
+        redirect: 'manual',
+        // @ts-expect-error - duplex is required for streaming request bodies
+        duplex: 'half'
+      })
+
+      span.setAttribute('http.response.status_code', response.status)
+      if (response.status >= 400) {
+        span.setStatus({ code: SpanStatusCode.ERROR })
+      }
+
+      // Create response with backend headers
+      const responseHeaders = new Headers(response.headers)
+      // Remove hop-by-hop headers
+      responseHeaders.delete('transfer-encoding')
+      responseHeaders.delete('connection')
+
+      return new NextResponse(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: responseHeaders
+      })
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        span.setStatus({ code: SpanStatusCode.ERROR, message: 'Request timeout' })
+        span.recordException(error)
+        return NextResponse.json({ error: 'Request timeout' }, { status: 504 })
+      }
+
+      // Only log detailed errors in development to avoid exposing sensitive information
+      if (process.env.NODE_ENV === 'development') {
+        console.error('Proxy error:', error)
+      }
+      span.setStatus({ code: SpanStatusCode.ERROR, message: 'Backend unavailable' })
+      span.recordException(error instanceof Error ? error : new Error(String(error)))
+      return NextResponse.json({ error: 'Backend unavailable' }, { status: 502 })
+    } finally {
+      clearTimeout(timeoutId)
+      span.end()
     }
-    return NextResponse.json({ error: 'Backend unavailable' }, { status: 502 })
-  } finally {
-    clearTimeout(timeoutId)
-  }
+  })
 }
 
 export async function GET(request: NextRequest, context: RouteContext) {

--- a/apps/portal/src/SEBT.Portal.Web/vitest.config.ts
+++ b/apps/portal/src/SEBT.Portal.Web/vitest.config.ts
@@ -4,9 +4,12 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     // @/env createEnv() requires NEXT_PUBLIC_STATE; SKIP_ENV_VALIDATION skips strict OIDC checks during tests.
+    // SKIP_ENV_VALIDATION also bypasses Zod defaults, so BACKEND_URL must be set explicitly here
+    // (mirroring env.ts's default) for the API proxy route tests.
     env: {
       SKIP_ENV_VALIDATION: '1',
-      NEXT_PUBLIC_STATE: 'dc'
+      NEXT_PUBLIC_STATE: 'dc',
+      BACKEND_URL: 'http://localhost:5280'
     },
     environment: 'jsdom',
     setupFiles: ['./src/test-env-preload.ts', './src/test-setup.ts'],

--- a/docs/adr/0018-web-tier-opentelemetry.md
+++ b/docs/adr/0018-web-tier-opentelemetry.md
@@ -1,0 +1,58 @@
+# 0018 — OpenTelemetry for the Web Tier
+
+**Status:** Accepted
+**Date:** 2026-07-15
+
+## Context
+
+The portal is two services: a Next.js Node server and a .NET 10 API. Browser requests proxy through Next.js to .NET. The backend already traces with the OpenTelemetry SDK as `sebt-portal-api` (`SEBT.Portal.Api/Telemetry/`), but the Next.js hop was uninstrumented — so the proxy's call to the backend started a fresh, parentless trace, and a slow or failing request couldn't be followed across the proxy. DC-341 closes that gap: OpenTelemetry for the web tier, exported to the same collector the backend uses.
+
+## Decision
+
+Instrument the Next.js apps with the raw OpenTelemetry JS SDK, packaged as a shared `@sebt/observability` workspace package that both apps register through Next's `instrumentation.ts` hook.
+
+| Choice | Decision | Why |
+|--------|----------|-----|
+| SDK | Raw `@opentelemetry/sdk-node` | Matches the backend; no `@vercel/otel` wrapper lock-in |
+| Packaging | Shared `@sebt/observability` package | One bootstrap for both Next apps; server-only, so it stays out of client bundles |
+| Signals | Traces + metrics + logs pipeline | Logs pipeline is wired but *dark* until a pino retrofit gives it an emit source |
+| Protocol | gRPC default, switchable via `OTEL_EXPORTER_OTLP_PROTOCOL` | gRPC matches the backend (`:4317`); http/protobuf available for HTTP-only paths |
+| Proxy tracing | Manual `http.proxy` span in the API proxy route | Adds proxy-level error semantics (timeout → 504, backend down → 502) as span status/exceptions |
+
+The SDK is *inert when unconfigured*: with no `OTEL_EXPORTER_OTLP_ENDPOINT`, `startOtel` resolves every signal to `none` and never starts. An environment that hasn't been pointed at a collector pays nothing.
+
+## The connected trace
+
+`UndiciInstrumentation` is what connects the two services' traces. It patches Node's `fetch` and injects the W3C `traceparent` header on outbound calls. The proxy route's `fetch` to the backend therefore carries the active trace context, and the .NET backend (already propagating W3C TraceContext) continues the *same* trace as a child. No explicit correlation code.
+
+The manual `http.proxy` span wraps the proxy operation so its failure modes are visible — `UndiciInstrumentation` alone traces the raw HTTP call but doesn't know the proxy maps a timeout to 504 or an unreachable backend to 502.
+
+## Deployment — matches the backend exactly
+
+The app always emits OTLP to `localhost:4317`. A collector sits there and routes onward. The endpoint is a fixed convention, never a per-environment variable — same as the backend, which hardcodes `Otel:Otlp:Endpoint` in `appsettings.json` and overrides it nowhere.
+
+- **Local:** the Jaeger container in `compose.yaml`.
+- **ECS (DC dev, CO):** an ADOT collector sidecar on the web task (`module.web` in `tofu/modules/sebt_application/`), mirroring the API. It forwards traces to Datadog APM when the Datadog integration key is present, reusing the existing `otel-config.yaml.tftpl` unchanged.
+- **IIS (DC prod):** OTEL vars in the `web.config` template. These are runtime vars, so `web.config`'s `environmentVariables` block is correct — unlike `NEXT_PUBLIC_*`, which is build-time inlined.
+
+## Alternatives considered
+
+1. **`@vercel/otel`** — the Next-recommended wrapper.
+   🟡 Fastest for traces, but thinner metrics/logs support and an opinionated surface. Diverges from the backend's raw-SDK pattern.
+2. **Per-app telemetry module** (no shared package) — instrument each app in-place.
+   🟡 Simpler wiring, but the identical bootstrap drifts across two apps over time. A shared package is the same pattern already used for `@sebt/design-system` and `@sebt/analytics`.
+3. **External-endpoint model** — point the app at a collector URL via a deploy-time variable.
+   🔴 Not how the backend works. It would introduce a second, inconsistent telemetry-routing pattern and require a reachable collector to exist independently of the task.
+
+## Consequences
+
+- **Logs export is dark until a pino retrofit.** The pipeline exists, but nothing emits OTEL log records yet; `console.*` doesn't auto-convert. Traces and metrics are live; span-recorded exceptions already carry error detail. Tracked as a follow-up.
+- **The enrollment checker's server OTEL is inert in production.** It deploys as a static export (S3/CloudFront) with no Node server, so `register` only runs at build time as a no-op. Instrumentation is kept to stay SSR-ready; real telemetry there would need browser RUM (out of scope).
+- **Where signals land is collector config, not app code.** The apps emit all three signals as OTLP to the sidecar; routing is `otel-config.yaml.tftpl`'s job — Datadog for dev/CO, Splunk for DC (the in-flight telemetry work). Today the collector sends traces to Datadog APM and metrics to CloudWatch, with no logs pipeline; extending it to route metrics and logs onward is that collector work, not a change here.
+- Adding a new signal or instrumentation is a one-file change in `@sebt/observability`, inherited by both apps.
+
+## References
+
+- [DC-341](https://codeforamerica.atlassian.net/browse/DC-341) — this work
+- `SEBT.Portal.Api/Telemetry/` — the backend OpenTelemetry setup this mirrors
+- Numbered 0018 because `0017` is the merged monorepo-consolidation ADR.

--- a/scripts/ci/templates/web.config
+++ b/scripts/ci/templates/web.config
@@ -15,6 +15,11 @@
         <environmentVariable name="NODE_ENV" value="production" />
         <environmentVariable name="BACKEND_URL" value="http://localhost:5280" />
         <environmentVariable name="NEXT_PUBLIC_STATE" value="dc" />
+        <!-- Emit OTLP to a collector on localhost:4317, matching the backend.
+             Setting the endpoint is what turns the web SDK on. -->
+        <environmentVariable name="OTEL_EXPORTER_OTLP_ENDPOINT" value="http://localhost:4317" />
+        <environmentVariable name="OTEL_SERVICE_NAME" value="sebt-portal-web" />
+        <environmentVariable name="OTEL_DEPLOYMENT_ENVIRONMENT" value="production" />
       </environmentVariables>
     </httpPlatform>
     <security>

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -111,7 +111,7 @@ module "api" {
 # via an internet facing Application Load Balancer. It communicates with the                                                                      
 # API service internally through the VPC.                                                                                                         
 module "web" {
-  source  = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.10.0"
+  source  = "github.com/codeforamerica/tofu-modules-aws-fargate-service?ref=1.13.0"
   project = "${var.project}-${var.state}"
   # TODO Make project_short a variable
   project_short = "sebt"

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -153,9 +153,22 @@ module "web" {
     STATE             = lower(var.state)
     NEXT_PUBLIC_STATE = lower(var.state)
     BACKEND_URL       = "https://${module.api.endpoint_url}"
+    # Emit OTLP to the collector sidecar (declared below); mirrors the API.
+    OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+    OTEL_SERVICE_NAME           = "sebt-portal-web"
+    OTEL_DEPLOYMENT_ENVIRONMENT = var.environment
   }, var.state_web_environment_variables)
 
   environment_secrets = var.state_web_environment_secrets
+
+  # ADOT collector sidecar, mirroring module.api (forwards traces to Datadog APM
+  # when the integration key is present).
+  otel_collector_version = "v0.47.0"
+  otel_config = local.otel_override_config ? templatefile("${path.module}/templates/otel-config.yaml.tftpl", {
+    app_namespace = "${var.project}-${var.state}/web"
+    environment   = var.environment
+  }) : null
+  otel_secrets = local.otel_secrets
 }
 
 # Store application secrets in Secrets Manager.


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-341

#### ✍️ Description
Second of the DC-341 stack, based on #468. Turns the instrumentation on and ships it.

- **`http.proxy` span** on the API proxy route. Captures method/path/status, marks the span ERROR on 4xx/5xx, records exceptions on timeout (504) and backend-down (502). It nests under the propagated trace — `UndiciInstrumentation` injects the outbound `traceparent`, so the .NET backend continues the same trace. 8 tests.
- **ECS (DC dev, CO):** an ADOT collector sidecar on the web task, mirroring `module.api`. Forwards traces to Datadog APM when the DD key is present; reuses the existing collector template.
- **IIS (DC prod):** OTEL runtime env in `web.config`.
- **ADR 0018** records the design.

The deployment model matches the backend: the app emits OTLP to `localhost:4317` and a collector routes onward — Jaeger locally, the ADOT sidecar in ECS, the host collector in IIS prod. No per-environment endpoint variable.

⚠️ The Tofu sidecar isn't machine-verified — no `tofu plan` here (needs AWS creds). It mirrors the proven `module.api` block and passes `terraform fmt`. Run `tofu plan` against dev-dc / dev-co before apply.

#### 🔗 Links to related PRs
- #468

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] New env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_DEPLOYMENT_ENVIRONMENT`) added in Tofu (`module.web`) and the IIS `web.config`
  - [ ] No new secrets — reuses the existing Datadog key via `otel_secrets`
  - [ ] No new appsettings
