### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@
 
 ## Git worktrees
 .worktrees/
-
-## Git worktrees
-.worktrees/
+.claude/worktrees/
 
 ## GitHub Actions Local Testing (act)
 .secrets


### PR DESCRIPTION
#### 🔗 Jira ticket
N/A

#### ✍️ Description
Adds `.claude/worktrees/` to .gitignore. The is the default directory for git worktrees when Claude Code uses a skill to assist with managing them.