### PR TITLE
[DC-599] Reflect the real environment in analytics data layer

### DIFF
--- a/.github/workflows/scripts/test-frontend.sh
+++ b/.github/workflows/scripts/test-frontend.sh
@@ -123,6 +123,17 @@ run_tests() {
   fi
 }
 
+# Run shared workspace package tests (packages/*). The web app's own `pnpm run
+# test` only covers apps/portal/src/SEBT.Portal.Web/src; without this the shared
+# @sebt/analytics and @sebt/design-system suites never run in CI.
+run_package_tests() {
+  log_info "Running shared package tests (packages/*)..."
+  cd "$PROJECT_ROOT"
+
+  pnpm --filter "./packages/*" --if-present run test
+  log_success "Package tests passed"
+}
+
 # Run type checking
 run_type_check() {
   log_info "Running TypeScript type checking..."
@@ -146,6 +157,7 @@ main() {
   run_type_check
   run_lint
   run_tests
+  run_package_tests
 
   echo ""
   log_success "=== All frontend tests passed ==="

--- a/packages/analytics/src/DataLayerProvider.test.tsx
+++ b/packages/analytics/src/DataLayerProvider.test.tsx
@@ -205,6 +205,37 @@ describe('PageTracker (via DataLayerProvider)', () => {
   })
 })
 
+describe('environment (via DataLayerProvider)', () => {
+  beforeEach(() => {
+    delete (window as unknown as Record<string, unknown>).digitalData
+  })
+
+  it('derives page.environment from the hostname when no prop is given', () => {
+    new DataLayer('digitalData')
+
+    render(
+      <DataLayerProvider application="test">
+        <div />
+      </DataLayerProvider>
+    )
+
+    // jsdom serves from http://localhost
+    expect(window.digitalData!.get('page.environment')).toBe('local')
+  })
+
+  it('prefers an explicit environment prop over host derivation', () => {
+    new DataLayer('digitalData')
+
+    render(
+      <DataLayerProvider application="test" environment="staging">
+        <div />
+      </DataLayerProvider>
+    )
+
+    expect(window.digitalData!.get('page.environment')).toBe('staging')
+  })
+})
+
 describe('WebVitalsTracker (via DataLayerProvider)', () => {
   beforeEach(() => {
     delete (window as unknown as Record<string, unknown>).digitalData

--- a/packages/analytics/src/DataLayerProvider.tsx
+++ b/packages/analytics/src/DataLayerProvider.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation'
 import { useEffect, useLayoutEffect, useRef, type ReactNode } from 'react'
 
 import { DataLayer } from './data-layer'
+import { deriveEnvironmentFromHost } from './environment'
 import { CTA_CLICK } from './events'
 import { initWebVitals } from './web-vitals'
 
@@ -22,7 +23,11 @@ export type RoutePageContextMap = Record<string, PageContext>
 interface DataLayerProviderProps {
   /** Application identifier set on page.application (e.g., "sebt-portal", "sebt-enrollment-checker") */
   application: string
-  /** Environment name (e.g., "dev", "staging", "production"). Defaults to NEXT_PUBLIC_ENVIRONMENT or "production". */
+  /**
+   * Environment name (e.g., "dev", "staging", "production"). Optional — when omitted,
+   * it falls back to NEXT_PUBLIC_ENVIRONMENT, and then to a value derived from the
+   * hostname at runtime (see {@link deriveEnvironmentFromHost}).
+   */
   environment?: string
   /** Map of pathname to page context. When navigation occurs, matching context is set and pageLoad() fires. */
   routes?: RoutePageContextMap
@@ -59,7 +64,9 @@ export function DataLayerProvider({
     window.digitalData!.page.set('entry_source', application.replace('sebt-', '').replace(/-/g, '_'))
     window.digitalData!.page.set(
       'environment',
-      environment ?? process.env.NEXT_PUBLIC_ENVIRONMENT ?? 'production'
+      environment ??
+        process.env.NEXT_PUBLIC_ENVIRONMENT ??
+        deriveEnvironmentFromHost(window.location.hostname)
     )
   }, [application, environment])
 

--- a/packages/analytics/src/environment.test.ts
+++ b/packages/analytics/src/environment.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveEnvironmentFromHost } from './environment'
+
+describe('deriveEnvironmentFromHost', () => {
+  it('returns the environment prefix for non-production hosts', () => {
+    expect(deriveEnvironmentFromHost('dev.co.sebt-portal.codeforamerica.app')).toBe('dev')
+    expect(deriveEnvironmentFromHost('dev.co.sebt-enrollment.codeforamerica.app')).toBe('dev')
+    expect(deriveEnvironmentFromHost('dev.dc.sebt-portal.codeforamerica.app')).toBe('dev')
+    expect(deriveEnvironmentFromHost('staging.co.sebt-portal.codeforamerica.app')).toBe('staging')
+    expect(deriveEnvironmentFromHost('test.co.sebt-portal.codeforamerica.app')).toBe('test')
+    expect(deriveEnvironmentFromHost('qa.co.sebt-portal.codeforamerica.app')).toBe('qa')
+    expect(deriveEnvironmentFromHost('uat.co.sebt-portal.codeforamerica.app')).toBe('uat')
+  })
+
+  it('returns "local" for local development hosts', () => {
+    expect(deriveEnvironmentFromHost('localhost')).toBe('local')
+    expect(deriveEnvironmentFromHost('127.0.0.1')).toBe('local')
+    expect(deriveEnvironmentFromHost('sebt.local')).toBe('local')
+  })
+
+  it('treats production hosts (no environment prefix) as "production"', () => {
+    expect(deriveEnvironmentFromHost('co.sebt-portal.codeforamerica.app')).toBe('production')
+    expect(deriveEnvironmentFromHost('dc.sebt-portal.codeforamerica.app')).toBe('production')
+    expect(deriveEnvironmentFromHost('sunbucks.dc.gov')).toBe('production')
+    expect(deriveEnvironmentFromHost('benefits.sunbucks.dc.gov')).toBe('production')
+  })
+
+  it('defaults unknown or empty hosts to "production"', () => {
+    expect(deriveEnvironmentFromHost('')).toBe('production')
+    expect(deriveEnvironmentFromHost('example.com')).toBe('production')
+  })
+})

--- a/packages/analytics/src/environment.ts
+++ b/packages/analytics/src/environment.ts
@@ -1,0 +1,21 @@
+const NON_PROD_PREFIXES = new Set(['dev', 'staging', 'test', 'qa', 'uat'])
+
+/**
+ * Derives the analytics environment label from a browser hostname.
+ *
+ * page.environment is a client-side telemetry dimension, so the host the user is
+ * actually on is the most reliable signal — and, unlike a build-time NEXT_PUBLIC_*
+ * value, it resolves correctly for both the server-rendered portal and the
+ * statically-exported enrollment checker, and survives promote-the-binary deploys.
+ *
+ * Non-production hosts carry a known environment prefix as their leftmost label
+ * (e.g. dev.co.sebt-portal…) or are local. Every other host — production .gov
+ * domains and prefix-less apex hosts — is treated as production.
+ */
+export function deriveEnvironmentFromHost(hostname: string): string {
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname.endsWith('.local')) {
+    return 'local'
+  }
+  const prefix = hostname.split('.')[0] ?? ''
+  return NON_PROD_PREFIXES.has(prefix) ? prefix : 'production'
+}

--- a/scripts/ci/test-frontend.sh
+++ b/scripts/ci/test-frontend.sh
@@ -109,6 +109,17 @@ run_tests() {
   fi
 }
 
+# Run shared workspace package tests (packages/*). The web app's own `pnpm run
+# test` only covers apps/portal/src/SEBT.Portal.Web/src; without this the shared
+# @sebt/analytics and @sebt/design-system suites never run in CI.
+run_package_tests() {
+  log_info "Running shared package tests (packages/*)..."
+  cd "$PROJECT_ROOT"
+
+  pnpm --filter "./packages/*" --if-present run test
+  log_success "Package tests passed"
+}
+
 # Run type checking
 run_type_check() {
   log_info "Running TypeScript type checking..."
@@ -131,6 +142,7 @@ main() {
   run_type_check
   run_lint
   run_tests
+  run_package_tests
 
   echo ""
   log_success "=== All frontend tests passed ==="


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-599

#### ✍️ Description
`digitalData.page.environment` always reported `"production"`, even on non-prod hosts like `dev.co.sebt-portal.codeforamerica.app`.

**Root cause:** the value resolved to `environment ?? NEXT_PUBLIC_ENVIRONMENT ?? 'production'`, but `NEXT_PUBLIC_ENVIRONMENT` was never declared in the env schema or threaded through any build, and neither app passed the `environment` prop — so it always fell through to the `'production'` literal.

**Fix:** derive the label from the browser hostname at runtime, in the shared `@sebt/analytics` package. `page.environment` is a client-side telemetry dimension, so the host the user is actually on is the most reliable signal — and unlike a build-time `NEXT_PUBLIC_*` value it works for both the SSR portal and the statically-exported enrollment checker, survives promote-the-binary deploys, and can't silently regress to `production` if a CI variable is left unset. The existing `environment` prop and `NEXT_PUBLIC_ENVIRONMENT` remain as higher-priority overrides.

Host → label:

| Host | Label |
|------|-------|
| `dev.*` / `staging.*` / `test.*` / `qa.*` / `uat.*` | that prefix |
| `localhost` / `127.0.0.1` / `*.local` | `local` |
| prod `.gov` and prefix-less apex hosts | `production` |

The one assumption: production hosts carry no `dev.`/`staging.` prefix (prod is the default). That holds for the current CO/DC domains.

**Also (CI gap):** the shared `packages/*` suites (`@sebt/analytics`, `@sebt/design-system`) were not run by any CI job — the frontend test step only covered `SEBT.Portal.Web/src`. Added a `run_package_tests` step to both frontend test scripts so they now gate CI (analytics 142, design-system 164). Because this PR touches `.github/` + `scripts/`, the full CI matrix runs and this new step exercises the analytics fix here.

Fixes both the portal and enrollment checker via the shared package; no public API change (the `environment` prop stays optional).

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes: none — environment is derived at runtime from the hostname; no new env vars, secrets, or appsettings
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
