### PR TITLE
DC-626(Chore): Upgrade brace-expansion; Remove: NPM/NPX from alpine image

### DIFF
--- a/apps/portal/src/SEBT.EnrollmentChecker.Web/Dockerfile.ssr
+++ b/apps/portal/src/SEBT.EnrollmentChecker.Web/Dockerfile.ssr
@@ -10,8 +10,13 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/ ./packages/
 COPY apps/portal/src/SEBT.EnrollmentChecker.Web/ ./apps/portal/src/SEBT.EnrollmentChecker.Web/
 
-# Install dependencies (workspace-aware)
-RUN corepack enable && pnpm install --frozen-lockfile
+# Install dependencies (workspace-aware).
+# Drop the base image's npm after pnpm is active — npm ships a vulnerable
+# node-tar (CVE-2026-59873 / CVE-2026-59874) that we never invoke.
+RUN corepack enable \
+  && corepack prepare pnpm@10 --activate \
+  && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+  && pnpm install --frozen-lockfile
 
 # Build SSR standalone output
 ARG STATE=co
@@ -32,8 +37,10 @@ RUN BUILD_STANDALONE=true pnpm --filter @sebt/enrollment-checker build
 FROM node:24-alpine AS runner
 WORKDIR /app
 
-# Non-root user for security
-RUN addgroup -S app && adduser -S app -G app
+# Runtime only needs the node binary. Remove npm/npx (and nested node-tar)
+# so container scans don't flag CVE-2026-59873 / CVE-2026-59874 from the base image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+  && addgroup -S app && adduser -S app -G app
 
 COPY --from=builder /app/apps/portal/src/SEBT.EnrollmentChecker.Web/.next/standalone ./
 COPY --from=builder /app/apps/portal/src/SEBT.EnrollmentChecker.Web/.next/static ./apps/portal/src/SEBT.EnrollmentChecker.Web/.next/static

--- a/apps/portal/src/SEBT.Portal.Web/Dockerfile
+++ b/apps/portal/src/SEBT.Portal.Web/Dockerfile
@@ -32,9 +32,12 @@ COPY packages/analytics/ ./packages/analytics/
 # Copy web workspace
 COPY apps/portal/src/SEBT.Portal.Web/ ./apps/portal/src/SEBT.Portal.Web/
 
-# Install + build web only
+# Install + build web only.
+# Drop the base image's npm after pnpm is active — npm ships a vulnerable
+# node-tar (CVE-2026-59873 / CVE-2026-59874) that we never invoke.
 RUN corepack enable \
   && corepack prepare pnpm@10 --activate \
+  && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
   && pnpm install --frozen-lockfile \
   && cd apps/portal/src/SEBT.Portal.Web \
   && pnpm build
@@ -46,8 +49,10 @@ ENV PORT=3000
 
 WORKDIR /app
 
-# Non-root user for security (mirrors the enrollment checker's Dockerfile.ssr)
-RUN addgroup -S app && adduser -S app -G app
+# Runtime only needs the node binary. Remove npm/npx (and nested node-tar)
+# so container scans don't flag CVE-2026-59873 / CVE-2026-59874 from the base image.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+  && addgroup -S app && adduser -S app -G app
 
 # Next standalone output
 COPY --from=build /workspace/apps/portal/src/SEBT.Portal.Web/.next/standalone ./

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,92 +36,6 @@ importers:
         specifier: ~2.9.0
         version: 2.9.0
 
-  packages/analytics:
-    dependencies:
-      web-vitals:
-        specifier: ^5.3.0
-        version: 5.3.0
-    devDependencies:
-      '@amplitude/analytics-browser':
-        specifier: ^2.40.0
-        version: 2.42.3
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.15
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
-      next:
-        specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
-      react:
-        specifier: 19.2.6
-        version: 19.2.6
-      react-dom:
-        specifier: 19.2.6
-        version: 19.2.6(react@19.2.6)
-      vite:
-        specifier: '>=8.0.16'
-        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
-
-  packages/design-system:
-    dependencies:
-      markdown-to-jsx:
-        specifier: ^9.8.0
-        version: 9.8.0(react@19.2.6)
-    devDependencies:
-      '@testing-library/jest-dom':
-        specifier: ^6.9.1
-        version: 6.9.1
-      '@testing-library/react':
-        specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@testing-library/user-event':
-        specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/node':
-        specifier: ^25.8.0
-        version: 25.9.1
-      '@types/react':
-        specifier: ^19.2.14
-        version: 19.2.15
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.15)
-      '@vitejs/plugin-react':
-        specifier: ^6.0.1
-        version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
-      i18next:
-        specifier: ^26.1.0
-        version: 26.2.0(typescript@6.0.3)
-      jsdom:
-        specifier: ^29.1.1
-        version: 29.1.1
-      next:
-        specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
-      react:
-        specifier: 19.2.6
-        version: 19.2.6
-      react-dom:
-        specifier: 19.2.6
-        version: 19.2.6(react@19.2.6)
-      react-i18next:
-        specifier: ^17.0.7
-        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      vite:
-        specifier: '>=8.0.16'
-        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
-      vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
-
   apps/portal/src/SEBT.EnrollmentChecker.Web:
     dependencies:
       '@amplitude/analytics-browser':
@@ -363,6 +277,92 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/analytics:
+    dependencies:
+      web-vitals:
+        specifier: ^5.3.0
+        version: 5.3.0
+    devDependencies:
+      '@amplitude/analytics-browser':
+        specifier: ^2.40.0
+        version: 2.42.3
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.15
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+      vite:
+        specifier: '>=8.0.16'
+        version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.9.1)(@vitest/coverage-v8@4.1.6)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.1)(typescript@6.0.3))(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/design-system:
+    dependencies:
+      markdown-to-jsx:
+        specifier: ^9.8.0
+        version: 9.8.0(react@19.2.6)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^25.8.0
+        version: 25.9.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0))
+      i18next:
+        specifier: ^26.1.0
+        version: 26.2.0(typescript@6.0.3)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      next:
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
+      react-i18next:
+        specifier: ^17.0.7
+        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       vite:
         specifier: '>=8.0.16'
         version: 8.1.0(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(tsx@4.22.3)(yaml@2.9.0)
@@ -2261,11 +2261,11 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -6960,12 +6960,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8787,11 +8787,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-626

#### ✍️ Description
Remediates CVE-2026-13149, CVE-2026-59873, and CVE-2026-59874.

- Bump transitive `brace-expansion` in `pnpm-lock.yaml` from 1.1.14 to 1.1.16 and from 5.0.6 to 5.0.7 (parent `minimatch` ranges already allow these patches).
- Remove `npm`/`npx` from the Node Alpine build and runtime stages in the Portal Web and Enrollment Checker SSR Dockerfiles. The vulnerable `tar` package that was noted in the CVE is not specifically an app dependency; it ships nested under the base image's `npm`.  We technically ONLY need `node` and the image doesn't have any fix out with a patch versioned of `npm` available, so the workaround for now is to strip it out.  This might seem crazy on paper, but since we're using `pnpm`, our app should be able to build fine without it.

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks
- [ ] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
```

**Test Notes**:  Try rebuilding/redeploying the Web image, confirm the container starts with `node server.js`, and re-run the scans.