### PR TITLE
DC-250: Install rotation Lambda dependencies in CI, not via local-exec

### DIFF
--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -320,6 +320,23 @@ jobs:
           docker push ${API_REPO}:${IMAGE_TAG}
           docker push ${WEB_REPO}:${IMAGE_TAG}
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Install DB rotation Lambda dependencies
+        run: |
+          pip install \
+            --platform manylinux_2_28_x86_64 \
+            --target tofu/modules/sebt_database/lambda \
+            --implementation cp \
+            --python-version 3.12 \
+            --only-binary :all: \
+            --upgrade \
+            --quiet \
+            -r tofu/modules/sebt_database/lambda/requirements.txt
+
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         with:
@@ -407,6 +424,23 @@ jobs:
 
           docker push ${API_REPO}:${IMAGE_TAG}
           docker push ${WEB_REPO}:${IMAGE_TAG}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Install DB rotation Lambda dependencies
+        run: |
+          pip install \
+            --platform manylinux_2_28_x86_64 \
+            --target tofu/modules/sebt_database/lambda \
+            --implementation cp \
+            --python-version 3.12 \
+            --only-binary :all: \
+            --upgrade \
+            --quiet \
+            -r tofu/modules/sebt_database/lambda/requirements.txt
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1

--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -326,16 +326,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install DB rotation Lambda dependencies
-        run: |
-          pip install \
-            --platform manylinux_2_28_x86_64 \
-            --target tofu/modules/sebt_database/lambda \
-            --implementation cp \
-            --python-version 3.12 \
-            --only-binary :all: \
-            --upgrade \
-            --quiet \
-            -r tofu/modules/sebt_database/lambda/requirements.txt
+        run: ./.github/workflows/scripts/install-rotation-lambda-deps.sh
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
@@ -431,16 +422,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install DB rotation Lambda dependencies
-        run: |
-          pip install \
-            --platform manylinux_2_28_x86_64 \
-            --target tofu/modules/sebt_database/lambda \
-            --implementation cp \
-            --python-version 3.12 \
-            --only-binary :all: \
-            --upgrade \
-            --quiet \
-            -r tofu/modules/sebt_database/lambda/requirements.txt
+        run: ./.github/workflows/scripts/install-rotation-lambda-deps.sh
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -53,16 +53,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install DB rotation Lambda dependencies
-        run: |
-          pip install \
-            --platform manylinux_2_28_x86_64 \
-            --target tofu/modules/sebt_database/lambda \
-            --implementation cp \
-            --python-version 3.12 \
-            --only-binary :all: \
-            --upgrade \
-            --quiet \
-            -r tofu/modules/sebt_database/lambda/requirements.txt
+        run: ./.github/workflows/scripts/install-rotation-lambda-deps.sh
 
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -47,6 +47,23 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Install DB rotation Lambda dependencies
+        run: |
+          pip install \
+            --platform manylinux_2_28_x86_64 \
+            --target tofu/modules/sebt_database/lambda \
+            --implementation cp \
+            --python-version 3.12 \
+            --only-binary :all: \
+            --upgrade \
+            --quiet \
+            -r tofu/modules/sebt_database/lambda/requirements.txt
+
       - name: Install OpenTofu
         uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
         with:

--- a/.github/workflows/scripts/install-rotation-lambda-deps.sh
+++ b/.github/workflows/scripts/install-rotation-lambda-deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Installs the DB rotation Lambda's Python dependencies. pymssql ships native
+# extensions, so it must be installed for the Lambda's target platform
+# (manylinux, x86_64, CPython 3.12) rather than the host OS. Shared by
+# deploy-ecr.yaml and plan.yaml so the install command can't drift between
+# the dc/co deploy jobs and the plan job.
+#
+# Usage
+#   ./.github/workflows/scripts/install-rotation-lambda-deps.sh
+
+set -e  # Exit on error
+set -u  # Exit on undefined variable
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "$0" )" &> /dev/null && pwd -P )
+LAMBDA_DIR="$SCRIPT_DIR/../../../tofu/modules/sebt_database/lambda"
+
+pip install \
+  --platform manylinux_2_28_x86_64 \
+  --target "$LAMBDA_DIR" \
+  --implementation cp \
+  --python-version 3.12 \
+  --only-binary :all: \
+  --upgrade \
+  --quiet \
+  -r "$LAMBDA_DIR/requirements.txt"

--- a/.gitignore
+++ b/.gitignore
@@ -473,6 +473,7 @@ tofu/modules/sebt_ses/lambda/*.zip
 tofu/modules/sebt_database/lambda/.venv/
 tofu/modules/sebt_database/lambda/pymssql/
 tofu/modules/sebt_database/lambda/pymssql-*.dist-info/
+tofu/modules/sebt_database/lambda/pymssql.libs/
 tofu/modules/sebt_database/*.zip
 
 

--- a/tofu/modules/sebt_database/rotation.tf
+++ b/tofu/modules/sebt_database/rotation.tf
@@ -38,27 +38,15 @@ resource "aws_secretsmanager_secret_version" "app_user_initial" {
 
 # ─── Lambda package ──────────────────────────────────────────────────────────
 #
-# pymssql ships native extensions so it must be installed for the Lambda's
+# pymssql ships native extensions, so it must be installed for the Lambda's
 # target platform (manylinux, x86_64, CPython 3.12) rather than the host OS.
-# The terraform_data resource re-runs pip whenever requirements.txt changes.
-
-resource "terraform_data" "lambda_dependencies" {
-  triggers_replace = [filemd5("${path.module}/lambda/requirements.txt")]
-
-  provisioner "local-exec" {
-    command = <<-EOT
-      pip install \
-        --platform manylinux_2_28_x86_64 \
-        --target "${path.module}/lambda" \
-        --implementation cp \
-        --python-version 3.12 \
-        --only-binary :all: \
-        --upgrade \
-        --quiet \
-        -r "${path.module}/lambda/requirements.txt"
-    EOT
-  }
-}
+# CI installs it into lambda/ as an explicit step before running tofu (see
+# deploy-ecr.yaml and plan.yaml), so it's already present by the time this
+# data source reads the directory. Running `tofu apply` locally requires the
+# same install first:
+#   pip install --platform manylinux_2_28_x86_64 --target lambda \
+#     --implementation cp --python-version 3.12 --only-binary :all: \
+#     --upgrade -r lambda/requirements.txt
 
 data "archive_file" "rotation_lambda" {
   type        = "zip"
@@ -71,8 +59,6 @@ data "archive_file" "rotation_lambda" {
     "requirements-test.txt",
     "test_rotate_db_credentials.py",
   ]
-
-  depends_on = [terraform_data.lambda_dependencies]
 }
 
 # ─── Lambda security group ────────────────────────────────────────────────────


### PR DESCRIPTION
#### 🔗 Jira ticket
DC-250

#### ✍️ Description
After merging #495, forcing a rotation in DC dev surfaced a Lambda failure: every invocation crashed with `Runtime.ImportModuleError: No module named 'pymssql'` before any of our code ran.

Root cause: `rotation.tf`'s `terraform_data.lambda_dependencies` installed pymssql's native wheel via a `local-exec` provisioner keyed off `requirements.txt`. Since #495 didn't touch `requirements.txt`, that trigger hash matched what was already in state, so Terraform correctly determined "no config change" and skipped the provisioner — but on `deploy-ecr`'s ephemeral GitHub Actions runner, skipping it meant `pip install` never actually ran on this runner's disk, so `archive_file.rotation_lambda` zipped up the Lambda's Python source with no vendored dependency at all.

This PR removes that provisioner entirely and moves the install to where it belongs: an explicit, unconditional CI step (mirroring the existing pattern in lambda-tests.yaml) that runs before `tofu apply/tofu plan`, so the dependency is always vendored regardless of runner state. `archive_file`'s hash now only changes when the Python source or the pinned dependency version actually changes.

Changes:
- `rotation.tf`: removed `terraform_data.lambda_dependencies` and the `depends_on` on `archive_file.rotation_lambda`.
- `deploy-ecr.yaml`: added `Set up Python` + `Install DB rotation Lambda` dependencies steps to both `deploy-dc` and `deploy-co` jobs, before Install OpenTofu.
- `plan.yaml`: same two steps, so PR preview plans reflect an accurate Lambda diff too.
- Pinned `actions/setup-python` to `v7.0.0` SHA (current latest at time of writing)