### PR TITLE
Upgrade: libphonenumber to 9.0.34 in Infrastructure

### DIFF
--- a/apps/portal/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
       <PackageReference Include="Bogus" Version="35.6.5" />
-      <PackageReference Include="libphonenumber-csharp" Version="9.0.30" />
+      <PackageReference Include="libphonenumber-csharp" Version="9.0.34" />
       <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />


### PR DESCRIPTION
#### 🔗 Jira ticket
N/A

#### ✍️ Description
This is just bumping the `libphonenumber` library to be in parity with the one in the Colorado plugin.  Dependabot doesn't account for shared assemblies between the host and the plugin, so we'll need to be careful in the future.

#### 🔗 Links to related PRs
<!-- If applicable, include links to dependent or related PRs in this or other repos  -->

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
