### PR TITLE
DC-665 Update: Health check to include Portal DB

### DIFF
--- a/apps/portal/src/SEBT.Portal.Api/Program.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Program.cs
@@ -166,6 +166,7 @@ builder.Services.AddFeatureManagement(builder.Configuration.GetSection("FeatureM
 builder.Services.AddUseCases();
 builder.Services.AddPortalInfrastructureServices(builder.Configuration);
 builder.Services.AddPortalDbContext(builder.Configuration, options => options.ConfigureDevelopmentSeeding());
+builder.Services.AddPortalDbHealthCheck(builder.Configuration);
 builder.Services.AddPortalInfrastructureRepositories(builder.Configuration);
 builder.Services.AddPortalInfrastructureAppSettings(builder.Configuration);
 

--- a/apps/portal/src/SEBT.Portal.Api/Startup/PortalDbHealthCheck.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Startup/PortalDbHealthCheck.cs
@@ -1,0 +1,33 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace SEBT.Portal.Api.Startup;
+
+/// <summary>
+/// Verifies connectivity to the portal SQL Server database by opening a
+/// connection and executing <c>SELECT 1</c>.
+/// </summary>
+internal class PortalDbHealthCheck(string connectionString) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = new SqlConnection(connectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new SqlCommand("SELECT 1", connection);
+            await command.ExecuteScalarAsync(cancellationToken);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            // Degraded (not Unhealthy) so ALB continues routing to the task while
+            // /health still surfaces the DB outage in its structured response.
+            return HealthCheckResult.Degraded(ex.Message, ex);
+        }
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Api/Startup/PortalDbHealthCheckExtensions.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Startup/PortalDbHealthCheckExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace SEBT.Portal.Api.Startup;
+
+/// <summary>
+/// Registers the portal database connectivity health check.
+/// </summary>
+internal static class PortalDbHealthCheckExtensions
+{
+    internal const string CheckName = "portal-db";
+
+    public static IServiceCollection AddPortalDbHealthCheck(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+
+        services.AddHealthChecks().AddCheck(
+            CheckName,
+            new PortalDbHealthCheck(connectionString),
+            failureStatus: HealthStatus.Degraded,
+            tags: ["database", "portal"]);
+
+        return services;
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Integration/HealthCheckEndpointTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Integration/HealthCheckEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using SEBT.Portal.Api.Startup;
 
 namespace SEBT.Portal.Tests.Integration;
 
@@ -34,12 +35,22 @@ public class HealthCheckEndpointTests : IClassFixture<PortalWebApplicationFactor
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        Assert.Equal("Healthy", root.GetProperty("status").GetString());
+        // Overall may be Healthy (SQL reachable) or Degraded (SQL unreachable in CI).
+        // Degraded still returns HTTP 200 so ALB keeps the task in service.
+        var status = root.GetProperty("status").GetString();
+        Assert.True(
+            status is "Healthy" or "Degraded",
+            $"Unexpected overall status: {status}");
+
         Assert.True(root.TryGetProperty("totalDuration", out var duration));
         Assert.Equal(JsonValueKind.Number, duration.ValueKind);
         Assert.True(root.TryGetProperty("checks", out var checks));
         Assert.Equal(JsonValueKind.Array, checks.ValueKind);
-        // No plugins loaded in test → no state health checks → empty array
-        Assert.Equal(0, checks.GetArrayLength());
+
+        // Portal DB check is always registered (state plugins may also appear depending on env).
+        var checkNames = checks.EnumerateArray()
+            .Select(c => c.GetProperty("name").GetString())
+            .ToList();
+        Assert.Contains(PortalDbHealthCheckExtensions.CheckName, checkNames);
     }
 }

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Api/Startup/PortalDbHealthCheckTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Api/Startup/PortalDbHealthCheckTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using SEBT.Portal.Api.Startup;
+
+namespace SEBT.Portal.Tests.Unit.Api.Startup;
+
+public class PortalDbHealthCheckTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenConnectionStringIsUnreachable()
+    {
+        var check = new PortalDbHealthCheck(
+            "Server=localhost,19999;Database=NonExistent;TrustServerCertificate=true;Connect Timeout=1");
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.NotNull(result.Exception);
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-665

#### ✍️ Description
Adds a portal MSSQL connectivity check to the API `/health` endpoint. Previously `/health` only ran state-plugin checks (CBMS for CO, DC source SQL for DC), so a `Healthy` response did not confirm the API could reach its own database.

The new `portal-db` check basically opens `ConnectionStrings:DefaultConnection` and runs `SELECT 1`. Failures report `Degraded` so ALB keeps routing to the task while the structured JSON still surfaces the outage. This already do this for the DC SQL health-check pattern, so this is mostly a copy from that work.

#### 🔗 Links to related PRs
N/A

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig