### PR TITLE
feat(DC-568): state-backend config model (vocabulary records)

### DIFF
--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Auth/StateBackendApiKeyAuthScheme.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Auth/StateBackendApiKeyAuthScheme.cs
@@ -1,0 +1,7 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Auth;
+
+public sealed record StateBackendApiKeyAuthScheme : StateBackendAuthScheme
+{
+    public required string Header { get; init; }
+    public required string KeyRef { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Auth/StateBackendAuthScheme.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Auth/StateBackendAuthScheme.cs
@@ -1,0 +1,3 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Auth;
+
+public abstract record StateBackendAuthScheme;

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Auth/StateBackendOAuthClientCredentialsAuthScheme.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Auth/StateBackendOAuthClientCredentialsAuthScheme.cs
@@ -1,0 +1,9 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Auth;
+
+public sealed record StateBackendOAuthClientCredentialsAuthScheme : StateBackendAuthScheme
+{
+    public required Uri TokenUrl { get; init; }
+    public required string ClientId { get; init; }
+    public required string ClientSecretRef { get; init; }
+    public string? Scope { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/AddressUpdateOperationConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/AddressUpdateOperationConfig.cs
@@ -1,0 +1,10 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public sealed record AddressUpdateOperationConfig() : StateBackendOperationConfig
+{
+    /// <summary>How to build the outgoing address-update request body.</summary>
+    public RequestBinding? Request { get; init; }
+
+    /// <summary>How to classify the backend's response into a canonical address-update outcome.</summary>
+    public ResultClassifier? Result { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/CardReplacementOperationConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/CardReplacementOperationConfig.cs
@@ -1,0 +1,10 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public sealed record CardReplacementOperationConfig() : StateBackendOperationConfig
+{
+    /// <summary>How to build the outgoing card-replacement request body; inputs include the decoded caseId fields.</summary>
+    public RequestBinding? Request { get; init; }
+
+    /// <summary>How to classify the backend's response into a canonical card-replacement outcome.</summary>
+    public ResultClassifier? Result { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/CaseIdComposition.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/CaseIdComposition.cs
@@ -1,0 +1,11 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Which fields compose a case's opaque (not encrypted) caseId token; a later write decodes them back as request-binding inputs.</summary>
+public sealed record CaseIdComposition
+{
+    /// <summary>Our routing-field name → the source property on the record whose value it carries.</summary>
+    public required Dictionary<string, string> Fields { get; init; }
+
+    /// <summary>Our routing-field name → a named <see cref="CaseIdContext"/> value; context names are a closed vocabulary resolved in code.</summary>
+    public Dictionary<string, string>? FromContext { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/EnrollmentCheckOperationConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/EnrollmentCheckOperationConfig.cs
@@ -1,0 +1,95 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>How the driver fans a child batch out to backend calls.</summary>
+public enum EnrollmentCallMode
+{
+    /// <summary>One backend call carrying every child as a correlated row.</summary>
+    Batch,
+
+    /// <summary>One call per child.</summary>
+    PerChild,
+}
+
+/// <summary>Request-side candidate-expansion strategy — closed set; add a named member, never operators.</summary>
+public enum CandidateExpansion
+{
+    /// <summary>Exactly one request row per child.</summary>
+    None,
+
+    /// <summary>Also emit a month/day-swapped DOB row.</summary>
+    TransposeMonthDay,
+}
+
+/// <summary>How a match is decided — closed set; add a named strategy, never operators.</summary>
+public enum EnrollmentMatchStrategy
+{
+    /// <summary>A row field's value is in a set.</summary>
+    AnyRowValueIn,
+
+    /// <summary>The best row's score strictly exceeds a threshold.</summary>
+    ConfidenceThreshold,
+}
+
+/// <summary>The enrollmentCheck operation: batch fan-out plus a per-child match verdict.</summary>
+public sealed record EnrollmentCheckOperationConfig() : StateBackendOperationConfig
+{
+    public required EnrollmentCallMode CallMode { get; init; }
+
+    /// <summary>How to build each outgoing request row from a child.</summary>
+    public EnrollmentRequestBinding? Request { get; init; }
+
+    /// <summary>How to correlate response rows back to children and classify them.</summary>
+    public EnrollmentResponseMapping? Response { get; init; }
+}
+
+/// <summary>Builds the per-child request rows.</summary>
+public sealed record EnrollmentRequestBinding
+{
+    /// <summary>Our child-field name → dotted target path in the request row.</summary>
+    public required Dictionary<string, string> Map { get; init; }
+
+    /// <summary>Like <see cref="Map"/>, but an unresolved input is omitted from the row (never written as null).</summary>
+    public Dictionary<string, string>? MapOptional { get; init; }
+
+    /// <summary>Dotted target path carrying the row's correlation index; required for batch, must be null for perChild — validated at load.</summary>
+    public string? IndexField { get; init; }
+
+    /// <summary>Candidate expansion applied to the DOB input.</summary>
+    public CandidateExpansion Expand { get; init; } = CandidateExpansion.None;
+}
+
+/// <summary>Correlates response rows back to children and decides match.</summary>
+public sealed record EnrollmentResponseMapping
+{
+    /// <summary>Path to the array of response rows.</summary>
+    public required string Root { get; init; }
+
+    /// <summary>Source property carrying the echoed correlation index; required for batch, must be null for perChild — validated at load.</summary>
+    public string? IndexField { get; init; }
+
+    /// <summary>Row property surfaced as the child's <c>StatusMessage</c> — per-row, unlike <see cref="MessageField"/>.</summary>
+    public string? StatusMessageField { get; init; }
+
+    /// <summary>Result-level property surfaced as <c>EnrollmentCheckResult.Message</c> — read from the response root, not per-row.</summary>
+    public string? MessageField { get; init; }
+
+    public required EnrollmentMatch Match { get; init; }
+}
+
+/// <summary>The match strategy and its params; wrong params for the chosen strategy fail at load.</summary>
+public sealed record EnrollmentMatch
+{
+    public required EnrollmentMatchStrategy Strategy { get; init; }
+
+    /// <summary>Row property inspected: required for anyRowValueIn, an optional eligibility check (with <see cref="ValueIn"/>) for confidenceThreshold.</summary>
+    public string? Field { get; init; }
+
+    /// <summary>Passing values for <see cref="Field"/>; the pair comes together or not at all — validated at load.</summary>
+    public List<string>? ValueIn { get; init; }
+
+    /// <summary>Row property carrying the numeric confidence score; confidenceThreshold only.</summary>
+    public string? ScoreField { get; init; }
+
+    /// <summary>The score must strictly exceed this to match; confidenceThreshold only.</summary>
+    public double? Threshold { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/FieldMapping.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/FieldMapping.cs
@@ -1,0 +1,17 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Maps one canonical domain field to source propert(ies); coercion is driven by the canonical field's C# type, not an explicit kind here.</summary>
+public sealed record FieldMapping
+{
+    /// <summary>Source property name(s) on the selected record.</summary>
+    public required FieldSources From { get; init; }
+
+    /// <summary>Exact date/time parse format for date-typed fields; no fallback.</summary>
+    public string? Format { get; init; }
+
+    /// <summary>Name of a <see cref="StateBackendConfiguration.Enums"/> table translating the source token to a canonical enum value.</summary>
+    public string? Enum { get; init; }
+
+    /// <summary>Contains-match inference over the <see cref="From"/> source(s) for an enum-typed field.</summary>
+    public KeywordRules? KeywordRules { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/FieldSources.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/FieldSources.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>One-or-more source property names for <see cref="FieldMapping.From"/>; hydrates from scalar or sequence YAML.</summary>
+public sealed class FieldSources : IEnumerable<string>
+{
+    private readonly IReadOnlyList<string> _sources;
+
+    public FieldSources(IReadOnlyList<string> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        if (sources.Count == 0)
+        {
+            throw new ArgumentException("A field mapping must name at least one source.", nameof(sources));
+        }
+
+        _sources = sources;
+    }
+
+    /// <summary>All source property names, in declared order.</summary>
+    public IReadOnlyList<string> All => _sources;
+
+    /// <summary>The single source; throws when the mapping names more than one.</summary>
+    public string Single => _sources.Count == 1
+        ? _sources[0]
+        : throw new InvalidOperationException(
+            $"Field mapping names {_sources.Count} sources; expected exactly one.");
+
+    public static implicit operator FieldSources(string source) => new(new[] { source });
+
+    public static implicit operator FieldSources(string[] sources) => new(sources);
+
+    // Null-tolerant so a null-conditional access (e.g. `mapping?.From`) converts without a warning.
+    public static implicit operator string?(FieldSources? sources) => sources?.Single;
+
+    public IEnumerator<string> GetEnumerator() => _sources.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/HealthOperationConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/HealthOperationConfig.cs
@@ -1,0 +1,3 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public sealed record HealthOperationConfig() : StateBackendOperationConfig;

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/HouseholdLookupOperationConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/HouseholdLookupOperationConfig.cs
@@ -1,0 +1,10 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public sealed record HouseholdLookupOperationConfig() : StateBackendOperationConfig
+{
+    /// <summary>How to build the outgoing lookup request body; when null the driver sends no body.</summary>
+    public RequestBinding? Request { get; init; }
+
+    /// <summary>How to map the backend's raw lookup response into canonical household data.</summary>
+    public StateBackendResponseMapping? Response { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/KeywordRules.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/KeywordRules.cs
@@ -1,0 +1,14 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Classifies an enum-typed field by keyword-substring scan of its <see cref="FieldMapping.From"/> source(s).</summary>
+public sealed record KeywordRules
+{
+    /// <summary>Canonical enum values in evaluation order; first-match-wins, so order is load-bearing.</summary>
+    public required List<string> Order { get; init; }
+
+    /// <summary>OUR canonical enum value → the substrings that indicate it.</summary>
+    public required Dictionary<string, List<string>> Map { get; init; }
+
+    /// <summary>Canonical enum value used when no keyword matches any source.</summary>
+    public required string Default { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/RequestBinding.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/RequestBinding.cs
@@ -1,0 +1,20 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Builds the outgoing request body; a mapped <c>isProofed</c> input passes the caller's identity-proofing status to the backend — a gate the backend relies on.</summary>
+public sealed record RequestBinding
+{
+    /// <summary>Dotted target path → fixed literal value (bool, number, string).</summary>
+    public Dictionary<string, object>? Constants { get; init; }
+
+    /// <summary>Our input name → dotted target path in the request body.</summary>
+    public Dictionary<string, string>? Map { get; init; }
+
+    /// <summary>Like <see cref="Map"/>, but an unresolved input is omitted from the body (never written as null).</summary>
+    public Dictionary<string, string>? MapOptional { get; init; }
+
+    /// <summary>Batch shape: a household-level routing field resolved once across every decoded caseId; fails loud if the caseIds disagree.</summary>
+    public Dictionary<string, string>? Shared { get; init; }
+
+    /// <summary>Batch shape: a per-case routing field gathered into an array, one element per decoded caseId.</summary>
+    public Dictionary<string, string>? Collect { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/ResultClassifier.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/ResultClassifier.cs
@@ -1,0 +1,43 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Canonical write-outcome vocabulary, shared by the card-replacement and address-update paths.</summary>
+public enum WriteOutcome
+{
+    Success,
+
+    /// <summary>The household is not eligible for the operation via the portal.</summary>
+    PolicyRejection,
+
+    /// <summary>The state backend returned an error.</summary>
+    BackendError,
+}
+
+/// <summary>Classifies a write response into a <see cref="WriteOutcome"/>: ordered <see cref="Conditions"/>, first match wins.</summary>
+public sealed record ResultClassifier
+{
+    public required List<ResultCondition> Conditions { get; init; }
+
+    /// <summary>Outcome when no condition matches.</summary>
+    public WriteOutcome Default { get; init; } = WriteOutcome.BackendError;
+}
+
+/// <summary>One classifier condition; exactly one of <see cref="StatusIn"/> / <see cref="ValueIn"/> / <see cref="MessageContains"/> — validated at load.</summary>
+public sealed record ResultCondition
+{
+    public required WriteOutcome Outcome { get; init; }
+
+    /// <summary>HTTP status code is in this set.</summary>
+    public List<int>? StatusIn { get; init; }
+
+    /// <summary>The body property <see cref="Field"/>'s value is in this set.</summary>
+    public List<string>? ValueIn { get; init; }
+
+    /// <summary>Body property inspected by <see cref="ValueIn"/>; required with it.</summary>
+    public string? Field { get; init; }
+
+    /// <summary>The body property <see cref="MessageField"/> contains any of these substrings (case-insensitive).</summary>
+    public List<string>? MessageContains { get; init; }
+
+    /// <summary>Body property scanned by <see cref="MessageContains"/>; required with it.</summary>
+    public string? MessageField { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendDisaggregation.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendDisaggregation.cs
@@ -1,0 +1,38 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Rule deciding whether a record represents an application-based case.</summary>
+public enum DisaggregationRule
+{
+    /// <summary>Application-based when the <see cref="StateBackendDisaggregation.DiscriminatorField"/> is present.</summary>
+    Presence,
+
+    /// <summary>Application-based when the discriminator's value is in <see cref="StateBackendDisaggregation.ApplicationValues"/>.</summary>
+    ValueInSet,
+}
+
+/// <summary>Named case-inclusion predicate — closed set; add a named member, never operators.</summary>
+public enum CaseInclusionPredicate
+{
+    /// <summary>Include every record.</summary>
+    All,
+
+    /// <summary>Include a record when it is approved, or when it is not application-based.</summary>
+    WhenApprovedOrNotApplicationBased,
+}
+
+/// <summary>How to group records into applications and which records to include as cases.</summary>
+public sealed record StateBackendDisaggregation
+{
+    public required DisaggregationRule Rule { get; init; }
+
+    /// <summary>Source field inspected by <see cref="Rule"/>.</summary>
+    public required string DiscriminatorField { get; init; }
+
+    /// <summary>Source field whose value groups records belonging to the same application.</summary>
+    public string? GroupApplicationsBy { get; init; }
+
+    /// <summary>For <see cref="DisaggregationRule.ValueInSet"/>: the discriminator values that mean "application-based".</summary>
+    public List<string>? ApplicationValues { get; init; }
+
+    public required CaseInclusionPredicate CaseInclusion { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendHttpMethod.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendHttpMethod.cs
@@ -1,0 +1,9 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public enum StateBackendHttpMethod
+{
+    Get,
+    Patch,
+    Post,
+    Put
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendOperationConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendOperationConfig.cs
@@ -1,0 +1,8 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public abstract record StateBackendOperationConfig()
+{
+    public required StateBackendHttpMethod Method { get; init; }
+
+    public required string Path { get; init; }
+};

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendOperations.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendOperations.cs
@@ -1,0 +1,10 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+public record StateBackendOperations
+{
+    public EnrollmentCheckOperationConfig? EnrollmentCheck { get; init; }
+    public HouseholdLookupOperationConfig? HouseholdLookup { get; init; }
+    public AddressUpdateOperationConfig? AddressUpdate { get; init; }
+    public CardReplacementOperationConfig? CardReplacement { get; init; }
+    public HealthOperationConfig? Health { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendResponseMapping.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/Operations/StateBackendResponseMapping.cs
@@ -1,0 +1,17 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+/// <summary>Maps a state backend's raw JSON response into canonical domain types.</summary>
+public sealed record StateBackendResponseMapping
+{
+    /// <summary>Path to the array of records within the raw response.</summary>
+    public required string Root { get; init; }
+
+    /// <summary>Canonical field name → how to pull and coerce it from the record selected by <see cref="Root"/>.</summary>
+    public required Dictionary<string, FieldMapping> Fields { get; init; }
+
+    /// <summary>Optional strategy for grouping records into applications and deciding case inclusion.</summary>
+    public StateBackendDisaggregation? Disaggregation { get; init; }
+
+    /// <summary>Optional composition of the case's opaque caseId token; a later write decodes it to recover routing fields.</summary>
+    public CaseIdComposition? CaseId { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/StateBackendCapabilities.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/StateBackendCapabilities.cs
@@ -1,0 +1,12 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration;
+
+public enum CardReplacementCapability
+{
+    None,
+    PerCase
+}
+
+public sealed record StateBackendCapabilities(
+    CardReplacementCapability CardReplacement,
+    bool AddressUpdate,
+    bool EnrollmentCheck);

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/StateBackendConfiguration.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/StateBackendConfiguration.cs
@@ -1,0 +1,24 @@
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Core.StateBackends.Configuration;
+
+public record StateBackendConfiguration
+{
+    public required Uri BaseUrl { get; init; }
+
+    public required StateBackendAuthScheme Auth { get; init; }
+
+    public required StateBackendOperations Operations { get; init; }
+
+    /// <summary>Named enum translation tables referenced by <see cref="Operations.FieldMapping.Enum"/>.</summary>
+    public Dictionary<string, StateBackendEnumTable>? Enums { get; init; }
+
+    public StateBackendCapabilities Capabilities =>
+        new(
+            Operations.CardReplacement != null
+                ? CardReplacementCapability.PerCase
+                : CardReplacementCapability.None,
+            Operations.AddressUpdate != null,
+            Operations.EnrollmentCheck != null);
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/StateBackendEnumsConfig.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/Configuration/StateBackendEnumsConfig.cs
@@ -1,0 +1,11 @@
+namespace SEBT.Portal.Core.StateBackends.Configuration;
+
+/// <summary>An enum translation table; <see cref="Default"/> applies only to unlisted tokens — a mistyped canonical value fails at load.</summary>
+public sealed record StateBackendEnumTable
+{
+    /// <summary>Our canonical enum value → the state token(s) that mean it.</summary>
+    public required Dictionary<string, List<string>> Map { get; init; }
+
+    /// <summary>Canonical enum value used for tokens not listed in <see cref="Map"/>.</summary>
+    public string? Default { get; init; }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 1 of 11.** We're adding a config-driven state-backend adapter. This stack builds it; nothing calls it yet, so runtime behavior doesn't change. Rationale: ADR-0020 (#544).

This PR is the config model — the C# records a state's YAML maps onto.

- `Core/StateBackends/Configuration/`: auth schemes, the five operation configs, field mapping, enum tables, disaggregation, caseId composition, result classifier, request binding.

**Focus:** does each config type explain itself from its name and one-line doc? It's the vocabulary a state author writes against.

#### ✅ Completion tasks
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ