### PR TITLE
feat(DC-568): per-operation Core ports + opaque caseId codec

### DIFF
--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/CaseIdContext.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/CaseIdContext.cs
@@ -1,0 +1,8 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+/// <summary>Caller-context values a caseId composition's <c>fromContext</c> can pack — closed vocabulary; a new value means a new property here plus its resolution in code.</summary>
+public sealed record CaseIdContext
+{
+    /// <summary>The identifier the lookup searched by; the composition packs empty when null.</summary>
+    public string? HouseholdIdentifier { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/IAddressUpdateBackend.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/IAddressUpdateBackend.cs
@@ -1,0 +1,26 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+public interface IAddressUpdateBackend
+{
+    Task<WriteResult> UpdateAddressAsync(
+        AddressUpdateRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A household-routed mailing-address update: <see cref="CaseIds"/> MAY BE EMPTY (a zero-case
+/// household still updates), and a single backend call yields a single <see cref="WriteResult"/>.
+/// </summary>
+public sealed record AddressUpdateRequest(
+    string HouseholdIdentifier,
+    IReadOnlyList<string> CaseIds,
+    AddressUpdateAddress Address);
+
+/// <summary>The validated mailing-address scalars to persist.</summary>
+public sealed record AddressUpdateAddress
+{
+    public string? Line1 { get; init; }
+    public string? Line2 { get; init; }
+    public string? City { get; init; }
+    public string? State { get; init; }
+    public string? Zip { get; init; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/ICardReplacementBackend.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/ICardReplacementBackend.cs
@@ -1,0 +1,13 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+public interface ICardReplacementBackend
+{
+    Task<WriteResult> RequestCardReplacementAsync(
+        CardReplacementRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A card-replacement request routed by opaque case tokens; the household identifier rides inside
+/// them. Cooldown, persistence, and hashing stay portal-side.
+/// </summary>
+public sealed record CardReplacementRequest(IReadOnlyList<string> CaseIds);

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/IEnrollmentCheckBackend.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/IEnrollmentCheckBackend.cs
@@ -1,0 +1,32 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+public interface IEnrollmentCheckBackend
+{
+    Task<EnrollmentCheckResult> CheckEnrollmentAsync(
+        EnrollmentCheckRequest request, CancellationToken cancellationToken = default);
+}
+
+/// <summary>An enrollment-eligibility check for a batch of children.</summary>
+public sealed record EnrollmentCheckRequest(IReadOnlyList<EnrollmentChild> Children);
+
+/// <summary>
+/// One child to check. <see cref="CheckId"/> is echoed on the result for correlation;
+/// <see cref="SchoolIdentifier"/> is the state's school name or code, when the portal has it.
+/// </summary>
+public sealed record EnrollmentChild(
+    string CheckId, string FirstName, string LastName, DateOnly DateOfBirth, string? SchoolIdentifier = null);
+
+/// <summary>
+/// Per-child outcomes, one per requested child in request order. <see cref="Message"/> is the
+/// backend's result-level status text, when a <c>messageField</c> is configured.
+/// </summary>
+public sealed record EnrollmentCheckResult(
+    IReadOnlyList<EnrollmentChildResult> Results, string? Message = null);
+
+/// <summary>
+/// <see cref="MatchConfidence"/> is the winning row's confidenceThreshold score, reported even below
+/// the threshold (null under other strategies). <see cref="StatusMessage"/> is the winning row's
+/// status text, when a <c>statusMessageField</c> is configured.
+/// </summary>
+public sealed record EnrollmentChildResult(
+    string CheckId, bool IsMatch, double? MatchConfidence = null, string? StatusMessage = null);

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/IHouseholdLookupBackend.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/IHouseholdLookupBackend.cs
@@ -1,0 +1,30 @@
+using SEBT.Portal.Core.Models.Household;
+
+namespace SEBT.Portal.Core.StateBackends;
+
+public enum HouseholdLookupStatus { Found, NotFound }
+
+public interface IHouseholdLookupBackend
+{
+    Task<HouseholdLookupResult> LookupHouseholdAsync(
+        HouseholdLookupRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed record IdentitySignal(string Type, string Value);
+
+/// <summary>
+/// <see cref="IsProofed"/> gates DC's email-lookup branch, so it must reflect the caller's real
+/// proofing status.
+/// </summary>
+public sealed record HouseholdLookupRequest(IReadOnlyList<IdentitySignal> Signals)
+{
+    public bool IsProofed { get; init; }
+    public string? PortalUuid { get; init; }
+
+    /// <summary>
+    /// The identifier this lookup searched by; <c>fromContext</c> caseId compositions pack it when a
+    /// write routes by a value the lookup response never echoes. Null when the caller has none.
+    /// </summary>
+    public string? HouseholdIdentifier { get; init; }
+}
+public sealed record HouseholdLookupResult(HouseholdLookupStatus Status, HouseholdData? Household);

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/IStateBackendHealth.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/IStateBackendHealth.cs
@@ -1,0 +1,8 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+public interface IStateBackendHealth
+{
+    Task<StateBackendHealth> GetHealthAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed record StateBackendHealth(bool IsHealthy);

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/IStateBackendSecretResolver.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/IStateBackendSecretResolver.cs
@@ -1,0 +1,11 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+/// <summary>
+/// Resolves a config-key reference (e.g. <c>StateBackend:Auth:ApiKey</c>) to a secret value. The
+/// reference is a key, never the value — implementations pull the secret from environment,
+/// <c>/run/secrets</c>, or a vault, keeping secrets out of config records.
+/// </summary>
+public interface IStateBackendSecretResolver
+{
+    string Resolve(string reference);
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/OpaqueCaseId.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/OpaqueCaseId.cs
@@ -1,0 +1,54 @@
+using System.Buffers.Text;
+using System.Text.Json;
+
+namespace SEBT.Portal.Core.StateBackends;
+
+/// <summary>
+/// Packs a case's routing fields into a URL-safe base64 JSON token; reads compose it, writes decode
+/// it. Fixed here so both integration paths share one token namespace.
+/// </summary>
+/// <remarks>
+/// Opaque, not encrypted — it carries only routing identifiers the backend already returned.
+/// Insertion order is preserved, so a fixed field order yields byte-identical tokens; callers rely on that.
+/// </remarks>
+public static class OpaqueCaseId
+{
+    /// <summary>Packs the named routing fields into a URL-safe base64 JSON token.</summary>
+    public static string Compose(IReadOnlyDictionary<string, string> fields)
+    {
+        ArgumentNullException.ThrowIfNull(fields);
+
+        byte[] json = JsonSerializer.SerializeToUtf8Bytes(fields);
+        return Base64Url.EncodeToString(json);
+    }
+
+    /// <summary>Decodes a token back into its routing fields. Fails loud on a malformed token.</summary>
+    /// <remarks>Failure messages never echo the token — it can carry email/phone, and callers log in full.</remarks>
+    public static IReadOnlyDictionary<string, string> Decode(string token)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+
+        byte[] json;
+        try
+        {
+            json = Base64Url.DecodeFromChars(token);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException("caseId token is not valid base64.", ex);
+        }
+
+        Dictionary<string, string>? fields;
+        try
+        {
+            fields = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("caseId token does not decode to routing fields.", ex);
+        }
+
+        return fields
+            ?? throw new InvalidOperationException("caseId token decoded to no routing fields.");
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Core/StateBackends/WriteResult.cs
+++ b/apps/portal/src/SEBT.Portal.Core/StateBackends/WriteResult.cs
@@ -1,0 +1,26 @@
+namespace SEBT.Portal.Core.StateBackends;
+
+/// <summary>
+/// Canonical write outcome (card replacement, address update): success, a policy rejection
+/// (household not eligible), or a backend error.
+/// </summary>
+public sealed record WriteResult
+{
+    public bool IsSuccess { get; init; }
+
+    /// <summary>The failure is a policy rejection rather than a technical backend error.</summary>
+    public bool IsPolicyRejection { get; init; }
+
+    public string? ErrorCode { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public static WriteResult Success() =>
+        new() { IsSuccess = true };
+
+    public static WriteResult PolicyRejected(string code, string message) =>
+        new() { IsSuccess = false, IsPolicyRejection = true, ErrorCode = code, ErrorMessage = message };
+
+    public static WriteResult BackendError(string code, string message) =>
+        new() { IsSuccess = false, IsPolicyRejection = false, ErrorCode = code, ErrorMessage = message };
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Core/StateBackends/OpaqueCaseIdTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Core/StateBackends/OpaqueCaseIdTests.cs
@@ -1,0 +1,119 @@
+using System.Buffers.Text;
+using System.Text;
+using SEBT.Portal.Core.StateBackends;
+
+namespace SEBT.Portal.Tests.Unit.Core.StateBackends;
+
+public class OpaqueCaseIdTests
+{
+    [Fact]
+    public void Compose_SameFieldsInSameOrder_YieldsByteIdenticalTokens()
+    {
+        // Callers use the token as a merge/lookup key across separate fetches,
+        // so composition must be deterministic for a fixed insertion order.
+        static Dictionary<string, string> BuildFields() => new(StringComparer.Ordinal)
+        {
+            ["caseId"] = "STATE-CASE-123",
+            ["applicationId"] = "APP-9",
+            ["applicationStudentId"] = "STU-7",
+            ["householdIdentifier"] = "user@example.com",
+        };
+
+        var first = OpaqueCaseId.Compose(BuildFields());
+        var second = OpaqueCaseId.Compose(BuildFields());
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Compose_ThenDecode_RoundTripsAllFields()
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["caseId"] = "STATE-CASE-123",
+            ["householdIdentifier"] = "user@example.com",
+        };
+
+        var decoded = OpaqueCaseId.Decode(OpaqueCaseId.Compose(fields));
+
+        Assert.Equal(fields, decoded);
+    }
+
+    [Fact]
+    public void Compose_ThenDecode_RoundTripsUnicodeFieldValues()
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["caseId"] = "CASO-Ñ-123",
+            ["householdIdentifier"] = "família@exämple.com — 日本語 🙂",
+        };
+
+        var decoded = OpaqueCaseId.Decode(OpaqueCaseId.Compose(fields));
+
+        Assert.Equal(fields, decoded);
+    }
+
+    [Fact]
+    public void Compose_ThenDecode_RoundTripsMultiKilobyteFieldValue()
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["caseId"] = new string('x', 4096),
+        };
+
+        var decoded = OpaqueCaseId.Decode(OpaqueCaseId.Compose(fields));
+
+        Assert.Equal(fields, decoded);
+    }
+
+    // Tokens can carry email/phone in householdIdentifier, and write handlers log full
+    // exceptions — the raw token must never appear in the failure message.
+    [Theory]
+    // Not base64 at all.
+    [InlineData("not!valid@base64#user@example.com", false, "not valid base64")]
+    // Base64, but the payload is not JSON.
+    [InlineData("user@example.com is not json", true, "does not decode to routing fields")]
+    // The JSON literal "null" deserializes without error to a null dictionary.
+    [InlineData("null", true, "decoded to no routing fields")]
+    public void Decode_MalformedToken_ThrowsWithoutEchoingToken(
+        string payload, bool encodeAsBase64, string expectedMessageFragment)
+    {
+        string token = encodeAsBase64
+            ? Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload))
+            : payload;
+
+        var ex = Assert.Throws<InvalidOperationException>(() => OpaqueCaseId.Decode(token));
+
+        Assert.Contains(expectedMessageFragment, ex.Message);
+        Assert.DoesNotContain(token, ex.Message);
+    }
+
+    [Fact]
+    public void Decode_FailureMessages_AreDistinctPerFailureMode()
+    {
+        string NotBase64Message()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => OpaqueCaseId.Decode("!!!not-base64!!!"));
+            return ex.Message;
+        }
+
+        string NotJsonMessage()
+        {
+            string token = Base64Url.EncodeToString(Encoding.UTF8.GetBytes("plainly not json"));
+            var ex = Assert.Throws<InvalidOperationException>(() => OpaqueCaseId.Decode(token));
+            return ex.Message;
+        }
+
+        string NullJsonMessage()
+        {
+            string token = Base64Url.EncodeToString(Encoding.UTF8.GetBytes("null"));
+            var ex = Assert.Throws<InvalidOperationException>(() => OpaqueCaseId.Decode(token));
+            return ex.Message;
+        }
+
+        var messages = new[] { NotBase64Message(), NotJsonMessage(), NullJsonMessage() };
+
+        Assert.Equal(3, messages.Distinct(StringComparer.Ordinal).Count());
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 2 of 11.** Still nothing calls the adapter.

Adds the Core ports — the interfaces the adapter will implement, one per operation.

- `IHouseholdLookupBackend`, `ICardReplacementBackend`, `IAddressUpdateBackend`, `IEnrollmentCheckBackend`, `IStateBackendHealth`, plus their request/result records and `WriteResult`.
- The opaque `caseId` codec: `OpaqueCaseId` and `CaseIdContext` — routing data travels inside an encoded caseId.

**Focus:** the port surface a caller depends on, and the opaque-token idea.

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ