### PR TITLE
feat(DC-568): JSON path/read primitives + StateBackends project

### DIFF
--- a/SEBT.slnx
+++ b/SEBT.slnx
@@ -17,6 +17,7 @@
     <Project Path="apps/portal/src/SEBT.Portal.Api/SEBT.Portal.Api.csproj" />
     <Project Path="apps/portal/src/SEBT.Portal.Core/SEBT.Portal.Core.csproj" />
     <Project Path="apps/portal/src/SEBT.Portal.Infrastructure.Seeding/SEBT.Portal.Infrastructure.Seeding.csproj" />
+    <Project Path="apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/SEBT.Portal.Infrastructure.StateBackends.csproj" />
     <Project Path="apps/portal/src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj" />
     <Project Path="apps/portal/src/SEBT.Portal.Kernel.AspNetCore/SEBT.Portal.Kernel.AspNetCore.csproj" />
     <Project Path="apps/portal/src/SEBT.Portal.Kernel/SEBT.Portal.Kernel.csproj" />

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/JsonPathSelector.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/JsonPathSelector.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Read-side path selector: a leading <c>$</c>, dotted property segments, and <c>[index]</c>
+/// element access only — not a general JSONPath engine. Returns a
+/// <see cref="JsonValueKind.Undefined"/> element when the path does not resolve.
+/// </summary>
+internal static class JsonPathSelector
+{
+    public static JsonElement Select(JsonElement root, string path)
+    {
+        JsonElement current = root;
+
+        foreach (string segment in SplitPath(path))
+        {
+            int bracket = segment.IndexOf('[');
+            string property = bracket >= 0 ? segment[..bracket] : segment;
+
+            if (property.Length > 0)
+            {
+                if (current.ValueKind != JsonValueKind.Object
+                    || !current.TryGetProperty(property, out current))
+                {
+                    return default;
+                }
+            }
+
+            while (bracket >= 0)
+            {
+                int close = segment.IndexOf(']', bracket);
+                if (close < 0)
+                {
+                    throw new FormatException($"Malformed path segment '{segment}' in '{path}'.");
+                }
+
+                int index = int.Parse(segment[(bracket + 1)..close], CultureInfo.InvariantCulture);
+                if (current.ValueKind != JsonValueKind.Array || index >= current.GetArrayLength())
+                {
+                    return default;
+                }
+
+                current = current[index];
+                bracket = segment.IndexOf('[', close);
+            }
+        }
+
+        return current;
+    }
+
+    private static IEnumerable<string> SplitPath(string path)
+    {
+        string trimmed = path.StartsWith("$.", StringComparison.Ordinal)
+            ? path[2..]
+            : path.StartsWith('$') ? path[1..] : path;
+
+        return trimmed.Split('.', StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/JsonPathWriter.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/JsonPathWriter.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Nodes;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Write-side path writer: sets a value at a dotted target path, building intermediate objects as
+/// needed. Dotted property paths only — no <c>$</c>/<c>[index]</c> grammar, narrower than the
+/// read-side <see cref="JsonPathSelector"/> by design.
+/// </summary>
+internal static class JsonPathWriter
+{
+    public static void Write(JsonObject root, string dottedPath, JsonNode? value)
+    {
+        string[] segments = dottedPath.Split('.');
+        JsonObject current = root;
+
+        for (int i = 0; i < segments.Length - 1; i++)
+        {
+            string segment = segments[i];
+            if (current[segment] is not JsonObject child)
+            {
+                child = new JsonObject();
+                current[segment] = child;
+            }
+
+            current = child;
+        }
+
+        current[segments[^1]] = value;
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/JsonRead.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/JsonRead.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Reads a named property off a JSON object as a string, fail-soft — a miss is always <c>null</c>,
+/// never an exception. Numbers keep their raw text (<c>"00"</c> keeps its leading zero) and bools
+/// read as <c>"true"</c>/<c>"false"</c> — load-bearing for valueIn and messageContains matching.
+/// </summary>
+internal static class JsonRead
+{
+    public static string? AsString(JsonElement parent, string property)
+    {
+        if (parent.ValueKind != JsonValueKind.Object
+            || !parent.TryGetProperty(property, out JsonElement value))
+        {
+            return null;
+        }
+
+        return AsString(value);
+    }
+
+    /// <summary>Same coercion off a nullable parent (null when the backend returned no/invalid JSON).</summary>
+    public static string? AsString(JsonElement? parent, string property) =>
+        parent is { } root ? AsString(root, property) : null;
+
+    /// <summary>Coerces an already-selected element (e.g. from a path selector) as a string.</summary>
+    public static string? AsString(JsonElement value) =>
+        value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.Number => value.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null,
+        };
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/SEBT.Portal.Infrastructure.StateBackends.csproj
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/SEBT.Portal.Infrastructure.StateBackends.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="SEBT.Portal.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../SEBT.Portal.Core/SEBT.Portal.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/apps/portal/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/apps/portal/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -76,6 +76,7 @@
 
     <ItemGroup>
       <ProjectReference Include="../../src/SEBT.Portal.Core/SEBT.Portal.Core.csproj" />
+      <ProjectReference Include="../../src/SEBT.Portal.Infrastructure.StateBackends/SEBT.Portal.Infrastructure.StateBackends.csproj" />
       <ProjectReference Include="../../src/SEBT.Portal.Infrastructure/SEBT.Portal.Infrastructure.csproj" />
       <ProjectReference Include="../../src/SEBT.Portal.Infrastructure.Seeding/SEBT.Portal.Infrastructure.Seeding.csproj" />
       <ProjectReference Include="../../src/SEBT.Portal.TestUtilities/SEBT.Portal.TestUtilities.csproj" />

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/JsonPathSelectorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/JsonPathSelectorTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class JsonPathSelectorTests
+{
+    private static JsonElement Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    // Supported grammar: dotted segments, [index] element access, optional $ root.
+    [Theory]
+    [InlineData("""{ "outer": { "inner": "value" } }""", "outer.inner", "\"value\"")]
+    [InlineData("""{ "rows": [ { "id": "a" }, { "id": "b" } ] }""", "rows[1].id", "\"b\"")]
+    [InlineData("""{ "data": { "count": 3 } }""", "$.data.count", "3")]
+    public void Select_ResolvesSupportedPathGrammar(string json, string path, string expectedRawText)
+    {
+        JsonElement root = Parse(json);
+
+        JsonElement result = JsonPathSelector.Select(root, path);
+
+        Assert.Equal(expectedRawText, result.GetRawText());
+    }
+
+    [Fact]
+    public void Select_ReturnsDefault_WhenPathMissing()
+    {
+        JsonElement root = Parse("""{ "present": "value" }""");
+
+        JsonElement result = JsonPathSelector.Select(root, "absent.child");
+
+        Assert.Equal(JsonValueKind.Undefined, result.ValueKind);
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/JsonPathWriterTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/JsonPathWriterTests.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Nodes;
+using SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class JsonPathWriterTests
+{
+    [Fact]
+    public void Write_SetsFlatProperty()
+    {
+        var root = new JsonObject();
+
+        JsonPathWriter.Write(root, "name", JsonValue.Create("value"));
+
+        Assert.Equal("value", root["name"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Write_CreatesIntermediateObjectsForNestedPath()
+    {
+        var root = new JsonObject();
+
+        JsonPathWriter.Write(root, "outer.inner", JsonValue.Create("value"));
+
+        JsonObject outer = Assert.IsType<JsonObject>(root["outer"]);
+        Assert.Equal("value", outer["inner"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Write_OverwritesExistingValue()
+    {
+        var root = new JsonObject { ["name"] = "original" };
+
+        JsonPathWriter.Write(root, "name", JsonValue.Create("replacement"));
+
+        Assert.Equal("replacement", root["name"]!.GetValue<string>());
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/JsonReadTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/JsonReadTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+/// <summary>
+/// Coercion contract for <see cref="JsonRead.AsString(JsonElement, string)"/>: numbers read as
+/// raw JSON text, bools as "true"/"false", and every miss is <c>null</c> — never a throw.
+/// </summary>
+public class JsonReadTests
+{
+    private static JsonElement Parse(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    [Theory]
+    [InlineData("""{ "field": "value" }""", "field", "value")]
+    [InlineData("""{ "count": 3 }""", "count", "3")]
+    // Raw read preserves the exact source text of a numeric token, unreformatted.
+    [InlineData("""{ "score": 0.50 }""", "score", "0.50")]
+    [InlineData("""{ "isEligible": true }""", "isEligible", "true")]
+    [InlineData("""{ "isEligible": false }""", "isEligible", "false")]
+    public void AsString_CoercesValueToRawText(string json, string field, string expected)
+    {
+        JsonElement root = Parse(json);
+
+        Assert.Equal(expected, JsonRead.AsString(root, field));
+    }
+
+    [Theory]
+    [InlineData("""{ "present": "value" }""", "absent")] // property absent
+    [InlineData("""{ "field": null }""", "field")] // value is JSON null
+    [InlineData("""[ "a", "b" ]""", "field")] // parent is not an object
+    public void AsString_ReturnsNull_OnAnyMiss(string json, string field)
+    {
+        JsonElement root = Parse(json);
+
+        Assert.Null(JsonRead.AsString(root, field));
+    }
+
+    [Fact]
+    public void AsString_ReturnsNull_WhenNullableParentIsNull()
+    {
+        JsonElement? body = null;
+
+        Assert.Null(JsonRead.AsString(body, "field"));
+    }
+
+    [Fact]
+    public void AsString_ReadsFromNullableParent_WhenPresent()
+    {
+        JsonElement? body = Parse("""{ "respCd": "00" }""");
+
+        Assert.Equal("00", JsonRead.AsString(body, "respCd"));
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 3 of 11.** Still nothing calls the adapter.

Adds the JSON primitives the mapper builds on, plus the project that houses the adapter.

- `JsonPathSelector` (read paths), `JsonPathWriter` (request paths), `JsonRead` (value coercion).
- New `SEBT.Portal.Infrastructure.StateBackends` project scaffold.

**Focus:** the capped path grammar — dotted segments and `[index]` only, deliberately not full JSONPath. Fully unit-tested here.

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ