### PR TITLE
feat(DC-568): config-driven mapping engine

### DIFF
--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentCandidateExpander.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentCandidateExpander.cs
@@ -1,0 +1,20 @@
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>The closed <c>transposeMonthDay</c> DOB candidate-expansion strategy.</summary>
+internal static class EnrollmentCandidateExpander
+{
+    /// <summary>
+    /// Returns the month/day-swapped DOB, or <c>null</c> when the swap yields the same date or an
+    /// invalid one. Only a day ≤ 12 can be a month; the original month is always a valid day.
+    /// </summary>
+    public static DateOnly? TryTransposeMonthDay(DateOnly dob)
+    {
+        if (dob.Day > 12)
+        {
+            return null;
+        }
+
+        var transposed = new DateOnly(dob.Year, dob.Day, dob.Month);
+        return transposed == dob ? null : transposed;
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentOperationValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentOperationValidator.cs
@@ -1,0 +1,92 @@
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Fail-loud validation of the enrollment op's call-mode / index-field / expand / match combination,
+/// so a misconfigured op fails at load rather than silently taking the wrong dispatch path.
+/// </summary>
+internal static class EnrollmentOperationValidator
+{
+    public static void Validate(
+        EnrollmentCallMode callMode, EnrollmentRequestBinding binding, EnrollmentResponseMapping mapping)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        ArgumentNullException.ThrowIfNull(mapping);
+
+        ValidateMatch(mapping.Match);
+
+        switch (callMode)
+        {
+            case EnrollmentCallMode.Batch:
+                if (string.IsNullOrEmpty(binding.IndexField) || string.IsNullOrEmpty(mapping.IndexField))
+                {
+                    throw new InvalidOperationException(
+                        "Enrollment callMode 'Batch' requires an indexField on both the request binding "
+                        + "and the response mapping so rows can be correlated back to children.");
+                }
+
+                break;
+
+            case EnrollmentCallMode.PerChild:
+                if (!string.IsNullOrEmpty(binding.IndexField) || !string.IsNullOrEmpty(mapping.IndexField))
+                {
+                    throw new InvalidOperationException(
+                        "Enrollment callMode 'PerChild' must NOT set an indexField: each call is a single "
+                        + "child, so there is no correlation index.");
+                }
+
+                if (binding.Expand != CandidateExpansion.None)
+                {
+                    throw new InvalidOperationException(
+                        "Enrollment callMode 'PerChild' with candidate expansion is not supported yet.");
+                }
+
+                break;
+
+            default:
+                throw new NotSupportedException($"Unsupported enrollment callMode '{callMode}'.");
+        }
+    }
+
+    // Fail loud when the strategy is missing its required params. The comparison lives in code;
+    // config only names the strategy.
+    private static void ValidateMatch(EnrollmentMatch match)
+    {
+        switch (match.Strategy)
+        {
+            case EnrollmentMatchStrategy.AnyRowValueIn:
+                if (string.IsNullOrEmpty(match.Field) || match.ValueIn is not { Count: > 0 })
+                {
+                    throw new InvalidOperationException(
+                        "Enrollment match strategy 'AnyRowValueIn' requires a 'field' and a non-empty 'valueIn'.");
+                }
+
+                break;
+
+            case EnrollmentMatchStrategy.ConfidenceThreshold:
+                if (string.IsNullOrEmpty(match.ScoreField) || match.Threshold is null)
+                {
+                    throw new InvalidOperationException(
+                        "Enrollment match strategy 'ConfidenceThreshold' requires a 'scoreField' and a 'threshold'.");
+                }
+
+                // The optional eligibility check is field + valueIn TOGETHER or neither — one alone
+                // would silently degrade to score-only matching.
+                bool hasField = !string.IsNullOrEmpty(match.Field);
+                bool hasValueIn = match.ValueIn is { Count: > 0 };
+                if (hasField != hasValueIn)
+                {
+                    throw new InvalidOperationException(
+                        "Enrollment match strategy 'ConfidenceThreshold' takes 'field' and a non-empty "
+                        + "'valueIn' together or not at all.");
+                }
+
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    $"Unsupported enrollment match strategy '{match.Strategy}'.");
+        }
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentRequestBuilder.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentRequestBuilder.cs
@@ -1,0 +1,109 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Builds the enrollment op's outgoing request-row array from the child batch: one row per child
+/// tagged with a 1-based correlation index, plus a second DOB-expanded row under the same index
+/// when the binding's <see cref="EnrollmentRequestBinding.Expand"/> strategy applies.
+/// </summary>
+internal static class EnrollmentRequestBuilder
+{
+    // Closed set of child fields a backend match reads.
+    private const string FirstNameInput = "firstName";
+    private const string LastNameInput = "lastName";
+    private const string DobInput = "dob";
+    private const string SchoolIdentifierInput = "schoolIdentifier";
+
+    public static JsonArray BuildRows(EnrollmentRequestBinding binding, EnrollmentCheckRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Batch mode: the validator guarantees a non-null index field before we get here.
+        string indexField = binding.IndexField
+            ?? throw new InvalidOperationException("Batch enrollment request binding requires an indexField.");
+
+        var rows = new JsonArray();
+
+        for (int i = 0; i < request.Children.Count; i++)
+        {
+            EnrollmentChild child = request.Children[i];
+            string index = (i + 1).ToString(CultureInfo.InvariantCulture);
+
+            rows.Add(BuildRow(binding, child, child.DateOfBirth, indexField, index));
+
+            // The swapped-DOB candidate goes under the same index.
+            if (binding.Expand == CandidateExpansion.TransposeMonthDay
+                && EnrollmentCandidateExpander.TryTransposeMonthDay(child.DateOfBirth) is { } transposed)
+            {
+                rows.Add(BuildRow(binding, child, transposed, indexField, index));
+            }
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Builds a single child's request body for PerChild fan-out: the same <c>map</c> vocabulary as a
+    /// batch row, but WITHOUT a correlation index (each call is one child).
+    /// </summary>
+    public static JsonObject BuildSingleChildBody(EnrollmentRequestBinding binding, EnrollmentChild child)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        ArgumentNullException.ThrowIfNull(child);
+
+        var body = new JsonObject();
+        BindChildFields(body, binding, child, child.DateOfBirth);
+        return body;
+    }
+
+    private static JsonObject BuildRow(
+        EnrollmentRequestBinding binding, EnrollmentChild child, DateOnly dob, string indexField, string index)
+    {
+        var row = new JsonObject();
+        BindChildFields(row, binding, child, dob);
+        JsonPathWriter.Write(row, indexField, JsonValue.Create(index));
+        return row;
+    }
+
+    // Required entries fail loud on an unresolved input; optional entries are omitted instead.
+    private static void BindChildFields(
+        JsonObject target, EnrollmentRequestBinding binding, EnrollmentChild child, DateOnly dob)
+    {
+        foreach ((string inputName, string targetPath) in binding.Map)
+        {
+            JsonPathWriter.Write(target, targetPath, JsonValue.Create(ResolveInput(inputName, child, dob)));
+        }
+
+        if (binding.MapOptional is { } mapOptional)
+        {
+            foreach ((string inputName, string targetPath) in mapOptional)
+            {
+                if (TryResolveInput(inputName, child, dob) is { } value)
+                {
+                    JsonPathWriter.Write(target, targetPath, JsonValue.Create(value));
+                }
+            }
+        }
+    }
+
+    // A map input with no value fails loud; mapOptional is the omit-instead channel.
+    private static string ResolveInput(string inputName, EnrollmentChild child, DateOnly dob) =>
+        TryResolveInput(inputName, child, dob)
+            ?? throw new InvalidOperationException(
+                $"Enrollment request map input '{inputName}' resolved to no value.");
+
+    private static string? TryResolveInput(string inputName, EnrollmentChild child, DateOnly dob) =>
+        inputName switch
+        {
+            FirstNameInput => child.FirstName,
+            LastNameInput => child.LastName,
+            DobInput => dob.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            SchoolIdentifierInput => child.SchoolIdentifier,
+            _ => null,
+        };
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentResponseCorrelator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/EnrollmentResponseCorrelator.cs
@@ -1,0 +1,195 @@
+using System.Globalization;
+using System.Text.Json;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Response-side fan-in: decides each child's match and fans verdicts back in by the echoed 1-based
+/// correlation index. The argmax and the strict <c>&gt;</c> in confidence matching live here, not in config.
+/// </summary>
+internal static class EnrollmentResponseCorrelator
+{
+    public static EnrollmentCheckResult Correlate(
+        EnrollmentResponseMapping mapping, JsonElement root, EnrollmentCheckRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(mapping);
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Batch mode: the validator guarantees a non-null index field before we get here.
+        string indexField = mapping.IndexField
+            ?? throw new InvalidOperationException("Batch enrollment response mapping requires an indexField.");
+
+        JsonElement rows = JsonPathSelector.Select(root, mapping.Root);
+
+        Dictionary<string, ChildVerdict> verdicts = mapping.Match.Strategy switch
+        {
+            EnrollmentMatchStrategy.AnyRowValueIn => CorrelateAnyRowValueIn(mapping, rows, indexField),
+            EnrollmentMatchStrategy.ConfidenceThreshold =>
+                CorrelateConfidenceThreshold(mapping, rows, indexField),
+            _ => throw new NotSupportedException(
+                $"Unsupported enrollment match strategy '{mapping.Match.Strategy}'."),
+        };
+
+        var results = new List<EnrollmentChildResult>(request.Children.Count);
+        for (int i = 0; i < request.Children.Count; i++)
+        {
+            string index = (i + 1).ToString(CultureInfo.InvariantCulture);
+            ChildVerdict verdict = verdicts.GetValueOrDefault(index, ChildVerdict.None);
+            results.Add(new EnrollmentChildResult(
+                request.Children[i].CheckId, verdict.IsMatch, verdict.MatchConfidence, verdict.StatusMessage));
+        }
+
+        return new EnrollmentCheckResult(results, ReadResultMessage(mapping, root));
+    }
+
+    /// <summary>
+    /// PerChild evaluation: applies the match strategy to the single result object at
+    /// <see cref="EnrollmentResponseMapping.Root"/> — no correlation index, no argmax.
+    /// </summary>
+    public static EnrollmentChildResult EvaluateSingleResult(
+        EnrollmentResponseMapping mapping, JsonElement root, string checkId)
+    {
+        ArgumentNullException.ThrowIfNull(mapping);
+
+        JsonElement result = JsonPathSelector.Select(root, mapping.Root);
+
+        bool isMatch = mapping.Match.Strategy switch
+        {
+            EnrollmentMatchStrategy.AnyRowValueIn => RowValueInSet(mapping.Match, result),
+            EnrollmentMatchStrategy.ConfidenceThreshold => ConfidenceThresholdMatches(mapping.Match, result),
+            _ => throw new NotSupportedException(
+                $"Unsupported enrollment match strategy '{mapping.Match.Strategy}'."),
+        };
+
+        // Like the batch path, confidence is reported even on the sub-threshold non-match path.
+        double? confidence =
+            mapping.Match.Strategy == EnrollmentMatchStrategy.ConfidenceThreshold
+                && TryReadScore(mapping.Match, result, out double score)
+            ? score
+            : null;
+
+        return new EnrollmentChildResult(checkId, isMatch, confidence, ReadStatusMessage(mapping, result));
+    }
+
+    /// <summary>Reads the configured <c>messageField</c> from the response document root — not a row.</summary>
+    public static string? ReadResultMessage(EnrollmentResponseMapping mapping, JsonElement root)
+    {
+        ArgumentNullException.ThrowIfNull(mapping);
+
+        return mapping.MessageField is null
+            ? null
+            : JsonRead.AsString(JsonPathSelector.Select(root, mapping.MessageField));
+    }
+
+    // A child's fan-in verdict; None means the response carried no matching/scored rows for it.
+    private sealed record ChildVerdict(bool IsMatch, double? MatchConfidence, string? StatusMessage)
+    {
+        public static readonly ChildVerdict None = new(false, null, null);
+    }
+
+    // The FIRST matching row wins and supplies the status message; no score field, so confidence
+    // is always null.
+    private static Dictionary<string, ChildVerdict> CorrelateAnyRowValueIn(
+        EnrollmentResponseMapping mapping, JsonElement rows, string indexField)
+    {
+        var verdicts = new Dictionary<string, ChildVerdict>(StringComparer.Ordinal);
+
+        if (rows.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement row in rows.EnumerateArray())
+            {
+                string? index = JsonRead.AsString(row, indexField);
+                if (index is not null && !verdicts.ContainsKey(index) && RowValueInSet(mapping.Match, row))
+                {
+                    verdicts[index] = new ChildVerdict(
+                        IsMatch: true, MatchConfidence: null, ReadStatusMessage(mapping, row));
+                }
+            }
+        }
+
+        return verdicts;
+    }
+
+    // Per index, take the argmax row and match iff its score > threshold (strict) AND it passes the
+    // optional eligibility check. A missing/non-numeric score contributes nothing.
+    private static Dictionary<string, ChildVerdict> CorrelateConfidenceThreshold(
+        EnrollmentResponseMapping mapping, JsonElement rows, string indexField)
+    {
+        EnrollmentMatch match = mapping.Match;
+        var bestByIndex = new Dictionary<string, (double Score, JsonElement Row)>(StringComparer.Ordinal);
+
+        if (rows.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement row in rows.EnumerateArray())
+            {
+                string? index = JsonRead.AsString(row, indexField);
+                if (index is null || !TryReadScore(match, row, out double score))
+                {
+                    continue;
+                }
+
+                if (!bestByIndex.TryGetValue(index, out (double Score, JsonElement Row) current)
+                    || score > current.Score)
+                {
+                    bestByIndex[index] = (score, row);
+                }
+            }
+        }
+
+        double threshold = match.Threshold!.Value;
+        var verdicts = new Dictionary<string, ChildVerdict>(StringComparer.Ordinal);
+        foreach ((string index, (double score, JsonElement row)) in bestByIndex)
+        {
+            // Eligibility is read from the argmax row only — a lower-scoring eligible candidate
+            // cannot rescue it. Its carriers are reported even on the non-match path (CO-plugin parity).
+            bool isMatch = score > threshold && PassesEligibility(match, row);
+            verdicts[index] = new ChildVerdict(isMatch, score, ReadStatusMessage(mapping, row));
+        }
+
+        return verdicts;
+    }
+
+    // The winning row's status text, when a statusMessageField is configured.
+    private static string? ReadStatusMessage(EnrollmentResponseMapping mapping, JsonElement row) =>
+        mapping.StatusMessageField is null ? null : JsonRead.AsString(row, mapping.StatusMessageField);
+
+    private static bool RowValueInSet(EnrollmentMatch match, JsonElement row)
+    {
+        string? value = JsonRead.AsString(row, match.Field!);
+        return value is not null && match.ValueIn!.Contains(value, StringComparer.Ordinal);
+    }
+
+    // The optional eligibility check on confidenceThreshold: a fixed AND — config only names the params.
+    private static bool PassesEligibility(EnrollmentMatch match, JsonElement row) =>
+        match.Field is null || RowValueInSet(match, row);
+
+    // PerChild confidenceThreshold: the single result carries both the score and (when configured)
+    // the eligibility flag.
+    private static bool ConfidenceThresholdMatches(EnrollmentMatch match, JsonElement result) =>
+        TryReadScore(match, result, out double score)
+            && score > match.Threshold!.Value
+            && PassesEligibility(match, result);
+
+    // Reads the score as a number; a missing property or non-numeric value is not a match.
+    private static bool TryReadScore(EnrollmentMatch match, JsonElement record, out double score)
+    {
+        score = 0;
+
+        if (record.ValueKind != JsonValueKind.Object
+            || !record.TryGetProperty(match.ScoreField!, out JsonElement value))
+        {
+            return false;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number => value.TryGetDouble(out score),
+            JsonValueKind.String => double.TryParse(
+                value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out score),
+            _ => false,
+        };
+    }
+
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/StateBackendRequestBinder.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/StateBackendRequestBinder.cs
@@ -1,0 +1,204 @@
+using System.Text.Json.Nodes;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Builds an outgoing request body from a <see cref="RequestBinding"/>: a map input resolving to
+/// nothing fails loud, a mapOptional input is omitted. <c>isProofed</c> passes straight through —
+/// never an authorization decision here.
+/// </summary>
+internal static class StateBackendRequestBinder
+{
+    public static JsonObject BuildBody(RequestBinding binding, HouseholdLookupRequest request)
+    {
+        var body = new JsonObject();
+
+        if (binding.Constants is { } constants)
+        {
+            foreach ((string targetPath, object value) in constants)
+            {
+                JsonPathWriter.Write(body, targetPath, JsonValue.Create(value));
+            }
+        }
+
+        if (binding.Map is { } map)
+        {
+            foreach ((string inputName, string targetPath) in map)
+            {
+                JsonNode value = ResolveInput(inputName, request);
+                JsonPathWriter.Write(body, targetPath, value);
+            }
+        }
+
+        if (binding.MapOptional is { } mapOptional)
+        {
+            foreach ((string inputName, string targetPath) in mapOptional)
+            {
+                if (TryResolveInput(inputName, request) is { } value)
+                {
+                    JsonPathWriter.Write(body, targetPath, value);
+                }
+            }
+        }
+
+        return body;
+    }
+
+    /// <summary>
+    /// Write-path binding: constants plus the routing fields decoded from the opaque caseId; an
+    /// unmatched map input fails loud.
+    /// </summary>
+    public static JsonObject BuildBody(RequestBinding binding, IReadOnlyDictionary<string, string> inputs)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        ArgumentNullException.ThrowIfNull(inputs);
+
+        var body = new JsonObject();
+
+        if (binding.Constants is { } constants)
+        {
+            foreach ((string targetPath, object value) in constants)
+            {
+                JsonPathWriter.Write(body, targetPath, JsonValue.Create(value));
+            }
+        }
+
+        if (binding.Map is { } map)
+        {
+            foreach ((string inputName, string targetPath) in map)
+            {
+                if (!inputs.TryGetValue(inputName, out string? value))
+                {
+                    throw new InvalidOperationException(
+                        $"Request map input '{inputName}' resolved to no value.");
+                }
+
+                JsonPathWriter.Write(body, targetPath, JsonValue.Create(value));
+            }
+        }
+
+        return body;
+    }
+
+    /// <summary>
+    /// Batch write-path binding (address update): the scalar binding plus the <c>shared</c> and
+    /// <c>collect</c> shapes over the decoded caseIds. A <c>shared</c> field that disagrees across
+    /// cases, or a shared/collect field missing from any caseId, fails loud.
+    /// </summary>
+    public static JsonObject BuildAddressBody(
+        RequestBinding binding,
+        IReadOnlyList<IReadOnlyDictionary<string, string>> decodedCaseIds,
+        IReadOnlyDictionary<string, string> scalarInputs)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        ArgumentNullException.ThrowIfNull(decodedCaseIds);
+        ArgumentNullException.ThrowIfNull(scalarInputs);
+
+        if (decodedCaseIds.Count == 0)
+        {
+            throw new InvalidOperationException("Address update requires at least one caseId.");
+        }
+
+        // Constants + scalar address fields reuse the existing scalar binding.
+        JsonObject body = BuildBody(binding, scalarInputs);
+
+        if (binding.Shared is { } shared)
+        {
+            foreach ((string fieldName, string targetPath) in shared)
+            {
+                JsonPathWriter.Write(body, targetPath, JsonValue.Create(ResolveShared(fieldName, decodedCaseIds)));
+            }
+        }
+
+        if (binding.Collect is { } collect)
+        {
+            foreach ((string fieldName, string targetPath) in collect)
+            {
+                JsonPathWriter.Write(body, targetPath, CollectArray(fieldName, decodedCaseIds));
+            }
+        }
+
+        return body;
+    }
+
+    // One household-level field across all decoded caseIds; fails loud on disagreement.
+    private static string ResolveShared(
+        string fieldName, IReadOnlyList<IReadOnlyDictionary<string, string>> decodedCaseIds)
+    {
+        string? resolved = null;
+
+        foreach (IReadOnlyDictionary<string, string> caseFields in decodedCaseIds)
+        {
+            if (!caseFields.TryGetValue(fieldName, out string? value))
+            {
+                throw new InvalidOperationException(
+                    $"Shared address field '{fieldName}' is missing from a decoded caseId.");
+            }
+
+            if (resolved is null)
+            {
+                resolved = value;
+            }
+            else if (!string.Equals(resolved, value, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Shared address field '{fieldName}' disagrees across caseIds — cannot resolve a single value.");
+            }
+        }
+
+        return resolved!;
+    }
+
+    // A per-case field gathered into an ordered array, one element per decoded caseId.
+    private static JsonArray CollectArray(
+        string fieldName, IReadOnlyList<IReadOnlyDictionary<string, string>> decodedCaseIds)
+    {
+        var array = new JsonArray();
+
+        foreach (IReadOnlyDictionary<string, string> caseFields in decodedCaseIds)
+        {
+            if (!caseFields.TryGetValue(fieldName, out string? value))
+            {
+                throw new InvalidOperationException(
+                    $"Collected address field '{fieldName}' is missing from a decoded caseId.");
+            }
+
+            array.Add(JsonValue.Create(value));
+        }
+
+        return array;
+    }
+
+    // Required entries fail loud on an unresolved input; optional entries are omitted instead.
+    private static JsonNode ResolveInput(string inputName, HouseholdLookupRequest request) =>
+        TryResolveInput(inputName, request)
+            ?? throw new InvalidOperationException(
+                $"Request map input '{inputName}' resolved to no value.");
+
+    // Closed set: household-identity signals by IdentitySignal.Type plus fixed caller-context names.
+    private static JsonNode? TryResolveInput(string inputName, HouseholdLookupRequest request)
+    {
+        if (string.Equals(inputName, "isProofed", StringComparison.Ordinal))
+        {
+            // Straight pass-through of the caller's proofing status — no authorization decision here.
+            return JsonValue.Create(request.IsProofed);
+        }
+
+        if (string.Equals(inputName, "portalUuid", StringComparison.Ordinal))
+        {
+            return request.PortalUuid is { } portalUuid ? JsonValue.Create(portalUuid) : null;
+        }
+
+        foreach (IdentitySignal signal in request.Signals)
+        {
+            if (string.Equals(signal.Type, inputName, StringComparison.Ordinal))
+            {
+                return JsonValue.Create(signal.Value);
+            }
+        }
+
+        return null;
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/StateBackendResponseMapper.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/StateBackendResponseMapper.cs
@@ -1,0 +1,631 @@
+using System.Globalization;
+using System.Text.Json;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// Maps a backend's raw JSON response into canonical domain types, driven by the operation's
+/// <see cref="StateBackendResponseMapping"/> and named enum tables.
+/// </summary>
+internal static class StateBackendResponseMapper
+{
+    /// <summary>The closed set of canonical field targets; a new canonical field means a new entry here — never reflection.</summary>
+    private static readonly IReadOnlyDictionary<string, FieldTarget> FieldTargets =
+        new Dictionary<string, FieldTarget>(StringComparer.Ordinal)
+        {
+            ["summerEBTCaseID"] = FieldTarget.String((c, v) => c.SummerEBTCaseID = v),
+            ["childFirstName"] = FieldTarget.String((c, v) => c.ChildFirstName = v),
+            ["childLastName"] = FieldTarget.String((c, v) => c.ChildLastName = v),
+            ["applicationId"] = FieldTarget.String((c, v) => c.ApplicationId = v),
+            ["ebtCardIssueDate"] = FieldTarget.DateTime((c, v) => c.EbtCardIssueDate = v),
+            ["ebtCardStatus"] = FieldTarget.Enum<CardStatus>((c, v) => c.EbtCardStatus = v),
+            ["applicationStatus"] = FieldTarget.Enum<ApplicationStatus>((c, v) => c.ApplicationStatus = v),
+            ["issuanceType"] = FieldTarget.Enum<IssuanceType>((c, v) => c.IssuanceType = v),
+        };
+
+    /// <summary>
+    /// The closed vocabulary of caller-context names a caseId <c>fromContext</c> entry may reference;
+    /// a new context value means a new entry here and on the record — never expressions in config.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, Func<CaseIdContext, string?>> ContextSources =
+        new Dictionary<string, Func<CaseIdContext, string?>>(StringComparer.Ordinal)
+        {
+            ["householdIdentifier"] = context => context.HouseholdIdentifier,
+        };
+
+    private enum FieldKind
+    {
+        String,
+        DateTime,
+        Enum,
+    }
+
+    /// <summary>
+    /// Fails loud at load when a <c>fromContext</c> entry references an unknown context name, or a
+    /// token field is sourced from both a response column and caller context.
+    /// </summary>
+    internal static void ValidateCaseIdCompositions(StateBackendConfiguration configuration)
+    {
+        foreach (StateBackendResponseMapping mapping in ResponseMappings(configuration))
+        {
+            if (mapping.CaseId is not { FromContext: { } fromContext } composition)
+            {
+                continue;
+            }
+
+            foreach ((string routingName, string contextName) in fromContext)
+            {
+                if (!ContextSources.ContainsKey(contextName))
+                {
+                    throw new InvalidOperationException(
+                        $"caseId fromContext references unknown context name '{contextName}'. " +
+                        $"Known names: {string.Join(", ", ContextSources.Keys)}.");
+                }
+
+                if (composition.Fields.ContainsKey(routingName))
+                {
+                    throw new InvalidOperationException(
+                        $"caseId token field '{routingName}' is sourced from both a response " +
+                        "column (fields) and caller context (fromContext) — pick one.");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fails loud at load on a field mapping naming an unknown canonical target, or a date-typed
+    /// target missing an exact <c>format</c>.
+    /// </summary>
+    internal static void ValidateFieldMappings(StateBackendConfiguration configuration)
+    {
+        foreach (StateBackendResponseMapping mapping in ResponseMappings(configuration))
+        {
+            foreach ((string canonicalField, FieldMapping fieldMapping) in mapping.Fields)
+            {
+                if (!FieldTargets.TryGetValue(canonicalField, out FieldTarget? target))
+                {
+                    throw new InvalidOperationException(
+                        $"Response mapping targets unknown canonical field '{canonicalField}'. " +
+                        $"Known fields: {string.Join(", ", FieldTargets.Keys)}.");
+                }
+
+                // A keywordRules primitive on a date target gets its (more precise) rejection from
+                // ValidateKeywordRules instead.
+                if (target.Kind == FieldKind.DateTime
+                    && fieldMapping.KeywordRules is null
+                    && fieldMapping.Format is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Date field '{canonicalField}' requires an exact 'format'.");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fails loud at load when a referenced enum table names a non-member canonical value, or maps
+    /// one source token to two canonical values.
+    /// </summary>
+    internal static void ValidateEnumTables(StateBackendConfiguration configuration)
+    {
+        foreach (StateBackendResponseMapping mapping in ResponseMappings(configuration))
+        {
+            foreach ((string canonicalField, FieldMapping fieldMapping) in mapping.Fields)
+            {
+                if (fieldMapping.KeywordRules is { } keywordRules)
+                {
+                    ValidateKeywordRules(canonicalField, keywordRules);
+                    continue;
+                }
+
+                if (fieldMapping.Enum is not { } tableName)
+                {
+                    continue;
+                }
+
+                FieldTarget target = ResolveTarget(canonicalField);
+                if (target.EnumType is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Field '{canonicalField}' references enum table '{tableName}' but is not an enum-typed target.");
+                }
+
+                StateBackendEnumTable table = ResolveTable(configuration, tableName);
+                BuildTokenLookup(tableName, table, target.EnumType);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Maps the selected records into cases and, when disaggregation is configured, splits out
+    /// grouped applications and links each application-based case to its application.
+    /// </summary>
+    public static HouseholdData MapHousehold(
+        JsonElement root,
+        StateBackendConfiguration configuration,
+        StateBackendResponseMapping mapping,
+        CaseIdContext context)
+    {
+        JsonElement records = JsonPathSelector.Select(root, mapping.Root);
+        var household = new HouseholdData();
+
+        if (records.ValueKind != JsonValueKind.Array)
+        {
+            return household;
+        }
+
+        // Fail loud on bad enum tables / keyword rules before mapping any records.
+        Dictionary<string, EnumResolver> enumResolvers = BuildEnumResolvers(configuration, mapping);
+        Dictionary<string, KeywordRuleResolver> keywordResolvers = BuildKeywordResolvers(mapping);
+
+        StateBackendDisaggregation? disaggregation = mapping.Disaggregation;
+
+        // Application group keys, in first-seen order.
+        var applicationKeys = new List<string>();
+        var seenApplicationKeys = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (JsonElement record in records.EnumerateArray())
+        {
+            // Map to canonical first — the inclusion predicate never reads raw state fields.
+            SummerEbtCase summerEbtCase = MapCase(record, mapping.Fields, enumResolvers, keywordResolvers);
+
+            if (mapping.CaseId is { } caseIdComposition)
+            {
+                summerEbtCase.SummerEBTCaseID = ComposeCaseId(record, caseIdComposition, context);
+            }
+
+            if (disaggregation is null)
+            {
+                household.SummerEbtCases.Add(summerEbtCase);
+                continue;
+            }
+
+            bool isApplicationBased = IsApplicationBased(record, disaggregation);
+
+            // Application-based records join their grouped application even when excluded as cases.
+            if (isApplicationBased && GroupKey(record, disaggregation) is { } key)
+            {
+                summerEbtCase.ApplicationId = key;
+
+                if (seenApplicationKeys.Add(key))
+                {
+                    applicationKeys.Add(key);
+                }
+            }
+
+            if (IncludeAsCase(disaggregation.CaseInclusion, isApplicationBased, summerEbtCase.ApplicationStatus))
+            {
+                household.SummerEbtCases.Add(summerEbtCase);
+            }
+        }
+
+        foreach (string key in applicationKeys)
+        {
+            household.Applications.Add(new Application { ApplicationNumber = key });
+        }
+
+        return household;
+    }
+
+    /// <summary>
+    /// For <see cref="CaseInclusionPredicate.WhenApprovedOrNotApplicationBased"/>, an unknown or
+    /// unmapped <see cref="ApplicationStatus"/> is not Approved — excluded, fail-closed.
+    /// </summary>
+    private static bool IncludeAsCase(
+        CaseInclusionPredicate caseInclusion, bool isApplicationBased, ApplicationStatus applicationStatus)
+    {
+        return caseInclusion switch
+        {
+            CaseInclusionPredicate.All => true,
+            CaseInclusionPredicate.WhenApprovedOrNotApplicationBased =>
+                !isApplicationBased || applicationStatus == ApplicationStatus.Approved,
+            _ => throw new NotSupportedException(
+                $"Case inclusion predicate '{caseInclusion}' is not implemented by the response mapper."),
+        };
+    }
+
+    private static bool IsApplicationBased(JsonElement record, StateBackendDisaggregation disaggregation)
+    {
+        string? discriminator = JsonRead.AsString(record, disaggregation.DiscriminatorField);
+
+        return disaggregation.Rule switch
+        {
+            DisaggregationRule.Presence => !string.IsNullOrEmpty(discriminator),
+            DisaggregationRule.ValueInSet =>
+                discriminator is not null
+                && disaggregation.ApplicationValues is { } values
+                && values.Contains(discriminator, StringComparer.Ordinal),
+            _ => throw new NotSupportedException(
+                $"Disaggregation rule '{disaggregation.Rule}' is not supported by the response mapper."),
+        };
+    }
+
+    private static string? GroupKey(JsonElement record, StateBackendDisaggregation disaggregation)
+    {
+        if (disaggregation.GroupApplicationsBy is not { } groupField)
+        {
+            return null;
+        }
+
+        string? value = JsonRead.AsString(record, groupField);
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    // Packs record + context routing fields into an opaque caseId token. A missing value packs
+    // empty; a later write that needs it fails loud.
+    private static string ComposeCaseId(JsonElement record, CaseIdComposition composition, CaseIdContext context)
+    {
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach ((string routingName, string sourceProperty) in composition.Fields)
+        {
+            fields[routingName] = JsonRead.AsString(record, sourceProperty) ?? string.Empty;
+        }
+
+        if (composition.FromContext is { } fromContext)
+        {
+            foreach ((string routingName, string contextName) in fromContext)
+            {
+                if (!ContextSources.TryGetValue(contextName, out Func<CaseIdContext, string?>? source))
+                {
+                    // Unreachable for validated configs; hand-built configs fail loud here too.
+                    throw new InvalidOperationException(
+                        $"caseId fromContext references unknown context name '{contextName}'.");
+                }
+
+                fields[routingName] = source(context) ?? string.Empty;
+            }
+        }
+
+        return OpaqueCaseId.Compose(fields);
+    }
+
+    private static SummerEbtCase MapCase(
+        JsonElement record,
+        Dictionary<string, FieldMapping> fields,
+        Dictionary<string, EnumResolver> enumResolvers,
+        Dictionary<string, KeywordRuleResolver> keywordResolvers)
+    {
+        var summerEbtCase = new SummerEbtCase();
+
+        foreach ((string canonicalField, FieldMapping fieldMapping) in fields)
+        {
+            FieldTarget target = ResolveTarget(canonicalField);
+
+            // keywordRules always yields a value (match or default), so it skips the presence guard.
+            if (fieldMapping.KeywordRules is not null)
+            {
+                target.SetEnum!(summerEbtCase, keywordResolvers[canonicalField].Resolve(record));
+                continue;
+            }
+
+            if (!record.TryGetProperty(fieldMapping.From.Single, out JsonElement value)
+                || value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            {
+                continue;
+            }
+
+            ApplyField(summerEbtCase, canonicalField, target, fieldMapping, value, enumResolvers);
+        }
+
+        return summerEbtCase;
+    }
+
+    private static void ApplyField(
+        SummerEbtCase target,
+        string canonicalField,
+        FieldTarget fieldTarget,
+        FieldMapping fieldMapping,
+        JsonElement value,
+        Dictionary<string, EnumResolver> enumResolvers)
+    {
+        switch (fieldTarget.Kind)
+        {
+            case FieldKind.String:
+                fieldTarget.SetString!(target, value.GetString() ?? string.Empty);
+                break;
+
+            case FieldKind.DateTime:
+                fieldTarget.SetDateTime!(target, ParseDate(canonicalField, fieldMapping, value));
+                break;
+
+            case FieldKind.Enum:
+                fieldTarget.SetEnum!(target, enumResolvers[canonicalField].Resolve(value.GetString()));
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    $"Field kind '{fieldTarget.Kind}' is not supported by the response mapper.");
+        }
+    }
+
+    private static DateTime ParseDate(string canonicalField, FieldMapping fieldMapping, JsonElement value)
+    {
+        string? raw = value.GetString();
+        if (fieldMapping.Format is not { } format)
+        {
+            throw new InvalidOperationException(
+                $"Date field '{canonicalField}' requires an exact 'format'.");
+        }
+
+        // Exact parse with the one configured format under InvariantCulture — no fallback.
+        return DateTime.ParseExact(raw!, format, CultureInfo.InvariantCulture, DateTimeStyles.None);
+    }
+
+    // A validated token → canonical-value resolver per enum field, fail-loud before any record maps.
+    private static Dictionary<string, EnumResolver> BuildEnumResolvers(
+        StateBackendConfiguration configuration,
+        StateBackendResponseMapping mapping)
+    {
+        var resolvers = new Dictionary<string, EnumResolver>(StringComparer.Ordinal);
+
+        foreach ((string canonicalField, FieldMapping fieldMapping) in mapping.Fields)
+        {
+            if (fieldMapping.Enum is not { } tableName)
+            {
+                continue;
+            }
+
+            FieldTarget target = ResolveTarget(canonicalField);
+            if (target.EnumType is null)
+            {
+                throw new InvalidOperationException(
+                    $"Field '{canonicalField}' references enum table '{tableName}' but is not an enum-typed target.");
+            }
+
+            StateBackendEnumTable table = ResolveTable(configuration, tableName);
+            (Dictionary<string, object> tokenLookup, object? defaultValue) =
+                BuildTokenLookup(tableName, table, target.EnumType);
+
+            resolvers[canonicalField] = new EnumResolver(tableName, tokenLookup, defaultValue);
+        }
+
+        return resolvers;
+    }
+
+    // A validated keyword-rule resolver per keywordRules field, fail-loud before any record maps.
+    private static Dictionary<string, KeywordRuleResolver> BuildKeywordResolvers(
+        StateBackendResponseMapping mapping)
+    {
+        var resolvers = new Dictionary<string, KeywordRuleResolver>(StringComparer.Ordinal);
+
+        foreach ((string canonicalField, FieldMapping fieldMapping) in mapping.Fields)
+        {
+            if (fieldMapping.KeywordRules is not { } keywordRules)
+            {
+                continue;
+            }
+
+            (Type enumType, List<(object Value, List<string> Keywords)> ordered, object defaultValue) =
+                ValidateKeywordRules(canonicalField, keywordRules);
+
+            resolvers[canonicalField] = new KeywordRuleResolver(
+                fieldMapping.From.All, ordered, defaultValue);
+        }
+
+        return resolvers;
+    }
+
+    // Validates a keywordRules primitive against its enum-typed target, fail-loud.
+    private static (Type EnumType, List<(object Value, List<string> Keywords)> Ordered, object Default)
+        ValidateKeywordRules(string canonicalField, KeywordRules keywordRules)
+    {
+        FieldTarget target = ResolveTarget(canonicalField);
+        if (target.EnumType is not { } enumType)
+        {
+            throw new InvalidOperationException(
+                $"Field '{canonicalField}' declares keywordRules but is not an enum-typed target.");
+        }
+
+        // Order must cover every map key so no keyword set is silently unreachable.
+        foreach (string mapKey in keywordRules.Map.Keys)
+        {
+            if (!keywordRules.Order.Contains(mapKey, StringComparer.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Field '{canonicalField}' keywordRules 'order' does not cover map key '{mapKey}'.");
+            }
+        }
+
+        var ordered = new List<(object Value, List<string> Keywords)>();
+        foreach (string ourValue in keywordRules.Order)
+        {
+            object parsed = ParseEnumMember($"keywordRules[{canonicalField}]", enumType, ourValue);
+            List<string> keywords = keywordRules.Map.TryGetValue(ourValue, out List<string>? mapped)
+                ? mapped
+                : new List<string>();
+            ordered.Add((parsed, keywords));
+        }
+
+        object defaultValue = ParseEnumMember($"keywordRules[{canonicalField}]", enumType, keywordRules.Default);
+
+        return (enumType, ordered, defaultValue);
+    }
+
+    // Inverts a table into a token → our-value lookup, rejecting non-member values and ambiguous tokens.
+    private static (Dictionary<string, object> TokenLookup, object? Default) BuildTokenLookup(
+        string tableName,
+        StateBackendEnumTable table,
+        Type enumType)
+    {
+        var tokenLookup = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        foreach ((string ourValue, List<string> tokens) in table.Map)
+        {
+            object parsed = ParseEnumMember(tableName, enumType, ourValue);
+
+            foreach (string token in tokens)
+            {
+                if (tokenLookup.TryGetValue(token, out object? existing) && !existing.Equals(parsed))
+                {
+                    throw new InvalidOperationException(
+                        $"Enum table '{tableName}' maps token '{token}' to more than one canonical value.");
+                }
+
+                tokenLookup[token] = parsed;
+            }
+        }
+
+        object? defaultValue = table.Default is { } def
+            ? ParseEnumMember(tableName, enumType, def)
+            : null;
+
+        return (tokenLookup, defaultValue);
+    }
+
+    private static object ParseEnumMember(string tableName, Type enumType, string memberName)
+    {
+        if (!Enum.TryParse(enumType, memberName, ignoreCase: false, out object? parsed) || parsed is null)
+        {
+            throw new InvalidOperationException(
+                $"Enum table '{tableName}' references '{memberName}', which is not a member of {enumType.Name}.");
+        }
+
+        return parsed;
+    }
+
+    private static FieldTarget ResolveTarget(string canonicalField)
+    {
+        if (!FieldTargets.TryGetValue(canonicalField, out FieldTarget? target))
+        {
+            throw new NotSupportedException(
+                $"Canonical field '{canonicalField}' is not supported by the response mapper.");
+        }
+
+        return target;
+    }
+
+    private static StateBackendEnumTable ResolveTable(StateBackendConfiguration configuration, string tableName)
+    {
+        if (configuration.Enums is null || !configuration.Enums.TryGetValue(tableName, out StateBackendEnumTable? table))
+        {
+            throw new InvalidOperationException(
+                $"Response mapping references enum table '{tableName}', which is not defined under 'enums'.");
+        }
+
+        return table;
+    }
+
+    private static IEnumerable<StateBackendResponseMapping> ResponseMappings(StateBackendConfiguration configuration)
+    {
+        if (configuration.Operations.HouseholdLookup?.Response is { } lookup)
+        {
+            yield return lookup;
+        }
+    }
+
+    /// <summary>A canonical field target: coercion kind, typed setter, and enum type for enum targets.</summary>
+    private sealed class FieldTarget
+    {
+        private FieldTarget(FieldKind kind)
+        {
+            Kind = kind;
+        }
+
+        public FieldKind Kind { get; }
+
+        public Type? EnumType { get; private init; }
+
+        public Action<SummerEbtCase, string>? SetString { get; private init; }
+
+        public Action<SummerEbtCase, DateTime>? SetDateTime { get; private init; }
+
+        public Action<SummerEbtCase, object>? SetEnum { get; private init; }
+
+        public static FieldTarget String(Action<SummerEbtCase, string> setter) =>
+            new(FieldKind.String) { SetString = setter };
+
+        public static FieldTarget DateTime(Action<SummerEbtCase, DateTime> setter) =>
+            new(FieldKind.DateTime) { SetDateTime = setter };
+
+        public static FieldTarget Enum<TEnum>(Action<SummerEbtCase, TEnum> setter) where TEnum : struct, Enum =>
+            new(FieldKind.Enum)
+            {
+                EnumType = typeof(TEnum),
+                SetEnum = (target, value) => setter(target, (TEnum)value),
+            };
+    }
+
+    /// <summary>
+    /// Scans a record's source values for the ordered keyword sets (first-match-wins,
+    /// case-insensitive contains); returns the match or the default.
+    /// </summary>
+    private sealed class KeywordRuleResolver
+    {
+        private readonly IReadOnlyList<string> _sources;
+        private readonly List<(object Value, List<string> Keywords)> _ordered;
+        private readonly object _default;
+
+        public KeywordRuleResolver(
+            IReadOnlyList<string> sources,
+            List<(object Value, List<string> Keywords)> ordered,
+            object defaultValue)
+        {
+            _sources = sources;
+            _ordered = ordered;
+            _default = defaultValue;
+        }
+
+        public object Resolve(JsonElement record)
+        {
+            // Uppercased once for case-insensitive contains.
+            var haystacks = new List<string>(_sources.Count);
+            foreach (string source in _sources)
+            {
+                string? value = JsonRead.AsString(record, source);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    haystacks.Add(value.ToUpperInvariant());
+                }
+            }
+
+            foreach ((object value, List<string> keywords) in _ordered)
+            {
+                foreach (string keyword in keywords)
+                {
+                    string needle = keyword.ToUpperInvariant();
+                    foreach (string haystack in haystacks)
+                    {
+                        if (haystack.Contains(needle, StringComparison.Ordinal))
+                        {
+                            return value;
+                        }
+                    }
+                }
+            }
+
+            return _default;
+        }
+    }
+
+    /// <summary>A validated token → canonical-enum-value lookup with a fallback default.</summary>
+    private sealed class EnumResolver
+    {
+        private readonly string _tableName;
+        private readonly Dictionary<string, object> _tokenLookup;
+        private readonly object? _default;
+
+        public EnumResolver(string tableName, Dictionary<string, object> tokenLookup, object? defaultValue)
+        {
+            _tableName = tableName;
+            _tokenLookup = tokenLookup;
+            _default = defaultValue;
+        }
+
+        public object Resolve(string? token)
+        {
+            if (token is not null && _tokenLookup.TryGetValue(token, out object? value))
+            {
+                return value;
+            }
+
+            // Default applies only to genuinely-unlisted tokens.
+            return _default
+                ?? throw new InvalidOperationException(
+                    $"Enum table '{_tableName}' has no mapping for token '{token}' and no default.");
+        }
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/WriteResultClassifier.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Mapping/WriteResultClassifier.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+/// <summary>
+/// A classified write outcome plus the backend-supplied message, when one was readable from the
+/// response body.
+/// </summary>
+internal readonly record struct WriteClassification(WriteOutcome Outcome, string? Message);
+
+/// <summary>
+/// Classifies a write response into a canonical <see cref="WriteOutcome"/>: ordered conditions,
+/// first-match-wins, falling back to the default.
+/// </summary>
+internal static class WriteResultClassifier
+{
+    /// <summary>
+    /// Fails loud at load unless each condition sets exactly one closed kind and value/message
+    /// kinds name the body property they read.
+    /// </summary>
+    public static void Validate(ResultClassifier classifier)
+    {
+        ArgumentNullException.ThrowIfNull(classifier);
+
+        foreach (ResultCondition condition in classifier.Conditions)
+        {
+            int kinds = 0;
+            if (condition.StatusIn is not null)
+            {
+                kinds++;
+            }
+
+            if (condition.ValueIn is not null)
+            {
+                kinds++;
+            }
+
+            if (condition.MessageContains is not null)
+            {
+                kinds++;
+            }
+
+            if (kinds != 1)
+            {
+                throw new InvalidOperationException(
+                    "Each write result condition must set exactly one of: statusIn, valueIn, messageContains.");
+            }
+
+            if (condition.ValueIn is not null && string.IsNullOrWhiteSpace(condition.Field))
+            {
+                throw new InvalidOperationException(
+                    "A write 'valueIn' condition requires a body 'field' to read.");
+            }
+
+            if (condition.MessageContains is not null && string.IsNullOrWhiteSpace(condition.MessageField))
+            {
+                throw new InvalidOperationException(
+                    "A write 'messageContains' condition requires a body 'messageField' to read.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Classifies a response. <paramref name="body"/> is null when the backend returned no/invalid
+    /// JSON — status-only conditions still apply.
+    /// </summary>
+    public static WriteClassification Classify(ResultClassifier classifier, int statusCode, JsonElement? body)
+    {
+        foreach (ResultCondition condition in classifier.Conditions)
+        {
+            if (Matches(condition, statusCode, body))
+            {
+                return new WriteClassification(condition.Outcome, ReadMessage(classifier, condition, body));
+            }
+        }
+
+        return new WriteClassification(classifier.Default, ReadMessage(classifier, matched: null, body));
+    }
+
+    // The matched condition's messageField, else the first messageField any condition declares —
+    // so a default-classified error still surfaces the backend's message.
+    private static string? ReadMessage(ResultClassifier classifier, ResultCondition? matched, JsonElement? body)
+    {
+        string? messageField = matched?.MessageField
+            ?? classifier.Conditions
+                .FirstOrDefault(condition => !string.IsNullOrWhiteSpace(condition.MessageField))?
+                .MessageField;
+
+        if (messageField is null || body is null)
+        {
+            return null;
+        }
+
+        string? message = JsonRead.AsString(body, messageField);
+        return string.IsNullOrWhiteSpace(message) ? null : message;
+    }
+
+    private static bool Matches(ResultCondition condition, int statusCode, JsonElement? body)
+    {
+        if (condition.StatusIn is { } statuses)
+        {
+            return statuses.Contains(statusCode);
+        }
+
+        if (condition.ValueIn is { } values)
+        {
+            string? value = JsonRead.AsString(body, condition.Field!);
+            return value is not null && values.Contains(value, StringComparer.Ordinal);
+        }
+
+        if (condition.MessageContains is { } needles)
+        {
+            string? message = JsonRead.AsString(body, condition.MessageField!);
+            if (message is null)
+            {
+                return false;
+            }
+
+            string haystack = message.ToUpperInvariant();
+            foreach (string needle in needles)
+            {
+                if (haystack.Contains(needle.ToUpperInvariant(), StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 4 of 11.** Still nothing calls the adapter.

Adds the transform layer — the code that turns config into a response read, a request build, and a result verdict.

- `StateBackendResponseMapper`, `StateBackendRequestBinder`, `WriteResultClassifier`.
- Enrollment helpers: `EnrollmentRequestBuilder`, `ResponseCorrelator`, `CandidateExpander`, `OperationValidator`.
- No standalone tests here — exercised by the loader and driver PRs above it.

**Focus:** how config drives each transform, and the closed set of named primitives. There's no expression language — every transform is a named operation config picks from.

#### ✅ Completion tasks
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ