### PR TITLE
feat(DC-568): YAML config loader + load-time validation

### DIFF
--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Configuration/Converters/FieldSourcesYamlTypeConverter.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Configuration/Converters/FieldSourcesYamlTypeConverter.cs
@@ -1,0 +1,42 @@
+namespace SEBT.Portal.Infrastructure.StateBackends.Configuration.Converters;
+
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+/// <summary>
+/// Hydrates a <see cref="FieldSources"/> from either a scalar (<c>from: X</c>) or a sequence
+/// (<c>from: [X, Y]</c>). Most fields bind a single source; the keyword-rules primitive may list more.
+/// </summary>
+internal sealed class FieldSourcesYamlTypeConverter : IYamlTypeConverter
+{
+    public bool Accepts(Type type)
+    {
+        return type == typeof(FieldSources);
+    }
+
+    public object? ReadYaml(IParser parser, Type type, ObjectDeserializer rootDeserializer)
+    {
+        if (parser.Current is SequenceStart)
+        {
+            parser.Consume<SequenceStart>();
+            var sources = new List<string>();
+            while (parser.Current is not SequenceEnd)
+            {
+                sources.Add(parser.Consume<Scalar>().Value);
+            }
+
+            parser.Consume<SequenceEnd>();
+            return new FieldSources(sources);
+        }
+
+        Scalar scalar = parser.Consume<Scalar>();
+        return new FieldSources(new[] { scalar.Value });
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type, ObjectSerializer serializer)
+    {
+        throw new NotSupportedException("State-backend configs are never serialized to YAML.");
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Configuration/StateBackendConfigurationLoader.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Configuration/StateBackendConfigurationLoader.cs
@@ -1,0 +1,47 @@
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+using SEBT.Portal.Infrastructure.StateBackends.Configuration.Converters;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Configuration;
+
+internal static class StateBackendConfigurationLoader
+{
+    private static readonly Lazy<IDeserializer> LazyDeserializer =
+        new(BuildDeserializer);
+
+    public static StateBackendConfiguration Load(string yaml)
+    {
+        StateBackendConfiguration configuration =
+            LazyDeserializer.Value.Deserialize<StateBackendConfiguration>(yaml);
+
+        // Fail loud at load on any malformed config shape.
+        StateBackendConfigurationValidator.Validate(configuration);
+
+        return configuration;
+    }
+
+    private static IDeserializer BuildDeserializer()
+    {
+        return new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .WithTypeConverter(new FieldSourcesYamlTypeConverter())
+            // Infer bool/number for unquoted scalars bound to `object` (e.g. a request binding's
+            // `const: true` must hydrate as a real bool so the emitted JSON body is `true`, not "true").
+            .WithAttemptingUnquotedStringTypeDeserialization()
+            .WithEnforceRequiredMembers()
+            .IgnoreUnmatchedProperties()
+            .WithTypeDiscriminatingNodeDeserializer(options =>
+            {
+                options.AddKeyValueTypeDiscriminator<StateBackendAuthScheme>(
+                    "scheme",
+                    new Dictionary<string, Type>
+                    {
+                        ["api_key"] = typeof(StateBackendApiKeyAuthScheme),
+                        ["client_credentials"] = typeof(StateBackendOAuthClientCredentialsAuthScheme),
+                    });
+            })
+            .Build();
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Configuration/StateBackendConfigurationValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Configuration/StateBackendConfigurationValidator.cs
@@ -1,0 +1,52 @@
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+using SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Configuration;
+
+/// <summary>
+/// The single load-time validation entry point for a state-backend config: a malformed config
+/// fails loud at startup rather than on the first user request.
+/// </summary>
+internal static class StateBackendConfigurationValidator
+{
+    public static void Validate(StateBackendConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        StateBackendResponseMapper.ValidateFieldMappings(configuration);
+        StateBackendResponseMapper.ValidateEnumTables(configuration);
+        StateBackendResponseMapper.ValidateCaseIdCompositions(configuration);
+
+        StateBackendOperations operations = configuration.Operations;
+
+        if (operations.CardReplacement?.Result is { } cardReplacementClassifier)
+        {
+            WriteResultClassifier.Validate(cardReplacementClassifier);
+        }
+
+        if (operations.AddressUpdate?.Result is { } addressUpdateClassifier)
+        {
+            WriteResultClassifier.Validate(addressUpdateClassifier);
+        }
+
+        // Write-path body builders don't read mapOptional yet; fail loud rather than silently no-op.
+        RejectMapOptional(operations.CardReplacement?.Request, "cardReplacement");
+        RejectMapOptional(operations.AddressUpdate?.Request, "addressUpdate");
+
+        // A partially modeled enrollment op is caught by the dispatch path's not-supported guards.
+        if (operations.EnrollmentCheck is { Request: { } binding, Response: { } mapping } enrollment)
+        {
+            EnrollmentOperationValidator.Validate(enrollment.CallMode, binding, mapping);
+        }
+    }
+
+    private static void RejectMapOptional(RequestBinding? request, string operationName)
+    {
+        if (request?.MapOptional is { Count: > 0 })
+        {
+            throw new InvalidOperationException(
+                $"mapOptional is not supported on write operations ({operationName}).");
+        }
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/apps/portal/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -38,6 +38,7 @@
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
+        <PackageReference Include="YamlDotNet" Version="18.1.0" />
     </ItemGroup>
 
   <!-- State connector contract lives in-repo (apps/connectors/state). Reference the project
@@ -72,6 +73,7 @@
         <Content Include="Integration\Fixtures\*.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
+        <EmbeddedResource Include="Unit/Infrastructure/StateBackends/ConfigSamples/*.yaml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigSamples/SampleLoader.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigSamples/SampleLoader.cs
@@ -1,0 +1,16 @@
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends.ConfigSamples;
+
+internal static class SampleLoader
+{
+    public static string Load(string name)
+    {
+        var assembly = typeof(SampleLoader).Assembly;
+        var ns = typeof(SampleLoader).Namespace;
+        var fullName = $"{ns}.{name}";
+
+        using var stream = assembly.GetManifestResourceStream(fullName)
+            ?? throw new InvalidOperationException($"Failed to locate embedded resource: {fullName}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigSamples/co.sample.yaml
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigSamples/co.sample.yaml
@@ -1,0 +1,94 @@
+baseUrl: http://localhost:8086
+auth:
+  scheme: client_credentials
+  tokenUrl: http://localhost:8086/oauth/token
+  clientId: co-client
+  clientSecretRef: co-client-secret
+operations:
+  householdLookup:
+    method: post
+    path: /sebt/get-account-details
+    request:
+      map:
+        phone: PhnNm
+    response:
+      root: $.stdntEnrollDtls
+      fields:
+        summerEBTCaseID:
+          from: sebtChldCwin
+        childFirstName:
+          from: chldNm
+        applicationStatus:
+          from: sebtAppSts
+          enum: applicationStatus
+      disaggregation:
+        rule: valueInSet
+        discriminatorField: eligSrc
+        applicationValues: [CBMS, PK]
+        groupApplicationsBy: sebtAppId
+        caseInclusion: whenApprovedOrNotApplicationBased
+  cardReplacement:
+    method: patch
+    path: /sebt/update-std-dtls
+  addressUpdate:
+    method: patch
+    path: /sebt/update-std-dtls
+    request:
+      # Batch shape: each decoded caseId's per-case write-id is COLLECTED into a PATCH array.
+      collect:
+        writeId: cases
+      # Scalar address fields bind through the same map vocabulary.
+      map:
+        line1: stdAddr
+        zip: stdZip
+    result:
+      conditions:
+        - outcome: success
+          field: respCd
+          valueIn: ["200", "00"]
+      default: backendError
+  enrollmentCheck:
+    method: post
+    path: /sebt/check-enrollment
+    # Batch fan-out: ONE call carries every child as a correlated row.
+    callMode: batch
+    request:
+      # Closed candidate-expansion primitive: emit the entered DOB plus its month/day-swapped
+      # candidate (when valid AND different) under one shared correlation index.
+      expand: transposeMonthDay
+      indexField: stdReqInd
+      map:
+        firstName: stdFirstName
+        lastName: stdLastName
+        dob: stdDob
+      # CO's match also reads the school code; optional because the portal may not have it.
+      mapOptional:
+        schoolIdentifier: StdSchlCd
+    response:
+      root: $.stdntDtls
+      indexField: stdReqInd
+      # The winning (argmax) row's eligibility text rides along per child — even on a sub-threshold
+      # non-match — and CBMS's root-level RespMsg is surfaced result-level.
+      statusMessageField: sebtEligSts
+      messageField: RespMsg
+      # CO's match: pick the child's highest-confidence candidate row (argmax by mtchCnfd) and
+      # match iff that best is STRICTLY greater than the threshold AND that SAME row is SEBT-eligible.
+      # The argmax, `>`, and the AND are fixed code; config only names the strategy and its params.
+      match:
+        strategy: confidenceThreshold
+        scoreField: mtchCnfd
+        threshold: 90
+        field: sebtEligSts
+        valueIn: ["Y"]
+  health:
+    method: get
+    path: /ping
+enums:
+  # CBMS application processing status (sebtAppSts). Domain-centered: OUR value -> state token(s).
+  # 2-letter CBMS codes; unlisted tokens fall through to Unknown (not Approved -> excluded if app-based).
+  applicationStatus:
+    map:
+      Approved: [AP]
+      Denied: [DE]
+      Pending: [PD, PE]
+    default: Unknown

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigSamples/dc.sample.yaml
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigSamples/dc.sample.yaml
@@ -1,0 +1,140 @@
+baseUrl: http://localhost:8085
+auth:
+  scheme: api_key
+  header: X-Api-Key
+  keyRef: dc-api-key
+operations:
+  householdLookup:
+    method: post
+    path: /households/lookup
+    request:
+      constants:
+        includePendingApplicantDetails: false
+      map:
+        email: guardianEmail
+        ic: guardianIdentifiers.IC
+        dob: guardianIdentifiers.DOB
+        portalUuid: guardianIdentifiers.PortalUUID
+        isProofed: isIdentityProofed
+      # Bound only when the signal is present; omitted from the body entirely when absent.
+      mapOptional:
+        socureUuid: guardianIdentifiers.SocureUUID
+    response:
+      root: $.resultSets[0]
+      fields:
+        summerEBTCaseID:
+          from: SummerEBTCaseID
+        childFirstName:
+          from: ChildFirstName
+        childLastName:
+          from: ChildLastName
+        ebtCardIssueDate:
+          from: EbtCardIssueDate
+          # The wrapper serializes DC's DATE column as ISO 8601 (System.Text.Json default).
+          format: yyyy-MM-ddTHH:mm:ss
+        ebtCardStatus:
+          from: EbtCardStatus
+          enum: cardStatus
+        # Issuance type is inferred from free-text fields via contains-match, first-match-wins.
+        # `from` lists one OR MORE source fields; a keyword found in ANY of them counts.
+        issuanceType:
+          from: [HouseholdType, EligibilityType]
+          keywordRules:
+            order: [SummerEbt, SnapEbtCard, TanfEbtCard]  # first-match-wins — order is load-bearing
+            map:
+              SummerEbt:   [OSSE, NSLP]                   # OUR value -> substrings that indicate it
+              SnapEbtCard: [FOOD, SNAP]
+              TanfEbtCard: [CASH, TANF]
+            default: Unknown
+      disaggregation:
+        rule: presence
+        discriminatorField: ApplicationId
+        groupApplicationsBy: ApplicationId
+        caseInclusion: all
+      # The case's id is an OPAQUE, self-describing token composed from the routing fields a write
+      # needs. Config lists WHICH fields; encode/decode is a fixed platform primitive.
+      caseId:
+        fields:
+          caseId: SummerEBTCaseID
+          applicationId: ApplicationId
+        # The lookup response never echoes the household email DC's writes bind, so it packs from
+        # the lookup's caller context. Context names are a closed set — today only householdIdentifier.
+        fromContext:
+          householdEmail: householdIdentifier
+  cardReplacement:
+    method: post
+    path: /card-replacements
+    request:
+      # Map LHS are the decoded caseId routing fields; RHS are the wrapper's request keys
+      # (bound 1:1 to the sproc's @householdEmail / @summerEbtCaseId params). The canonical
+      # contract carries no replacement reason, so the wrapper's `reason` key is unbound (SQL NULL).
+      map:
+        caseId: summerEbtCaseId
+        householdEmail: householdEmail
+    result:
+      # Ordered, first-match-wins. Each condition is EXACTLY ONE of three closed kinds:
+      # statusIn / valueIn(field) / messageContains(messageField). NO combinators, NO nesting.
+      # The wrapper returns HTTP 200 with the sproc's raw OUTPUT params: numeric resultCode
+      # (0 = success) and resultMessage (policy rejections carry "policy" wording).
+      conditions:
+        # DC: a "policy" message is a policy rejection — evaluated BEFORE success (order matters).
+        - outcome: policyRejection
+          messageField: resultMessage
+          messageContains: [policy]
+        - outcome: success
+          field: resultCode
+          valueIn: ["0"]  # numeric 0 — JsonRead stringifies numbers
+      default: backendError
+  addressUpdate:
+    method: post
+    path: /households/address
+    request:
+      constants:
+        source: portal
+      # Batch shape: one household identifier resolved across ALL decoded caseIds; the binder fails
+      # loud if the cases disagree. LHS is a decoded routing field; RHS is the write-body path.
+      shared:
+        householdEmail: householdIdentifier
+      # Scalar address fields bind through the same map vocabulary as other writes.
+      map:
+        line1: address.line1
+        city: address.city
+        state: address.state
+        zip: address.zip
+    result:
+      # Same capped 3-kind classifier as card replacement — reused, not a second classifier.
+      conditions:
+        - outcome: success
+          field: resultCode
+          valueIn: [OK]
+      default: backendError
+  enrollmentCheck:
+    method: post
+    path: /enrollment/check
+    # PerChild fan-out: the driver loops the batch, one call per child. No correlation index, no DOB expansion.
+    callMode: perChild
+    request:
+      map:
+        firstName: firstName
+        lastName: lastName
+        dob: dateOfBirth
+      # DC's sproc match also reads the school name; optional because the portal may not have it.
+      mapOptional:
+        schoolIdentifier: schoolName
+    response:
+      # The single result object is the response root; the anyRowValueIn strategy reads the boolean
+      # eligibility flag (one result, so no fan-in).
+      root: $
+      match:
+        strategy: anyRowValueIn
+        field: isEligible
+        valueIn: ["true"]
+  health:
+    method: get
+    path: /health
+enums:
+  cardStatus:
+    map:
+      Active: [ACTIVE]
+      Lost: [LOST, "LOST, AUTO REISSUE"]
+    default: Unknown

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendConfigurationHydrationTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendConfigurationHydrationTests.cs
@@ -1,0 +1,650 @@
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+using SEBT.Portal.Infrastructure.StateBackends.Configuration;
+using SEBT.Portal.Tests.Unit.Infrastructure.StateBackends.ConfigSamples;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+/// <summary>
+/// Hydrates the canonical state-backend config records from YAML and asserts the shape of both
+/// sample bundles, plus the validator's fail-loud checks.
+/// </summary>
+public class StateBackendConfigurationHydrationTests
+{
+    [Fact]
+    public void Hydrates_StateBackendConfiguration_FromEmbeddedYaml()
+    {
+        string yaml = SampleLoader.Load("dc.sample.yaml");
+        var config = StateBackendConfigurationLoader.Load(yaml);
+
+        Assert.Equal(new Uri("http://localhost:8085"), config.BaseUrl);
+
+        StateBackendApiKeyAuthScheme apiKeyAuth = Assert.IsType<StateBackendApiKeyAuthScheme>(config.Auth);
+        Assert.Equal("X-Api-Key", apiKeyAuth.Header);
+        Assert.Equal("dc-api-key", apiKeyAuth.KeyRef);
+
+        HouseholdLookupOperationConfig? householdLookup = config.Operations.HouseholdLookup;
+        Assert.NotNull(householdLookup);
+        Assert.Equal(StateBackendHttpMethod.Post, householdLookup.Method);
+        Assert.Equal("/households/lookup", householdLookup.Path);
+
+        RequestBinding? request = householdLookup.Request;
+        Assert.NotNull(request);
+
+        Assert.NotNull(request.Constants);
+        Assert.Equal(false, request.Constants["includePendingApplicantDetails"]);
+
+        // isIdentityProofed must be a per-request map pass-through, never a constant — hardcoding it
+        // would bypass the DC lookup's proofing gate.
+        Assert.DoesNotContain("isIdentityProofed", request.Constants.Keys);
+
+        Assert.NotNull(request.Map);
+        Assert.Equal("guardianEmail", request.Map["email"]);
+        Assert.Equal("guardianIdentifiers.IC", request.Map["ic"]);
+        Assert.Equal("guardianIdentifiers.DOB", request.Map["dob"]);
+        Assert.Equal("guardianIdentifiers.PortalUUID", request.Map["portalUuid"]);
+        Assert.Equal("isIdentityProofed", request.Map["isProofed"]);
+
+        // Optional inputs bind if present and are omitted from the request body when absent.
+        Assert.NotNull(request.MapOptional);
+        Assert.Equal("guardianIdentifiers.SocureUUID", request.MapOptional["socureUuid"]);
+
+        StateBackendResponseMapping? response = householdLookup.Response;
+        Assert.NotNull(response);
+        Assert.Equal("$.resultSets[0]", response.Root);
+        Assert.Equal("SummerEBTCaseID", response.Fields["summerEBTCaseID"].From);
+        Assert.Equal("ChildFirstName", response.Fields["childFirstName"].From);
+
+        // The wrapper passes DC's raw column names through and serializes DATE columns as ISO 8601.
+        FieldMapping issueDate = response.Fields["ebtCardIssueDate"];
+        Assert.Equal("EbtCardIssueDate", issueDate.From);
+        Assert.Equal("yyyy-MM-ddTHH:mm:ss", issueDate.Format);
+
+        FieldMapping cardStatus = response.Fields["ebtCardStatus"];
+        Assert.Equal("EbtCardStatus", cardStatus.From);
+        Assert.Equal("cardStatus", cardStatus.Enum);
+
+        FieldMapping issuanceType = response.Fields["issuanceType"];
+        Assert.Equal(new[] { "HouseholdType", "EligibilityType" }, issuanceType.From.All);
+        KeywordRules keywordRules = Assert.IsType<KeywordRules>(issuanceType.KeywordRules);
+        Assert.Equal(new[] { "SummerEbt", "SnapEbtCard", "TanfEbtCard" }, keywordRules.Order);
+        Assert.Equal(new[] { "OSSE", "NSLP" }, keywordRules.Map["SummerEbt"]);
+        Assert.Equal(new[] { "FOOD", "SNAP" }, keywordRules.Map["SnapEbtCard"]);
+        Assert.Equal(new[] { "CASH", "TANF" }, keywordRules.Map["TanfEbtCard"]);
+        Assert.Equal("Unknown", keywordRules.Default);
+
+        Assert.NotNull(config.Enums);
+        StateBackendEnumTable cardStatusTable = config.Enums["cardStatus"];
+        Assert.Equal(new[] { "ACTIVE" }, cardStatusTable.Map["Active"]);
+        Assert.Equal(new[] { "LOST", "LOST, AUTO REISSUE" }, cardStatusTable.Map["Lost"]);
+        Assert.Equal("Unknown", cardStatusTable.Default);
+
+        StateBackendDisaggregation? disaggregation = response.Disaggregation;
+        Assert.NotNull(disaggregation);
+        Assert.Equal(DisaggregationRule.Presence, disaggregation.Rule);
+        Assert.Equal("ApplicationId", disaggregation.DiscriminatorField);
+        Assert.Equal("ApplicationId", disaggregation.GroupApplicationsBy);
+        Assert.Equal(CaseInclusionPredicate.All, disaggregation.CaseInclusion);
+
+        CaseIdComposition caseId = Assert.IsType<CaseIdComposition>(response.CaseId);
+        Assert.Equal("SummerEBTCaseID", caseId.Fields["caseId"]);
+        Assert.Equal("ApplicationId", caseId.Fields["applicationId"]);
+
+        // The lookup response never echoes the household email DC's writes bind, so the token
+        // packs it from the lookup's caller context.
+        Assert.NotNull(caseId.FromContext);
+        Assert.Equal("householdIdentifier", caseId.FromContext["householdEmail"]);
+
+        CardReplacementOperationConfig? cardReplacement = config.Operations.CardReplacement;
+        Assert.NotNull(cardReplacement);
+        Assert.Equal(StateBackendHttpMethod.Post, cardReplacement.Method);
+        Assert.Equal("/card-replacements", cardReplacement.Path);
+
+        // The wrapper's request model is the sproc's three inputs; the canonical contract carries
+        // no replacement reason, so only the two token-carried routing fields bind.
+        Assert.NotNull(cardReplacement.Request);
+        Assert.Null(cardReplacement.Request.Constants);
+        Assert.Equal("summerEbtCaseId", cardReplacement.Request.Map!["caseId"]);
+        Assert.Equal("householdEmail", cardReplacement.Request.Map["householdEmail"]);
+
+        // The wrapper returns the sproc's raw OUTPUT params: numeric resultCode + resultMessage.
+        ResultClassifier classifier = Assert.IsType<ResultClassifier>(cardReplacement.Result);
+        Assert.Equal(2, classifier.Conditions.Count);
+        Assert.Equal(WriteOutcome.PolicyRejection, classifier.Conditions[0].Outcome);
+        Assert.Equal("resultMessage", classifier.Conditions[0].MessageField);
+        Assert.Equal(new[] { "policy" }, classifier.Conditions[0].MessageContains);
+        Assert.Equal(WriteOutcome.Success, classifier.Conditions[1].Outcome);
+        Assert.Equal("resultCode", classifier.Conditions[1].Field);
+        Assert.Equal(new[] { "0" }, classifier.Conditions[1].ValueIn);
+        Assert.Equal(WriteOutcome.BackendError, classifier.Default);
+
+        // DC address update uses the SHARED batch shape (one household field across all cases).
+        AddressUpdateOperationConfig? dcAddressUpdate = config.Operations.AddressUpdate;
+        Assert.NotNull(dcAddressUpdate);
+        Assert.Equal(StateBackendHttpMethod.Post, dcAddressUpdate.Method);
+        Assert.Equal("/households/address", dcAddressUpdate.Path);
+
+        Assert.NotNull(dcAddressUpdate.Request);
+        Assert.Equal("portal", dcAddressUpdate.Request.Constants!["source"]);
+        Assert.Equal("householdIdentifier", dcAddressUpdate.Request.Shared!["householdEmail"]);
+        Assert.Null(dcAddressUpdate.Request.Collect);
+        Assert.Equal("address.line1", dcAddressUpdate.Request.Map!["line1"]);
+        Assert.Equal("address.city", dcAddressUpdate.Request.Map["city"]);
+        Assert.Equal("address.state", dcAddressUpdate.Request.Map["state"]);
+        Assert.Equal("address.zip", dcAddressUpdate.Request.Map["zip"]);
+
+        ResultClassifier dcAddressClassifier = Assert.IsType<ResultClassifier>(dcAddressUpdate.Result);
+        ResultCondition dcAddressSuccess = Assert.Single(dcAddressClassifier.Conditions);
+        Assert.Equal(WriteOutcome.Success, dcAddressSuccess.Outcome);
+        Assert.Equal("resultCode", dcAddressSuccess.Field);
+        Assert.Equal(new[] { "OK" }, dcAddressSuccess.ValueIn);
+        Assert.Equal(WriteOutcome.BackendError, dcAddressClassifier.Default);
+
+        // DC enrollment uses PerChild fan-out (no index, no expansion).
+        EnrollmentCheckOperationConfig? dcEnrollment = config.Operations.EnrollmentCheck;
+        Assert.NotNull(dcEnrollment);
+        Assert.Equal(StateBackendHttpMethod.Post, dcEnrollment.Method);
+        Assert.Equal("/enrollment/check", dcEnrollment.Path);
+        Assert.Equal(EnrollmentCallMode.PerChild, dcEnrollment.CallMode);
+
+        Assert.NotNull(dcEnrollment.Request);
+        Assert.Equal(CandidateExpansion.None, dcEnrollment.Request.Expand);
+        Assert.Null(dcEnrollment.Request.IndexField);
+        Assert.Equal("firstName", dcEnrollment.Request.Map["firstName"]);
+        Assert.Equal("dateOfBirth", dcEnrollment.Request.Map["dob"]);
+
+        // schoolIdentifier is optional: the portal may not carry it, but DC's match reads it when sent.
+        Assert.NotNull(dcEnrollment.Request.MapOptional);
+        Assert.Equal("schoolName", dcEnrollment.Request.MapOptional["schoolIdentifier"]);
+
+        Assert.NotNull(dcEnrollment.Response);
+        Assert.Equal("$", dcEnrollment.Response.Root);
+        Assert.Null(dcEnrollment.Response.IndexField);
+        Assert.Equal(EnrollmentMatchStrategy.AnyRowValueIn, dcEnrollment.Response.Match.Strategy);
+        Assert.Equal("isEligible", dcEnrollment.Response.Match.Field);
+        Assert.Equal(new[] { "true" }, dcEnrollment.Response.Match.ValueIn);
+
+        // DC's backend never reported per-row or result-level messages — carriers stay unconfigured.
+        Assert.Null(dcEnrollment.Response.StatusMessageField);
+        Assert.Null(dcEnrollment.Response.MessageField);
+
+        Assert.NotNull(config.Operations.Health);
+
+        // Capabilities derive from which operations the config declares.
+        StateBackendCapabilities capabilities = config.Capabilities;
+        Assert.Equal(CardReplacementCapability.PerCase, capabilities.CardReplacement);
+        Assert.True(capabilities.AddressUpdate);
+        Assert.True(capabilities.EnrollmentCheck);
+    }
+
+    [Fact]
+    public void Hydrates_CoStateBackendConfiguration_FromEmbeddedYaml()
+    {
+        string yaml = SampleLoader.Load("co.sample.yaml");
+        var config = StateBackendConfigurationLoader.Load(yaml);
+
+        Assert.Equal(new Uri("http://localhost:8086"), config.BaseUrl);
+
+        // Covers the client_credentials auth branch (DC covers api_key).
+        StateBackendOAuthClientCredentialsAuthScheme oauthAuth =
+            Assert.IsType<StateBackendOAuthClientCredentialsAuthScheme>(config.Auth);
+        Assert.Equal(new Uri("http://localhost:8086/oauth/token"), oauthAuth.TokenUrl);
+        Assert.Equal("co-client", oauthAuth.ClientId);
+        Assert.Equal("co-client-secret", oauthAuth.ClientSecretRef);
+
+        HouseholdLookupOperationConfig? householdLookup = config.Operations.HouseholdLookup;
+        Assert.NotNull(householdLookup);
+        Assert.Equal(StateBackendHttpMethod.Post, householdLookup.Method);
+        Assert.Equal("/sebt/get-account-details", householdLookup.Path);
+
+        RequestBinding? request = householdLookup.Request;
+        Assert.NotNull(request);
+        Assert.NotNull(request.Map);
+        Assert.Equal("PhnNm", request.Map["phone"]);
+
+        Assert.Equal("sebtChldCwin", householdLookup.Response?.Fields["summerEBTCaseID"].From);
+
+        // Covers the valueInSet disaggregation branch (DC covers presence).
+        StateBackendDisaggregation? disaggregation = householdLookup.Response?.Disaggregation;
+        Assert.NotNull(disaggregation);
+        Assert.Equal(DisaggregationRule.ValueInSet, disaggregation.Rule);
+        Assert.Equal("eligSrc", disaggregation.DiscriminatorField);
+        Assert.Equal(new[] { "CBMS", "PK" }, disaggregation.ApplicationValues);
+        Assert.Equal(
+            CaseInclusionPredicate.WhenApprovedOrNotApplicationBased,
+            disaggregation.CaseInclusion);
+
+        // The status the WhenApprovedOrNotApplicationBased predicate reads.
+        FieldMapping applicationStatus = householdLookup.Response!.Fields["applicationStatus"];
+        Assert.Equal("sebtAppSts", applicationStatus.From);
+        Assert.Equal("applicationStatus", applicationStatus.Enum);
+
+        Assert.NotNull(config.Enums);
+        StateBackendEnumTable applicationStatusTable = config.Enums["applicationStatus"];
+        Assert.Equal(new[] { "AP" }, applicationStatusTable.Map["Approved"]);
+        Assert.Equal(new[] { "DE" }, applicationStatusTable.Map["Denied"]);
+        Assert.Equal("Unknown", applicationStatusTable.Default);
+
+        AddressUpdateOperationConfig? addressUpdate = config.Operations.AddressUpdate;
+        Assert.NotNull(addressUpdate);
+        Assert.Equal(StateBackendHttpMethod.Patch, addressUpdate.Method);
+        Assert.Equal("/sebt/update-std-dtls", addressUpdate.Path);
+
+        // CO uses the COLLECT batch shape: per-case write-ids into an array (DC uses shared).
+        Assert.NotNull(addressUpdate.Request);
+        Assert.Equal("cases", addressUpdate.Request.Collect!["writeId"]);
+        Assert.Null(addressUpdate.Request.Shared);
+        Assert.Equal("stdAddr", addressUpdate.Request.Map!["line1"]);
+        Assert.Equal("stdZip", addressUpdate.Request.Map["zip"]);
+
+        ResultClassifier coAddressClassifier = Assert.IsType<ResultClassifier>(addressUpdate.Result);
+        ResultCondition coAddressSuccess = Assert.Single(coAddressClassifier.Conditions);
+        Assert.Equal(WriteOutcome.Success, coAddressSuccess.Outcome);
+        Assert.Equal("respCd", coAddressSuccess.Field);
+        Assert.Equal(new[] { "200", "00" }, coAddressSuccess.ValueIn);
+
+        // CO enrollment uses batch + transposeMonthDay expansion + confidenceThreshold match.
+        EnrollmentCheckOperationConfig? coEnrollment = config.Operations.EnrollmentCheck;
+        Assert.NotNull(coEnrollment);
+        Assert.Equal(StateBackendHttpMethod.Post, coEnrollment.Method);
+        Assert.Equal("/sebt/check-enrollment", coEnrollment.Path);
+
+        Assert.Equal(EnrollmentCallMode.Batch, coEnrollment.CallMode);
+        Assert.NotNull(coEnrollment.Request);
+        Assert.Equal(CandidateExpansion.TransposeMonthDay, coEnrollment.Request.Expand);
+        Assert.Equal("stdReqInd", coEnrollment.Request.IndexField);
+        Assert.Equal("stdFirstName", coEnrollment.Request.Map["firstName"]);
+        Assert.Equal("stdLastName", coEnrollment.Request.Map["lastName"]);
+        Assert.Equal("stdDob", coEnrollment.Request.Map["dob"]);
+
+        // schoolIdentifier is optional: the portal may not carry it, but CO's match reads it when sent.
+        Assert.NotNull(coEnrollment.Request.MapOptional);
+        Assert.Equal("StdSchlCd", coEnrollment.Request.MapOptional["schoolIdentifier"]);
+
+        Assert.NotNull(coEnrollment.Response);
+        Assert.Equal("$.stdntDtls", coEnrollment.Response.Root);
+        Assert.Equal("stdReqInd", coEnrollment.Response.IndexField);
+
+        // CO surfaces the winning row's eligibility text per child and CBMS's root RespMsg
+        // result-level — the carriers the plugin exposed on the wire.
+        Assert.Equal("sebtEligSts", coEnrollment.Response.StatusMessageField);
+        Assert.Equal("RespMsg", coEnrollment.Response.MessageField);
+        Assert.Equal(EnrollmentMatchStrategy.ConfidenceThreshold, coEnrollment.Response.Match.Strategy);
+        Assert.Equal("mtchCnfd", coEnrollment.Response.Match.ScoreField);
+        Assert.Equal(90.0, coEnrollment.Response.Match.Threshold);
+
+        // CO's real rule also requires the best row's eligibility flag — not score alone.
+        Assert.Equal("sebtEligSts", coEnrollment.Response.Match.Field);
+        Assert.Equal(new[] { "Y" }, coEnrollment.Response.Match.ValueIn);
+
+        StateBackendCapabilities capabilities = config.Capabilities;
+        Assert.True(capabilities.AddressUpdate);
+        Assert.True(capabilities.EnrollmentCheck);
+    }
+
+    // A canonical value that is NOT a real member of the target C# enum must fail loud at LOAD time.
+    [Fact]
+    public void Validate_FailsLoud_WhenCanonicalValueIsNotARealEnumMember()
+    {
+        StateBackendConfiguration config = BuildEnumConfig(
+            new StateBackendEnumTable
+            {
+                Map = new Dictionary<string, List<string>>
+                {
+                    ["Active"] = new() { "ACTIVE" },
+                    ["Frozn"] = new() { "FROZEN" }, // typo: not a CardStatus member
+                },
+                Default = "Unknown",
+            });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("Frozn", ex.Message);
+    }
+
+    // A single source token mapped under two of OUR values is ambiguous and must fail loud.
+    [Fact]
+    public void Validate_FailsLoud_WhenTokenIsAmbiguous()
+    {
+        StateBackendConfiguration config = BuildEnumConfig(
+            new StateBackendEnumTable
+            {
+                Map = new Dictionary<string, List<string>>
+                {
+                    ["Active"] = new() { "ISSUED" },
+                    ["Processed"] = new() { "ISSUED" }, // same token under two canonical values
+                },
+                Default = "Unknown",
+            });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("ISSUED", ex.Message);
+    }
+
+    // A keywordRules value that is NOT a real IssuanceType member must fail loud at load.
+    [Fact]
+    public void Validate_FailsLoud_WhenKeywordRuleValueIsNotARealIssuanceType()
+    {
+        StateBackendConfiguration config = BuildIssuanceKeywordConfig(
+            new KeywordRules
+            {
+                Order = new List<string> { "SummerEbt", "Snap" }, // "Snap" is not an IssuanceType member
+                Map = new Dictionary<string, List<string>>
+                {
+                    ["SummerEbt"] = new() { "OSSE" },
+                    ["Snap"] = new() { "SNAP" },
+                },
+                Default = "Unknown",
+            });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("Snap", ex.Message);
+    }
+
+    // A malformed classifier (a condition setting no closed kind) fails loud at load — the
+    // validator checks BOTH write ops.
+    [Theory]
+    [InlineData(true)] // card replacement
+    [InlineData(false)] // address update
+    public void Validate_FailsLoud_WhenWriteClassifierConditionSetsNoKind(bool onCardReplacement)
+    {
+        StateBackendConfiguration config = BuildWriteClassifierConfig(
+            cardReplacementClassifier: onCardReplacement ? MalformedClassifier() : null,
+            addressUpdateClassifier: onCardReplacement ? null : MalformedClassifier());
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("exactly one", ex.Message);
+    }
+
+    // The write-path body builders ignore mapOptional, so a config setting it — on EITHER write
+    // op — must fail at load rather than silently dropping the binding.
+    [Theory]
+    [InlineData(true)] // card replacement
+    [InlineData(false)] // address update
+    public void Validate_FailsLoud_WhenWriteRequestSetsMapOptional(bool onCardReplacement)
+    {
+        StateBackendConfiguration config = BuildWriteMapOptionalConfig(
+            cardReplacementRequest: onCardReplacement ? MapOptionalRequestBinding() : null,
+            addressUpdateRequest: onCardReplacement ? null : MapOptionalRequestBinding());
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("mapOptional", ex.Message);
+    }
+
+    // A fromContext entry referencing a context name outside the closed vocabulary fails at load —
+    // context names are resolved in fixed code, never expressions.
+    [Fact]
+    public void Validate_FailsLoud_WhenCaseIdFromContextNameIsUnknown()
+    {
+        StateBackendConfiguration config = BuildCaseIdConfig(new CaseIdComposition
+        {
+            Fields = new Dictionary<string, string> { ["caseId"] = "SummerEBTCaseID" },
+            FromContext = new Dictionary<string, string> { ["householdEmail"] = "guardianEmail" },
+        });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("guardianEmail", ex.Message);
+    }
+
+    // The same token field sourced from BOTH a response column and caller context is ambiguous.
+    [Fact]
+    public void Validate_FailsLoud_WhenCaseIdFieldIsInBothFieldsAndFromContext()
+    {
+        StateBackendConfiguration config = BuildCaseIdConfig(new CaseIdComposition
+        {
+            Fields = new Dictionary<string, string> { ["householdEmail"] = "GuardianEmail" },
+            FromContext = new Dictionary<string, string> { ["householdEmail"] = "householdIdentifier" },
+        });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("householdEmail", ex.Message);
+    }
+
+    // A date-typed target without an exact 'format' must fail at LOAD, not on the first mapped
+    // record.
+    [Fact]
+    public void Validate_FailsLoud_WhenDateFieldHasNoFormat()
+    {
+        StateBackendConfiguration config = BuildLookupFieldsConfig(
+            new Dictionary<string, FieldMapping>
+            {
+                ["ebtCardIssueDate"] = new() { From = "IssueDate" }, // no format
+            });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("ebtCardIssueDate", ex.Message);
+        Assert.Contains("format", ex.Message);
+    }
+
+    // A fields entry naming a target outside the closed canonical set must fail at LOAD, not on
+    // the first mapped record.
+    [Fact]
+    public void Validate_FailsLoud_WhenFieldNamesUnknownCanonicalTarget()
+    {
+        StateBackendConfiguration config = BuildLookupFieldsConfig(
+            new Dictionary<string, FieldMapping>
+            {
+                ["ebtCardIssueDte"] = new() { From = "IssueDate" }, // typo: not a canonical target
+            });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("ebtCardIssueDte", ex.Message);
+    }
+
+    // A messageContains condition without a messageField has no body property to read.
+    [Fact]
+    public void Validate_FailsLoud_WhenMessageContainsHasNoMessageField()
+    {
+        StateBackendConfiguration config = BuildWriteClassifierConfig(
+            cardReplacementClassifier: new ResultClassifier
+            {
+                Conditions = new List<ResultCondition>
+                {
+                    new()
+                    {
+                        Outcome = WriteOutcome.PolicyRejection,
+                        MessageContains = new List<string> { "policy" },
+                    },
+                },
+            },
+            addressUpdateClassifier: null);
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("messageField", ex.Message);
+    }
+
+    // A keywordRules 'order' that omits a map key would make that keyword set silently unreachable.
+    [Fact]
+    public void Validate_FailsLoud_WhenKeywordRulesOrderDoesNotCoverMapKey()
+    {
+        StateBackendConfiguration config = BuildIssuanceKeywordConfig(
+            new KeywordRules
+            {
+                Order = new List<string> { "SummerEbt" }, // SnapEbtCard is mapped but not ordered
+                Map = new Dictionary<string, List<string>>
+                {
+                    ["SummerEbt"] = new() { "OSSE" },
+                    ["SnapEbtCard"] = new() { "SNAP" },
+                },
+                Default = "Unknown",
+            });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("SnapEbtCard", ex.Message);
+    }
+
+    // A field referencing an enum table the config never defines fails at load.
+    [Fact]
+    public void Validate_FailsLoud_WhenReferencedEnumTableIsUndefined()
+    {
+        StateBackendConfiguration config = BuildEnumConfig(
+            new StateBackendEnumTable
+            {
+                Map = new Dictionary<string, List<string>> { ["Active"] = new() { "ACTIVE" } },
+                Default = "Unknown",
+            }) with
+        {
+            Enums = null, // the field's Enum = "cardStatus" now dangles
+        };
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => StateBackendConfigurationValidator.Validate(config));
+        Assert.Contains("cardStatus", ex.Message);
+    }
+
+    // Minimal config whose household lookup maps the supplied fields.
+    private static StateBackendConfiguration BuildLookupFieldsConfig(
+        Dictionary<string, FieldMapping> fields) =>
+        StateBackendTestConfig.Base().WithLookup(new HouseholdLookupOperationConfig
+        {
+            Method = StateBackendHttpMethod.Post,
+            Path = "/lookup",
+            Response = new StateBackendResponseMapping
+            {
+                Root = "$.records",
+                Fields = fields,
+            },
+        });
+
+    // Minimal config whose household lookup composes caseId tokens with the supplied composition.
+    private static StateBackendConfiguration BuildCaseIdConfig(CaseIdComposition caseId) =>
+        StateBackendTestConfig.Base().WithLookup(new HouseholdLookupOperationConfig
+        {
+            Method = StateBackendHttpMethod.Post,
+            Path = "/lookup",
+            Response = new StateBackendResponseMapping
+            {
+                Root = "$.records",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["childFirstName"] = new() { From = "ChildFirstName" },
+                },
+                CaseId = caseId,
+            },
+        });
+
+    // A write-op request binding carrying a mapOptional entry — unsupported on the write path.
+    private static RequestBinding MapOptionalRequestBinding() =>
+        new()
+        {
+            Map = new Dictionary<string, string> { ["caseId"] = "summerEbtCaseId" },
+            MapOptional = new Dictionary<string, string> { ["reason"] = "reason" },
+        };
+
+    // Minimal config carrying an optional card-replacement and/or address-update write op, each with
+    // the supplied request binding.
+    private static StateBackendConfiguration BuildWriteMapOptionalConfig(
+        RequestBinding? cardReplacementRequest, RequestBinding? addressUpdateRequest) =>
+        StateBackendTestConfig.Base() with
+        {
+            Operations = new StateBackendOperations
+            {
+                CardReplacement = cardReplacementRequest is null
+                    ? null
+                    : new CardReplacementOperationConfig
+                    {
+                        Method = StateBackendHttpMethod.Post,
+                        Path = "/cards/replace",
+                        Request = cardReplacementRequest,
+                    },
+                AddressUpdate = addressUpdateRequest is null
+                    ? null
+                    : new AddressUpdateOperationConfig
+                    {
+                        Method = StateBackendHttpMethod.Post,
+                        Path = "/households/address",
+                        Request = addressUpdateRequest,
+                    },
+            },
+        };
+
+    // A classifier whose single condition sets NONE of the three closed kinds — malformed shape.
+    private static ResultClassifier MalformedClassifier() =>
+        new()
+        {
+            Conditions = new List<ResultCondition>
+            {
+                new() { Outcome = WriteOutcome.Success },
+            },
+        };
+
+    // Minimal config carrying an optional card-replacement and/or address-update write op, each with
+    // the supplied result classifier.
+    private static StateBackendConfiguration BuildWriteClassifierConfig(
+        ResultClassifier? cardReplacementClassifier, ResultClassifier? addressUpdateClassifier) =>
+        StateBackendTestConfig.Base() with
+        {
+            Operations = new StateBackendOperations
+            {
+                CardReplacement = cardReplacementClassifier is null
+                    ? null
+                    : new CardReplacementOperationConfig
+                    {
+                        Method = StateBackendHttpMethod.Post,
+                        Path = "/cards/replace",
+                        Result = cardReplacementClassifier,
+                    },
+                AddressUpdate = addressUpdateClassifier is null
+                    ? null
+                    : new AddressUpdateOperationConfig
+                    {
+                        Method = StateBackendHttpMethod.Post,
+                        Path = "/households/address",
+                        Result = addressUpdateClassifier,
+                    },
+            },
+        };
+
+    // Minimal config whose household lookup infers issuanceType via a keywordRules primitive.
+    private static StateBackendConfiguration BuildIssuanceKeywordConfig(KeywordRules keywordRules) =>
+        StateBackendTestConfig.Base().WithLookup(new HouseholdLookupOperationConfig
+        {
+            Method = StateBackendHttpMethod.Post,
+            Path = "/lookup",
+            Response = new StateBackendResponseMapping
+            {
+                Root = "$.records",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["issuanceType"] = new()
+                    {
+                        From = new[] { "HouseholdType", "EligibilityType" },
+                        KeywordRules = keywordRules,
+                    },
+                },
+            },
+        });
+
+    // Minimal config whose household lookup maps ebtCardStatus through a named "cardStatus" table.
+    private static StateBackendConfiguration BuildEnumConfig(StateBackendEnumTable cardStatusTable) =>
+        StateBackendTestConfig.Base().WithLookup(new HouseholdLookupOperationConfig
+        {
+            Method = StateBackendHttpMethod.Post,
+            Path = "/lookup",
+            Response = new StateBackendResponseMapping
+            {
+                Root = "$.records",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["ebtCardStatus"] = new() { From = "CardStatus", Enum = "cardStatus" },
+                },
+            },
+        }) with
+        {
+            Enums = new Dictionary<string, StateBackendEnumTable>
+            {
+                ["cardStatus"] = cardStatusTable,
+            },
+        };
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendTestConfig.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendTestConfig.cs
@@ -1,0 +1,82 @@
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+/// <summary>
+/// Shared invariant boilerplate for driver-test configurations: the test envelope (base URL +
+/// API-key auth) plus <c>With*</c> helpers that swap one operation. Per-test VARIATION — the
+/// operation configs themselves — stays visible at the call site.
+/// </summary>
+internal static class StateBackendTestConfig
+{
+    /// <summary>The test envelope: base URL + API-key auth, no operations.</summary>
+    public static StateBackendConfiguration Base() =>
+        new()
+        {
+            BaseUrl = new Uri("http://backend.test"),
+            Auth = new StateBackendApiKeyAuthScheme { Header = "X-Api-Key", KeyRef = "test-api-key" },
+            Operations = new StateBackendOperations(),
+        };
+
+    /// <summary>DC-shaped lookup base mirroring the sample: multi-result-set root, original column names.</summary>
+    public static StateBackendConfiguration DcLookup() =>
+        Base().WithLookup(new HouseholdLookupOperationConfig
+        {
+            Method = StateBackendHttpMethod.Post,
+            Path = "/households/lookup",
+            Response = new StateBackendResponseMapping
+            {
+                Root = "$.resultSets[0]",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["summerEBTCaseID"] = new() { From = "SummerEBTCaseID" },
+                    ["childFirstName"] = new() { From = "ChildFirstName" },
+                    ["childLastName"] = new() { From = "ChildLastName" },
+                },
+            },
+        });
+
+    public static StateBackendConfiguration WithLookup(
+        this StateBackendConfiguration config, HouseholdLookupOperationConfig lookup) =>
+        config with { Operations = config.Operations with { HouseholdLookup = lookup } };
+
+    public static StateBackendConfiguration WithLookupResponse(
+        this StateBackendConfiguration config, StateBackendResponseMapping response) =>
+        config.WithLookup(config.Operations.HouseholdLookup! with { Response = response });
+
+    public static StateBackendConfiguration WithLookupRequest(
+        this StateBackendConfiguration config, RequestBinding binding) =>
+        config.WithLookup(config.Operations.HouseholdLookup! with { Request = binding });
+
+    public static StateBackendConfiguration WithCardReplacement(
+        this StateBackendConfiguration config, CardReplacementOperationConfig cardReplacement) =>
+        config with { Operations = config.Operations with { CardReplacement = cardReplacement } };
+
+    public static StateBackendConfiguration WithAddressUpdate(
+        this StateBackendConfiguration config, AddressUpdateOperationConfig addressUpdate) =>
+        config with { Operations = config.Operations with { AddressUpdate = addressUpdate } };
+
+    public static StateBackendConfiguration WithEnrollment(
+        this StateBackendConfiguration config, EnrollmentCheckOperationConfig enrollment) =>
+        config with { Operations = config.Operations with { EnrollmentCheck = enrollment } };
+
+    public static StateBackendConfiguration WithEnrollmentRequest(
+        this StateBackendConfiguration config, EnrollmentRequestBinding request) =>
+        config.WithEnrollment(config.Operations.EnrollmentCheck! with { Request = request });
+
+    public static StateBackendConfiguration WithEnrollmentMatch(
+        this StateBackendConfiguration config, EnrollmentMatch match)
+    {
+        EnrollmentCheckOperationConfig operation = config.Operations.EnrollmentCheck!;
+        return config.WithEnrollment(operation with
+        {
+            Response = operation.Response! with { Match = match },
+        });
+    }
+
+    public static StateBackendConfiguration WithHealth(
+        this StateBackendConfiguration config, HealthOperationConfig health) =>
+        config with { Operations = config.Operations with { Health = health } };
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 5 of 11.** Still nothing calls the adapter.

Loads a state's YAML into the config model and validates it at startup.

- `StateBackendConfigurationLoader`, `StateBackendConfigurationValidator`, the `FieldSources` converter.
- DC and CO sample configs, plus hydration tests.

**Focus:** fail-fast at load — a bad config throws at startup, not on first request. The two sample YAMLs show a real DC and CO config end to end.

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ