### PR TITLE
feat(DC-568): API-key + OAuth client-credentials auth handlers

### DIFF
--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Auth/ConfigurationStateBackendSecretResolver.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Auth/ConfigurationStateBackendSecretResolver.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Configuration;
+using SEBT.Portal.Core.StateBackends;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Auth;
+
+/// <summary>
+/// Resolves secret references against <see cref="IConfiguration"/>, so secrets ride the same
+/// pipeline as the rest of runtime config. A missing or empty key fails loud — a silently empty
+/// credential would only surface later as an opaque auth failure.
+/// </summary>
+public sealed class ConfigurationStateBackendSecretResolver : IStateBackendSecretResolver
+{
+    private readonly IConfiguration _configuration;
+
+    public ConfigurationStateBackendSecretResolver(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        _configuration = configuration;
+    }
+
+    public string Resolve(string reference)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reference);
+
+        string? value = _configuration[reference];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"State-backend secret reference '{reference}' resolved to no value. " +
+                "Set that configuration key (e.g. via an environment variable) to the secret it names.");
+        }
+
+        return value;
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Auth/StateBackendApiKeyAuthHandler.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Auth/StateBackendApiKeyAuthHandler.cs
@@ -1,0 +1,35 @@
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Auth;
+
+/// <summary>
+/// Applies an API-key scheme by setting the configured header to the resolved key. The key is
+/// resolved via <see cref="IStateBackendSecretResolver"/> — never inlined.
+/// </summary>
+public sealed class StateBackendApiKeyAuthHandler : DelegatingHandler
+{
+    private readonly StateBackendApiKeyAuthScheme _scheme;
+    private readonly IStateBackendSecretResolver _secretResolver;
+
+    public StateBackendApiKeyAuthHandler(
+        StateBackendApiKeyAuthScheme scheme,
+        IStateBackendSecretResolver secretResolver)
+    {
+        ArgumentNullException.ThrowIfNull(scheme);
+        ArgumentNullException.ThrowIfNull(secretResolver);
+
+        _scheme = scheme;
+        _secretResolver = secretResolver;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        string key = _secretResolver.Resolve(_scheme.KeyRef);
+        request.Headers.Remove(_scheme.Header);
+        request.Headers.Add(_scheme.Header, key);
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Auth/StateBackendOAuthClientCredentialsAuthHandler.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/Auth/StateBackendOAuthClientCredentialsAuthHandler.cs
@@ -1,0 +1,125 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+
+namespace SEBT.Portal.Infrastructure.StateBackends.Auth;
+
+/// <summary>
+/// Applies an OAuth2 client-credentials scheme: fetches a token, caches it until near expiry, and
+/// attaches it as a bearer token. The client secret is resolved via
+/// <see cref="IStateBackendSecretResolver"/> at token-fetch time — never inlined.
+/// </summary>
+public sealed class StateBackendOAuthClientCredentialsAuthHandler : DelegatingHandler
+{
+    // Refresh before actual expiry to avoid a token lapsing in flight.
+    private static readonly TimeSpan ExpiryLeeway = TimeSpan.FromSeconds(30);
+
+    private readonly StateBackendOAuthClientCredentialsAuthScheme _scheme;
+    private readonly IStateBackendSecretResolver _secretResolver;
+    private readonly HttpClient _tokenClient;
+    private readonly SemaphoreSlim _tokenLock = new(1, 1);
+    private readonly TimeProvider _timeProvider;
+
+    private string? _cachedToken;
+    private DateTimeOffset _tokenExpiresAt;
+
+    public StateBackendOAuthClientCredentialsAuthHandler(
+        StateBackendOAuthClientCredentialsAuthScheme scheme,
+        IStateBackendSecretResolver secretResolver,
+        HttpClient tokenClient,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(scheme);
+        ArgumentNullException.ThrowIfNull(secretResolver);
+        ArgumentNullException.ThrowIfNull(tokenClient);
+
+        _scheme = scheme;
+        _secretResolver = secretResolver;
+        _tokenClient = tokenClient;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        string token = await GetTokenAsync(cancellationToken).ConfigureAwait(false);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+    {
+        if (_cachedToken is not null && _timeProvider.GetUtcNow() < _tokenExpiresAt)
+        {
+            return _cachedToken;
+        }
+
+        await _tokenLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_cachedToken is not null && _timeProvider.GetUtcNow() < _tokenExpiresAt)
+            {
+                return _cachedToken;
+            }
+
+            TokenResponse tokenResponse = await FetchTokenAsync(cancellationToken).ConfigureAwait(false);
+            _cachedToken = tokenResponse.AccessToken;
+            _tokenExpiresAt = _timeProvider.GetUtcNow()
+                + TimeSpan.FromSeconds(tokenResponse.ExpiresInSeconds) - ExpiryLeeway;
+
+            return _cachedToken;
+        }
+        finally
+        {
+            _tokenLock.Release();
+        }
+    }
+
+    private async Task<TokenResponse> FetchTokenAsync(CancellationToken cancellationToken)
+    {
+        string clientSecret = _secretResolver.Resolve(_scheme.ClientSecretRef);
+
+        var form = new Dictionary<string, string>
+        {
+            ["grant_type"] = "client_credentials",
+            ["client_id"] = _scheme.ClientId,
+            ["client_secret"] = clientSecret,
+        };
+        if (!string.IsNullOrWhiteSpace(_scheme.Scope))
+        {
+            form["scope"] = _scheme.Scope;
+        }
+
+        using var tokenRequest = new HttpRequestMessage(HttpMethod.Post, _scheme.TokenUrl)
+        {
+            Content = new FormUrlEncodedContent(form),
+        };
+
+        using HttpResponseMessage response = await _tokenClient
+            .SendAsync(tokenRequest, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream stream = await response.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        TokenResponse? tokenResponse = await JsonSerializer
+            .DeserializeAsync<TokenResponse>(stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return tokenResponse
+            ?? throw new InvalidOperationException("Token endpoint returned an empty response.");
+    }
+
+    private sealed record TokenResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; init; } = string.Empty;
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresInSeconds { get; init; }
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigurationStateBackendSecretResolverTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigurationStateBackendSecretResolverTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Configuration;
+using SEBT.Portal.Infrastructure.StateBackends.Auth;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class ConfigurationStateBackendSecretResolverTests
+{
+    private static ConfigurationStateBackendSecretResolver BuildResolver(
+        Dictionary<string, string?> settings)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+        return new ConfigurationStateBackendSecretResolver(configuration);
+    }
+
+    [Fact]
+    public void Resolve_WithConfiguredKey_ReturnsValue()
+    {
+        var resolver = BuildResolver(new Dictionary<string, string?>
+        {
+            ["StateBackend:Auth:ApiKey"] = "super-secret-value",
+        });
+
+        var value = resolver.Resolve("StateBackend:Auth:ApiKey");
+
+        Assert.Equal("super-secret-value", value);
+    }
+
+    // A missing key and a present-but-empty key both fail loud, naming the reference.
+    [Theory]
+    [InlineData(null)] // key absent entirely
+    [InlineData("")] // key present but empty
+    public void Resolve_WithMissingOrEmptyKey_ThrowsNamingTheReference(string? configuredValue)
+    {
+        var resolver = BuildResolver(configuredValue is null
+            ? []
+            : new Dictionary<string, string?> { ["StateBackend:Auth:ApiKey"] = configuredValue });
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => resolver.Resolve("StateBackend:Auth:ApiKey"));
+
+        Assert.Contains("StateBackend:Auth:ApiKey", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_WithBlankReference_ThrowsArgumentException(string reference)
+    {
+        var resolver = BuildResolver([]);
+
+        Assert.Throws<ArgumentException>(() => resolver.Resolve(reference));
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendApiKeyAuthHandlerTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendApiKeyAuthHandlerTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using RichardSzalay.MockHttp;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+using SEBT.Portal.Infrastructure.StateBackends.Auth;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class StateBackendApiKeyAuthHandlerTests
+{
+    [Fact]
+    public async Task SetsConfiguredHeaderToResolvedKey_OnOutgoingRequest()
+    {
+        // Arrange
+        var scheme = new StateBackendApiKeyAuthScheme
+        {
+            Header = "X-Api-Key",
+            KeyRef = "StateBackend:Auth:ApiKey",
+        };
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Get, "http://backend.test/data")
+            .WithHeaders("X-Api-Key", "resolved-secret-value")
+            .Respond(HttpStatusCode.OK);
+
+        var handler = new StateBackendApiKeyAuthHandler(scheme, new StubSecretResolver("resolved-secret-value"))
+        {
+            InnerHandler = mockHttp,
+        };
+        var client = new HttpClient(handler);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("http://backend.test/data");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    private sealed class StubSecretResolver(string value) : IStateBackendSecretResolver
+    {
+        public string Resolve(string reference) => value;
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendOAuthClientCredentialsAuthHandlerTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/StateBackendOAuthClientCredentialsAuthHandlerTests.cs
@@ -1,0 +1,252 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Microsoft.Extensions.Time.Testing;
+using RichardSzalay.MockHttp;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration.Auth;
+using SEBT.Portal.Infrastructure.StateBackends.Auth;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class StateBackendOAuthClientCredentialsAuthHandlerTests
+{
+    private static StateBackendOAuthClientCredentialsAuthScheme BuildScheme() =>
+        new()
+        {
+            TokenUrl = new Uri("http://backend.test/oauth/token"),
+            ClientId = "co-client",
+            ClientSecretRef = "StateBackend:Auth:ClientSecret",
+        };
+
+    [Fact]
+    public async Task FetchesToken_AndAttachesBearer_ToOutgoingRequest()
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/oauth/token")
+            .Respond("application/json", "{\"access_token\":\"token-abc\",\"token_type\":\"Bearer\",\"expires_in\":3600}");
+        mockHttp
+            .Expect(HttpMethod.Get, "http://backend.test/data")
+            .WithHeaders("Authorization", "Bearer token-abc")
+            .Respond(HttpStatusCode.OK);
+
+        var handler = new StateBackendOAuthClientCredentialsAuthHandler(
+            BuildScheme(),
+            new StubSecretResolver("client-secret-value"),
+            mockHttp.ToHttpClient())
+        {
+            InnerHandler = mockHttp,
+        };
+        var client = new HttpClient(handler);
+
+        // Act
+        HttpResponseMessage response = await client.GetAsync("http://backend.test/data");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task CachesToken_AndFetchesOnlyOnce_AcrossMultipleRequests()
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        int tokenFetches = 0;
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/oauth/token")
+            .Respond(() =>
+            {
+                Interlocked.Increment(ref tokenFetches);
+                var message = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"access_token\":\"token-abc\",\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                };
+                message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                return Task.FromResult(message);
+            });
+        mockHttp
+            .When(HttpMethod.Get, "http://backend.test/data")
+            .Respond(HttpStatusCode.OK);
+
+        var handler = new StateBackendOAuthClientCredentialsAuthHandler(
+            BuildScheme(),
+            new StubSecretResolver("client-secret-value"),
+            mockHttp.ToHttpClient())
+        {
+            InnerHandler = mockHttp,
+        };
+        var client = new HttpClient(handler);
+
+        // Act
+        await client.GetAsync("http://backend.test/data");
+        await client.GetAsync("http://backend.test/data");
+
+        // Assert
+        Assert.Equal(1, tokenFetches);
+    }
+
+    // Wires a counting token endpoint + data endpoint behind a handler driven by the fake clock.
+    private static (HttpClient Client, Func<int> TokenFetches) BuildClientWithCountingTokenEndpoint(
+        FakeTimeProvider timeProvider)
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        int tokenFetches = 0;
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/oauth/token")
+            .Respond(() =>
+            {
+                Interlocked.Increment(ref tokenFetches);
+                var message = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"access_token\":\"token-abc\",\"token_type\":\"Bearer\",\"expires_in\":3600}"),
+                };
+                message.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                return Task.FromResult(message);
+            });
+        mockHttp
+            .When(HttpMethod.Get, "http://backend.test/data")
+            .Respond(HttpStatusCode.OK);
+
+        var handler = new StateBackendOAuthClientCredentialsAuthHandler(
+            BuildScheme(),
+            new StubSecretResolver("client-secret-value"),
+            mockHttp.ToHttpClient(),
+            timeProvider)
+        {
+            InnerHandler = mockHttp,
+        };
+        return (new HttpClient(handler), () => tokenFetches);
+    }
+
+    // The handler refreshes ExpiryLeeway (30s) BEFORE the token's actual expiry, so with
+    // expires_in=3600 the cached token is reused until +3570s and refetched after.
+    [Theory]
+    [InlineData(3569, 1)] // just before the refresh point: cached token reused
+    [InlineData(3571, 2)] // just past the refresh point: token refetched
+    public async Task RefetchesToken_OnlyWhenClockPassesExpiryMinusLeeway(
+        int advanceSeconds, int expectedTokenFetches)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        (HttpClient client, Func<int> tokenFetches) =
+            BuildClientWithCountingTokenEndpoint(timeProvider);
+
+        // Act
+        await client.GetAsync("http://backend.test/data");
+        timeProvider.Advance(TimeSpan.FromSeconds(advanceSeconds));
+        await client.GetAsync("http://backend.test/data");
+
+        // Assert
+        Assert.Equal(expectedTokenFetches, tokenFetches());
+    }
+
+    [Fact]
+    public async Task TokenEndpointFailure_Surfaces_WithoutLeakingClientSecret()
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/oauth/token")
+            .Respond(HttpStatusCode.InternalServerError);
+
+        var handler = new StateBackendOAuthClientCredentialsAuthHandler(
+            BuildScheme(),
+            new StubSecretResolver("client-secret-value"),
+            mockHttp.ToHttpClient())
+        {
+            InnerHandler = mockHttp,
+        };
+        var client = new HttpClient(handler);
+
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync("http://backend.test/data"));
+        Assert.DoesNotContain("client-secret-value", ex.Message);
+    }
+
+    [Fact]
+    public async Task ScopeConfigured_IsCarriedInTokenRequestForm()
+    {
+        // Arrange
+        StateBackendOAuthClientCredentialsAuthScheme scheme = BuildScheme() with
+        {
+            Scope = "sebt.read",
+        };
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/oauth/token")
+            .WithFormData("grant_type", "client_credentials")
+            .WithFormData("client_id", "co-client")
+            .WithFormData("scope", "sebt.read")
+            .Respond("application/json", "{\"access_token\":\"token-abc\",\"token_type\":\"Bearer\",\"expires_in\":3600}");
+        mockHttp
+            .Expect(HttpMethod.Get, "http://backend.test/data")
+            .Respond(HttpStatusCode.OK);
+
+        var handler = new StateBackendOAuthClientCredentialsAuthHandler(
+            scheme,
+            new StubSecretResolver("client-secret-value"),
+            mockHttp.ToHttpClient())
+        {
+            InnerHandler = mockHttp,
+        };
+        var client = new HttpClient(handler);
+
+        // Act
+        await client.GetAsync("http://backend.test/data");
+
+        // Assert
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    private static HttpClient BuildClientWithTokenBody(string tokenBody)
+    {
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/oauth/token")
+            .Respond("application/json", tokenBody);
+        mockHttp
+            .When(HttpMethod.Get, "http://backend.test/data")
+            .Respond(HttpStatusCode.OK);
+
+        var handler = new StateBackendOAuthClientCredentialsAuthHandler(
+            BuildScheme(),
+            new StubSecretResolver("client-secret-value"),
+            mockHttp.ToHttpClient())
+        {
+            InnerHandler = mockHttp,
+        };
+        return new HttpClient(handler);
+    }
+
+    // The JSON literal null deserializes without error to a null response → the explicit throw.
+    [Fact]
+    public async Task TokenBodyIsJsonNull_ThrowsInvalidOperation()
+    {
+        HttpClient client = BuildClientWithTokenBody("null");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetAsync("http://backend.test/data"));
+        Assert.Contains("empty response", ex.Message);
+    }
+
+    [Fact]
+    public async Task TokenBodyIsNotJson_ThrowsJsonException()
+    {
+        HttpClient client = BuildClientWithTokenBody("plainly not json");
+
+        await Assert.ThrowsAsync<JsonException>(
+            () => client.GetAsync("http://backend.test/data"));
+    }
+
+    private sealed class StubSecretResolver(string value) : IStateBackendSecretResolver
+    {
+        public string Resolve(string reference) => value;
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 6 of 11.** Still nothing calls the adapter.

Adds the two auth schemes a state config can pick, plus secret resolution.

- `StateBackendApiKeyAuthHandler`, `StateBackendOAuthClientCredentialsAuthHandler`, `ConfigurationStateBackendSecretResolver`.

**Focus:** secrets by reference: config names a key, never the value. Check the OAuth handler's token caching.

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ