### PR TITLE
feat(DC-568): config-driven driver — household lookup + health

### DIFF
--- a/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/ConfigurableStateBackend.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure.StateBackends/ConfigurableStateBackend.cs
@@ -1,0 +1,131 @@
+﻿using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+using SEBT.Portal.Infrastructure.StateBackends.Mapping;
+
+namespace SEBT.Portal.Infrastructure.StateBackends;
+
+public class ConfigurableStateBackend :
+    IHouseholdLookupBackend,
+    IStateBackendHealth
+{
+    private readonly StateBackendConfiguration _configuration;
+    private readonly HttpClient _httpClient;
+    private readonly Func<string> _idempotencyKeyFactory;
+
+    public ConfigurableStateBackend(StateBackendConfiguration configuration, HttpClient httpClient)
+        : this(configuration, httpClient, () => Guid.NewGuid().ToString())
+    {
+    }
+
+    // Idempotency-key factory is injectable for deterministic tests; production yields a fresh UUID.
+    public ConfigurableStateBackend(
+        StateBackendConfiguration configuration, HttpClient httpClient, Func<string> idempotencyKeyFactory)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(idempotencyKeyFactory);
+
+        _configuration = configuration;
+        _httpClient = httpClient;
+        _idempotencyKeyFactory = idempotencyKeyFactory;
+        _httpClient.BaseAddress ??= _configuration.BaseUrl;
+    }
+
+    // Capability guards derive from the loaded configuration; capabilities are not part of the ports.
+    private StateBackendCapabilities Capabilities =>
+        _configuration.Capabilities;
+
+    public async Task<StateBackendHealth> GetHealthAsync(CancellationToken cancellationToken = default)
+    {
+        HealthOperationConfig? health = _configuration.Operations.Health
+            ?? throw new NotSupportedException("Health check is not configured for the state backend.");
+
+        // Liveness probe; the shared handler chain still applies the state's auth scheme.
+        using HttpRequestMessage request = BuildRequest(health);
+
+        try
+        {
+            using HttpResponseMessage response = await _httpClient
+                .SendAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+
+            return new StateBackendHealth(response.IsSuccessStatusCode);
+        }
+        catch (HttpRequestException)
+        {
+            return new StateBackendHealth(IsHealthy: false);
+        }
+    }
+
+    private static HttpMethod ToHttpMethod(StateBackendHttpMethod method) =>
+        method switch
+        {
+            StateBackendHttpMethod.Get => HttpMethod.Get,
+            StateBackendHttpMethod.Patch => HttpMethod.Patch,
+            StateBackendHttpMethod.Post => HttpMethod.Post,
+            StateBackendHttpMethod.Put => HttpMethod.Put,
+            _ => throw new NotSupportedException($"Unsupported HTTP method: {method}."),
+        };
+
+    private static HttpRequestMessage BuildRequest(StateBackendOperationConfig operation) =>
+        new(ToHttpMethod(operation.Method), operation.Path);
+
+    // Shared read-path plumbing: send, fail loud on a non-success status, parse the JSON body.
+    private async Task<JsonDocument> SendAndParseAsync(
+        HttpRequestMessage httpRequest, CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage response = await _httpClient
+            .SendAsync(httpRequest, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream stream = await response.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return await JsonDocument
+            .ParseAsync(stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<HouseholdLookupResult> LookupHouseholdAsync(HouseholdLookupRequest request, CancellationToken cancellationToken = default)
+    {
+        HouseholdLookupOperationConfig? lookup = _configuration.Operations.HouseholdLookup
+            ?? throw new NotSupportedException("Household lookup is not configured for the state backend.");
+
+        StateBackendResponseMapping mapping = lookup.Response
+            ?? throw new NotSupportedException("Household lookup has no response mapping configured.");
+
+        // Auth (when configured) is applied by the HttpClient's handler chain, not here.
+        using HttpRequestMessage httpRequest = BuildRequest(lookup);
+
+        if (lookup.Request is { } binding)
+        {
+            JsonObject body = StateBackendRequestBinder.BuildBody(binding, request);
+            httpRequest.Content = new StringContent(
+                body.ToJsonString(), Encoding.UTF8, "application/json");
+        }
+
+        using JsonDocument document = await SendAndParseAsync(httpRequest, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Caller context for caseId composition: identifiers a later write must route by that the
+        // lookup response never echoes.
+        var caseIdContext = new CaseIdContext { HouseholdIdentifier = request.HouseholdIdentifier };
+
+        HouseholdData household = StateBackendResponseMapper.MapHousehold(
+            document.RootElement, _configuration, mapping, caseIdContext);
+
+        // A lookup mapping zero cases reads as NotFound — mirrors the plugin path's contract.
+        if (household.SummerEbtCases.Count == 0)
+        {
+            return new HouseholdLookupResult(HouseholdLookupStatus.NotFound, Household: null);
+        }
+
+        return new HouseholdLookupResult(HouseholdLookupStatus.Found, household);
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigurableStateBackendGetHealthTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigurableStateBackendGetHealthTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using RichardSzalay.MockHttp;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+using SEBT.Portal.Infrastructure.StateBackends;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class ConfigurableStateBackendGetHealthTests
+{
+    private static StateBackendConfiguration BuildConfiguration() =>
+        StateBackendTestConfig.Base().WithHealth(new HealthOperationConfig
+        {
+            Method = StateBackendHttpMethod.Get,
+            Path = "/health",
+        });
+
+    // Dispatches to the configured health endpoint and reports healthy iff the backend says OK.
+    [Theory]
+    [InlineData(HttpStatusCode.OK, true)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, false)]
+    [InlineData(HttpStatusCode.InternalServerError, false)]
+    public async Task GetHealthAsync_ReportsHealth_FromConfiguredEndpointStatus(
+        HttpStatusCode status, bool expectedHealthy)
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Get, "http://backend.test/health")
+            .Respond(status, "application/json", "{\"status\":\"ok\"}");
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(BuildConfiguration(), httpClient);
+
+        // Act
+        StateBackendHealth health = await backend.GetHealthAsync();
+
+        // Assert
+        Assert.Equal(expectedHealthy, health.IsHealthy);
+    }
+
+    // A connection-level failure (DNS, refused, timeout surfaced as HttpRequestException)
+    // reports unhealthy rather than letting the exception escape the health probe.
+    [Fact]
+    public async Task GetHealthAsync_ConnectionFailure_ReportsUnhealthy()
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Get, "http://backend.test/health")
+            .Throw(new HttpRequestException("connection refused"));
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(BuildConfiguration(), httpClient);
+
+        // Act
+        StateBackendHealth health = await backend.GetHealthAsync();
+
+        // Assert
+        Assert.False(health.IsHealthy);
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigurableStateBackendLookupHouseholdTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/StateBackends/ConfigurableStateBackendLookupHouseholdTests.cs
@@ -1,0 +1,743 @@
+using System.Net;
+using System.Text.Json;
+using RichardSzalay.MockHttp;
+using SEBT.Portal.Core.Models.Household;
+using SEBT.Portal.Core.StateBackends;
+using SEBT.Portal.Core.StateBackends.Configuration;
+using SEBT.Portal.Core.StateBackends.Configuration.Operations;
+using SEBT.Portal.Infrastructure.StateBackends;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.StateBackends;
+
+public class ConfigurableStateBackendLookupHouseholdTests
+{
+    // The DC-shaped lookup base every test in this class starts from.
+    private static StateBackendConfiguration BuildConfiguration() =>
+        StateBackendTestConfig.DcLookup();
+
+    // Raw passthrough shaped like the DC REST wrapper: multi-result-set, original column names.
+    private const string DcRawResponse =
+        """
+        {
+          "resultSets": [
+            [
+              { "SummerEBTCaseID": "SEBT-001", "ChildFirstName": "Ada", "ChildLastName": "Lovelace", "ApplicationId": null },
+              { "SummerEBTCaseID": "SEBT-002", "ChildFirstName": "Alan", "ChildLastName": "Turing", "ApplicationId": null }
+            ]
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task LookupHouseholdAsync_MapsRootAndFields_IntoCanonicalCases()
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", DcRawResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(BuildConfiguration(), httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.Found, result.Status);
+        Assert.NotNull(result.Household);
+
+        List<SummerEbtCase> cases = result.Household.SummerEbtCases;
+        Assert.Equal(2, cases.Count);
+
+        Assert.Equal("SEBT-001", cases[0].SummerEBTCaseID);
+        Assert.Equal("Ada", cases[0].ChildFirstName);
+        Assert.Equal("Lovelace", cases[0].ChildLastName);
+
+        Assert.Equal("SEBT-002", cases[1].SummerEBTCaseID);
+        Assert.Equal("Alan", cases[1].ChildFirstName);
+        Assert.Equal("Turing", cases[1].ChildLastName);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    // DC-shaped record carrying a formatted date and a state card-status token.
+    private static string DcTypedResponse(string cardStatusToken) =>
+        $$"""
+        {
+          "resultSets": [
+            [
+              {
+                "SummerEBTCaseID": "SEBT-001",
+                "ChildFirstName": "Ada",
+                "ChildLastName": "Lovelace",
+                "IssueDate": "06/15/2025",
+                "CardStatus": "{{cardStatusToken}}"
+              }
+            ]
+          ]
+        }
+        """;
+
+    [Theory]
+    [InlineData("ACTIVE", CardStatus.Active)]
+    // "LOST, AUTO REISSUE" is one of several tokens the table maps to CardStatus.Lost.
+    [InlineData("LOST, AUTO REISSUE", CardStatus.Lost)]
+    // An unmapped token falls through to the enum table's default.
+    [InlineData("NEVER SEEN", CardStatus.Unknown)]
+    public async Task LookupHouseholdAsync_MapsTypedFields_StringsDateAndEnum(
+        string cardStatusToken, CardStatus expectedCardStatus)
+    {
+        // Arrange
+        StateBackendConfiguration configuration = BuildConfiguration().WithLookupResponse(
+            new StateBackendResponseMapping
+            {
+                Root = "$.resultSets[0]",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["summerEBTCaseID"] = new() { From = "SummerEBTCaseID" },
+                    ["childFirstName"] = new() { From = "ChildFirstName" },
+                    ["ebtCardIssueDate"] = new() { From = "IssueDate", Format = "MM/dd/yyyy" },
+                    ["ebtCardStatus"] = new() { From = "CardStatus", Enum = "cardStatus" },
+                },
+            });
+        configuration = configuration with
+        {
+            Enums = new Dictionary<string, StateBackendEnumTable>
+            {
+                ["cardStatus"] = new()
+                {
+                    Map = new Dictionary<string, List<string>>
+                    {
+                        ["Active"] = new() { "ACTIVE" },
+                        ["Lost"] = new() { "LOST", "LOST, AUTO REISSUE" },
+                    },
+                    Default = "Unknown",
+                },
+            },
+        };
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", DcTypedResponse(cardStatusToken));
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.Found, result.Status);
+        SummerEbtCase mapped = Assert.Single(result.Household!.SummerEbtCases);
+
+        Assert.Equal("SEBT-001", mapped.SummerEBTCaseID);
+        Assert.Equal("Ada", mapped.ChildFirstName);
+
+        Assert.Equal(new DateTime(2025, 6, 15), mapped.EbtCardIssueDate);
+
+        Assert.Equal(expectedCardStatus, mapped.EbtCardStatus);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    private static RequestBinding DcRequestBinding() =>
+        new()
+        {
+            Constants = new Dictionary<string, object>
+            {
+                ["includePendingApplicantDetails"] = false,
+            },
+            Map = new Dictionary<string, string>
+            {
+                ["email"] = "guardianEmail",
+                ["ic"] = "guardianIdentifiers.IC",
+                ["dob"] = "guardianIdentifiers.DOB",
+                ["portalUuid"] = "guardianIdentifiers.PortalUUID",
+                ["isProofed"] = "isIdentityProofed",
+            },
+        };
+
+    private static StateBackendConfiguration WithRequestBinding(RequestBinding binding) =>
+        BuildConfiguration().WithLookupRequest(binding);
+
+    private static HouseholdLookupRequest DcRequest(bool isProofed) =>
+        new(
+            new[]
+            {
+                new IdentitySignal("email", "ada@example.test"),
+                new IdentitySignal("ic", "IC-123"),
+                new IdentitySignal("dob", "1815-12-10"),
+            })
+        {
+            IsProofed = isProofed,
+            PortalUuid = "uuid-abc",
+        };
+
+    private static async Task<string> CaptureLookupBodyAsync(
+        StateBackendConfiguration configuration, HouseholdLookupRequest request)
+    {
+        string? capturedBody = null;
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/households/lookup")
+            .With(message =>
+            {
+                capturedBody = message.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+                return true;
+            })
+            .Respond("application/json", DcRawResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        await backend.LookupHouseholdAsync(request);
+
+        Assert.NotNull(capturedBody);
+        return capturedBody;
+    }
+
+    [Fact]
+    public async Task LookupHouseholdAsync_BindsDcRequestBody_FromSignalsContextAndConstants()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = WithRequestBinding(DcRequestBinding());
+
+        // Act
+        string capturedBody = await CaptureLookupBodyAsync(configuration, DcRequest(isProofed: true));
+
+        // Assert
+        using JsonDocument document = JsonDocument.Parse(capturedBody);
+        JsonElement root = document.RootElement;
+
+        Assert.False(root.GetProperty("includePendingApplicantDetails").GetBoolean());
+        Assert.Equal("ada@example.test", root.GetProperty("guardianEmail").GetString());
+
+        // Dotted target paths produce nested objects.
+        JsonElement guardianIdentifiers = root.GetProperty("guardianIdentifiers");
+        Assert.Equal("IC-123", guardianIdentifiers.GetProperty("IC").GetString());
+        Assert.Equal("1815-12-10", guardianIdentifiers.GetProperty("DOB").GetString());
+        Assert.Equal("uuid-abc", guardianIdentifiers.GetProperty("PortalUUID").GetString());
+    }
+
+    // SECURITY: isIdentityProofed must mirror the caller's real proofing status. The DC lookup gates
+    // its email branch on it; hardcoding true would bypass the proofing gate.
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task LookupHouseholdAsync_BindsIsIdentityProofed_FromCallerProofingStatus(
+        bool isProofed)
+    {
+        // Arrange
+        StateBackendConfiguration configuration = WithRequestBinding(DcRequestBinding());
+
+        // Act
+        string capturedBody = await CaptureLookupBodyAsync(
+            configuration, DcRequest(isProofed: isProofed));
+
+        // Assert
+        using JsonDocument document = JsonDocument.Parse(capturedBody);
+        Assert.Equal(
+            isProofed, document.RootElement.GetProperty("isIdentityProofed").GetBoolean());
+    }
+
+    // Fail-loud: a map entry whose input isn't present must throw, not silently drop.
+    [Fact]
+    public async Task LookupHouseholdAsync_ThrowsWhenMapInputIsNotPresent()
+    {
+        // Arrange — map requires an "ic" signal that the request does not carry.
+        StateBackendConfiguration configuration = WithRequestBinding(
+            new RequestBinding
+            {
+                Map = new Dictionary<string, string>
+                {
+                    ["ic"] = "guardianIdentifiers.IC",
+                },
+            });
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", DcRawResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act + Assert
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => backend.LookupHouseholdAsync(request));
+        Assert.Contains("ic", ex.Message);
+    }
+
+    // Binding carrying both a required map and an optional one, mirroring DC's lookup shape.
+    private static RequestBinding EmailWithOptionalSocureBinding() =>
+        new()
+        {
+            Map = new Dictionary<string, string>
+            {
+                ["email"] = "guardianEmail",
+            },
+            MapOptional = new Dictionary<string, string>
+            {
+                ["socureUuid"] = "guardianIdentifiers.SocureUUID",
+            },
+        };
+
+    [Fact]
+    public async Task LookupHouseholdAsync_MapOptional_BindsWhenInputIsPresent()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = WithRequestBinding(EmailWithOptionalSocureBinding());
+        var request = new HouseholdLookupRequest(
+            new[]
+            {
+                new IdentitySignal("email", "ada@example.test"),
+                new IdentitySignal("socureUuid", "socure-123"),
+            });
+
+        // Act
+        string capturedBody = await CaptureLookupBodyAsync(configuration, request);
+
+        // Assert — an optional input binds to its target path exactly like a required one.
+        using JsonDocument document = JsonDocument.Parse(capturedBody);
+        JsonElement root = document.RootElement;
+        Assert.Equal("ada@example.test", root.GetProperty("guardianEmail").GetString());
+        Assert.Equal(
+            "socure-123",
+            root.GetProperty("guardianIdentifiers").GetProperty("SocureUUID").GetString());
+    }
+
+    [Fact]
+    public async Task LookupHouseholdAsync_MapOptional_OmitsFieldWhenInputIsAbsent()
+    {
+        // Arrange — no socureUuid signal.
+        StateBackendConfiguration configuration = WithRequestBinding(EmailWithOptionalSocureBinding());
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act
+        string capturedBody = await CaptureLookupBodyAsync(configuration, request);
+
+        // Assert — the optional field is omitted ENTIRELY, never written as null.
+        using JsonDocument document = JsonDocument.Parse(capturedBody);
+        JsonElement root = document.RootElement;
+        Assert.Equal("ada@example.test", root.GetProperty("guardianEmail").GetString());
+        Assert.False(root.TryGetProperty("guardianIdentifiers", out _));
+    }
+
+    // A mapOptional section must not relax the required map's fail-loud contract.
+    [Fact]
+    public async Task LookupHouseholdAsync_MapOptional_RequiredMapStillThrowsWhenInputIsAbsent()
+    {
+        // Arrange — map requires an "ic" signal the request does not carry; mapOptional is present.
+        StateBackendConfiguration configuration = WithRequestBinding(
+            new RequestBinding
+            {
+                Map = new Dictionary<string, string>
+                {
+                    ["ic"] = "guardianIdentifiers.IC",
+                },
+                MapOptional = new Dictionary<string, string>
+                {
+                    ["socureUuid"] = "guardianIdentifiers.SocureUUID",
+                },
+            });
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", DcRawResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act + Assert
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => backend.LookupHouseholdAsync(request));
+        Assert.Contains("ic", ex.Message);
+    }
+
+    [Fact]
+    public async Task LookupHouseholdAsync_BindsCoRequestBody_FromPhoneSignal()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = WithRequestBinding(
+            new RequestBinding
+            {
+                Map = new Dictionary<string, string>
+                {
+                    ["phone"] = "PhnNm",
+                },
+            });
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("phone", "5551234567") });
+
+        // Act
+        string capturedBody = await CaptureLookupBodyAsync(configuration, request);
+
+        // Assert
+        using JsonDocument document = JsonDocument.Parse(capturedBody);
+        Assert.Equal("5551234567", document.RootElement.GetProperty("PhnNm").GetString());
+    }
+
+    // DC-shaped mix: two records carry an ApplicationId (same one → one grouped application),
+    // one does not (auto-issued case, no application).
+    private const string DcDisaggregationResponse =
+        """
+        {
+          "resultSets": [
+            [
+              { "SummerEBTCaseID": "SEBT-001", "ChildFirstName": "Ada", "ChildLastName": "Lovelace", "ApplicationId": "APP-100" },
+              { "SummerEBTCaseID": "SEBT-002", "ChildFirstName": "Alan", "ChildLastName": "Turing", "ApplicationId": "APP-100" },
+              { "SummerEBTCaseID": "SEBT-003", "ChildFirstName": "Grace", "ChildLastName": "Hopper", "ApplicationId": null }
+            ]
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task LookupHouseholdAsync_PresenceRule_All_SplitsCasesAndGroupsApplications()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = BuildConfiguration();
+        configuration = configuration.WithLookupResponse(
+            configuration.Operations.HouseholdLookup!.Response! with
+            {
+                Disaggregation = new StateBackendDisaggregation
+                {
+                    Rule = DisaggregationRule.Presence,
+                    DiscriminatorField = "ApplicationId",
+                    GroupApplicationsBy = "ApplicationId",
+                    CaseInclusion = CaseInclusionPredicate.All,
+                },
+            });
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", DcDisaggregationResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.Found, result.Status);
+        Assert.NotNull(result.Household);
+
+        List<SummerEbtCase> cases = result.Household.SummerEbtCases;
+        Assert.Equal(3, cases.Count);
+
+        // App-based cases link to their application; the auto-issued case does not.
+        Assert.Equal("APP-100", cases[0].ApplicationId);
+        Assert.Equal("APP-100", cases[1].ApplicationId);
+        Assert.Null(cases[2].ApplicationId);
+
+        List<Application> applications = result.Household.Applications;
+        Assert.Single(applications);
+        Assert.Equal("APP-100", applications[0].ApplicationNumber);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    // CO-shaped: eligSrc partitions application-based (CBMS/PK) from streamlined (SCHOOL).
+    // Two application-based records share sebtAppId APP-CO-1 → one grouped application.
+    private const string CoDisaggregationResponse =
+        """
+        {
+          "stdntEnrollDtls": [
+            { "sebtChldCwin": "CO-001", "chldNm": "Ada", "eligSrc": "CBMS", "sebtAppId": "APP-CO-1" },
+            { "sebtChldCwin": "CO-002", "chldNm": "Alan", "eligSrc": "PK", "sebtAppId": "APP-CO-1" },
+            { "sebtChldCwin": "CO-003", "chldNm": "Grace", "eligSrc": "SCHOOL", "sebtAppId": null }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task LookupHouseholdAsync_ValueInSetRule_All_PartitionsAndGroupsApplications()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = BuildConfiguration().WithLookupResponse(
+            new StateBackendResponseMapping
+            {
+                Root = "$.stdntEnrollDtls",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["summerEBTCaseID"] = new() { From = "sebtChldCwin" },
+                    ["childFirstName"] = new() { From = "chldNm" },
+                },
+                Disaggregation = new StateBackendDisaggregation
+                {
+                    Rule = DisaggregationRule.ValueInSet,
+                    DiscriminatorField = "eligSrc",
+                    ApplicationValues = new List<string> { "CBMS", "PK" },
+                    GroupApplicationsBy = "sebtAppId",
+                    CaseInclusion = CaseInclusionPredicate.All,
+                },
+            });
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", CoDisaggregationResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("phone", "5551234567") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.Found, result.Status);
+        Assert.NotNull(result.Household);
+
+        List<SummerEbtCase> cases = result.Household.SummerEbtCases;
+        Assert.Equal(3, cases.Count);
+
+        // eligSrc in {CBMS,PK} → app-based, linked to sebtAppId; SCHOOL → streamlined, unlinked.
+        Assert.Equal("APP-CO-1", cases[0].ApplicationId);
+        Assert.Equal("APP-CO-1", cases[1].ApplicationId);
+        Assert.Null(cases[2].ApplicationId);
+
+        List<Application> applications = result.Household.Applications;
+        Assert.Single(applications);
+        Assert.Equal("APP-CO-1", applications[0].ApplicationNumber);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    // CO-shaped with an application status: two app-based records (CBMS/PK) share sebtAppId
+    // APP-CO-1 — one Approved (AP), one Denied (DE) — plus one streamlined (SCHOOL) record.
+    private const string CoStatusDisaggregationResponse =
+        """
+        {
+          "stdntEnrollDtls": [
+            { "sebtChldCwin": "CO-001", "chldNm": "Ada", "eligSrc": "CBMS", "sebtAppId": "APP-CO-1", "sebtAppSts": "AP" },
+            { "sebtChldCwin": "CO-002", "chldNm": "Alan", "eligSrc": "PK", "sebtAppId": "APP-CO-1", "sebtAppSts": "DE" },
+            { "sebtChldCwin": "CO-003", "chldNm": "Grace", "eligSrc": "SCHOOL", "sebtAppId": null, "sebtAppSts": null }
+          ]
+        }
+        """;
+
+    private static StateBackendConfiguration WithCoStatusInclusion()
+    {
+        StateBackendConfiguration configuration = BuildConfiguration().WithLookupResponse(
+            new StateBackendResponseMapping
+            {
+                Root = "$.stdntEnrollDtls",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["summerEBTCaseID"] = new() { From = "sebtChldCwin" },
+                    ["childFirstName"] = new() { From = "chldNm" },
+                    ["applicationStatus"] = new() { From = "sebtAppSts", Enum = "applicationStatus" },
+                },
+                Disaggregation = new StateBackendDisaggregation
+                {
+                    Rule = DisaggregationRule.ValueInSet,
+                    DiscriminatorField = "eligSrc",
+                    ApplicationValues = new List<string> { "CBMS", "PK" },
+                    GroupApplicationsBy = "sebtAppId",
+                    CaseInclusion = CaseInclusionPredicate.WhenApprovedOrNotApplicationBased,
+                },
+            });
+        return configuration with
+        {
+            Enums = new Dictionary<string, StateBackendEnumTable>
+            {
+                ["applicationStatus"] = new()
+                {
+                    Map = new Dictionary<string, List<string>>
+                    {
+                        ["Approved"] = new() { "AP" },
+                        ["Denied"] = new() { "DE" },
+                        ["Pending"] = new() { "PD", "PE" },
+                    },
+                    Default = "Unknown",
+                },
+            },
+        };
+    }
+
+    [Fact]
+    public async Task LookupHouseholdAsync_WhenApprovedOrNotApplicationBased_IncludesApprovedAndStreamlinedCases()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = WithCoStatusInclusion();
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", CoStatusDisaggregationResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("phone", "5551234567") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.Found, result.Status);
+        Assert.NotNull(result.Household);
+
+        // Cases: app-based+Approved (CO-001) and streamlined (CO-003) are included.
+        // The app-based+Denied record (CO-002) is NOT a case.
+        List<SummerEbtCase> cases = result.Household.SummerEbtCases;
+        Assert.Equal(2, cases.Count);
+        Assert.Equal("CO-001", cases[0].SummerEBTCaseID);
+        Assert.Equal(ApplicationStatus.Approved, cases[0].ApplicationStatus);
+        Assert.Equal("APP-CO-1", cases[0].ApplicationId);
+
+        Assert.Equal("CO-003", cases[1].SummerEBTCaseID);
+        Assert.Null(cases[1].ApplicationId);
+
+        // The denied record is excluded as a case but still belongs to its (pending) application.
+        List<Application> applications = result.Household.Applications;
+        Assert.Single(applications);
+        Assert.Equal("APP-CO-1", applications[0].ApplicationNumber);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    // DC-shaped free-text records exercising issuance-type inference, including one carrying both an
+    // OSSE and a SNAP keyword (first-match-wins tiebreak) and one with no keyword (default).
+    private const string DcIssuanceResponse =
+        """
+        {
+          "resultSets": [
+            [
+              { "SummerEBTCaseID": "SEBT-001", "HouseholdType": "OSSE ENROLLED", "EligibilityType": "DIRECT CERT" },
+              { "SummerEBTCaseID": "SEBT-002", "HouseholdType": "STANDARD", "EligibilityType": "SNAP HOUSEHOLD" },
+              { "SummerEBTCaseID": "SEBT-003", "HouseholdType": "OSSE ENROLLED", "EligibilityType": "SNAP HOUSEHOLD" },
+              { "SummerEBTCaseID": "SEBT-004", "HouseholdType": "STANDARD", "EligibilityType": "NONE" }
+            ]
+          ]
+        }
+        """;
+
+    private static StateBackendConfiguration WithIssuanceKeywordRules() =>
+        BuildConfiguration().WithLookupResponse(
+            new StateBackendResponseMapping
+            {
+                Root = "$.resultSets[0]",
+                Fields = new Dictionary<string, FieldMapping>
+                {
+                    ["summerEBTCaseID"] = new() { From = "SummerEBTCaseID" },
+                    ["issuanceType"] = new()
+                    {
+                        From = new[] { "HouseholdType", "EligibilityType" },
+                        KeywordRules = new KeywordRules
+                        {
+                            // Order is load-bearing: SummerEbt is evaluated before SnapEbtCard.
+                            Order = new List<string> { "SummerEbt", "SnapEbtCard", "TanfEbtCard" },
+                            Map = new Dictionary<string, List<string>>
+                            {
+                                ["SummerEbt"] = new() { "OSSE", "NSLP" },
+                                ["SnapEbtCard"] = new() { "FOOD", "SNAP" },
+                                ["TanfEbtCard"] = new() { "CASH", "TANF" },
+                            },
+                            Default = "Unknown",
+                        },
+                    },
+                },
+            });
+
+    [Fact]
+    public async Task LookupHouseholdAsync_InfersIssuanceType_FromKeywordRules_FirstMatchWins()
+    {
+        // Arrange
+        StateBackendConfiguration configuration = WithIssuanceKeywordRules();
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .Expect(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", DcIssuanceResponse);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(configuration, httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.Found, result.Status);
+        List<SummerEbtCase> cases = result.Household!.SummerEbtCases;
+        Assert.Equal(4, cases.Count);
+
+        Assert.Equal(IssuanceType.SummerEbt, cases[0].IssuanceType);
+        Assert.Equal(IssuanceType.SnapEbtCard, cases[1].IssuanceType);
+
+        // Both OSSE and SNAP present → SummerEbt wins (earlier in `order`).
+        Assert.Equal(IssuanceType.SummerEbt, cases[2].IssuanceType);
+
+        // No keyword → default.
+        Assert.Equal(IssuanceType.Unknown, cases[3].IssuanceType);
+
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Theory]
+    [InlineData("""{ "resultSets": [ [] ] }""")] // root resolves to an empty array
+    [InlineData("{}")] // root path missing entirely — the selector finds nothing to map
+    public async Task LookupHouseholdAsync_ReturnsNotFound_WhenRootSelectsNoRecords(string responseJson)
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond("application/json", responseJson);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(BuildConfiguration(), httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "nobody@example.test") });
+
+        // Act
+        HouseholdLookupResult result = await backend.LookupHouseholdAsync(request);
+
+        // Assert
+        Assert.Equal(HouseholdLookupStatus.NotFound, result.Status);
+        Assert.Null(result.Household);
+    }
+
+    // Pins the current read-path contract: a non-2xx lookup response throws a raw
+    // HttpRequestException (no error mapping, no partial result). A future error-mapping
+    // design must change this test deliberately.
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task LookupHouseholdAsync_NonSuccessStatus_ThrowsHttpRequestException(
+        HttpStatusCode status)
+    {
+        // Arrange
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, "http://backend.test/households/lookup")
+            .Respond(status);
+
+        var httpClient = mockHttp.ToHttpClient();
+        var backend = new ConfigurableStateBackend(BuildConfiguration(), httpClient);
+        var request = new HouseholdLookupRequest(
+            new[] { new IdentitySignal("email", "ada@example.test") });
+
+        // Act + Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() => backend.LookupHouseholdAsync(request));
+    }
+}


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-568](https://codeforamerica.atlassian.net/browse/DC-568)

#### ✍️ Description
**Stack 1, PR 7 of 11.** Still nothing calls the adapter.

Adds the driver itself, `ConfigurableStateBackend`, starting with two read operations: household lookup and health.

- This is where config, primitives, and mapping come together against (mocked) HTTP.

**Focus:** the request→send→map pipeline for a read. The driver grows one operation per PR from here.

#### ✅ Completion tasks
- [ ] Added relevant tests
- [ ] Meets acceptance criteria in ticket


[DC-568]: https://codeforamerica.atlassian.net/browse/DC-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ