### PR TITLE
[DC-159] Switch CI to Doppler OIDC identity auth

### DIFF
--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   deployments: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: deploy-${{ github.event.pull_request.number || github.ref }}
@@ -234,7 +235,7 @@ jobs:
       web_url: ${{ steps.deploy-url.outputs.url }}
     env:
       AWS_REGION: us-east-1
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_OIDC_IDENTITY: ${{ secrets.DOPPLER_OIDC_IDENTITY }}
       TF_VAR_domain: ${{ vars.DOMAIN }}
       TF_VAR_sender_email: ${{ vars.SENDER_EMAIL }}
       TF_VAR_vpc_cidr: ${{ vars.VPC_CIDR }}
@@ -294,6 +295,12 @@ jobs:
           docker push ${API_REPO}:${IMAGE_TAG}
           docker push ${WEB_REPO}:${IMAGE_TAG}
 
+      - name: Get an OIDC token for Doppler
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
+
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -334,7 +341,7 @@ jobs:
       web_url: ${{ steps.deploy-url.outputs.url }}
     env:
       AWS_REGION: us-east-1
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_OIDC_IDENTITY: ${{ secrets.DOPPLER_OIDC_IDENTITY }}
       TF_VAR_domain: ${{ vars.DOMAIN }}
       TF_VAR_sender_email: ${{ vars.SENDER_EMAIL }}
       TF_VAR_vpc_cidr: ${{ vars.VPC_CIDR }}
@@ -390,6 +397,12 @@ jobs:
 
           docker push ${API_REPO}:${IMAGE_TAG}
           docker push ${WEB_REPO}:${IMAGE_TAG}
+
+      - name: Get an OIDC token for Doppler
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7

--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   plan:
@@ -29,7 +30,7 @@ jobs:
     environment: ${{ inputs.environment }}
     env:
       AWS_REGION: us-east-1
-      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+      DOPPLER_OIDC_IDENTITY: ${{ secrets.DOPPLER_OIDC_IDENTITY }}
       TF_VAR_domain: ${{ vars.DOMAIN }}
       TF_VAR_sender_email: ${{ vars.SENDER_EMAIL }}
       TF_VAR_vpc_cidr: ${{ vars.VPC_CIDR }}
@@ -74,6 +75,12 @@ jobs:
             echo "::error::Invalid image_tag: $IMAGE_TAG"
             exit 1
           fi
+
+      - name: Get an OIDC token for Doppler
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
 
       - name: OpenTofu Init
         working-directory: tofu/config/${{ inputs.config }}


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-159

#### ✍️ Description
The apply from #509 failed on both dev-dc and dev-co: the Doppler Terraform provider needs to create an `AWS Secrets Manager` integration in Doppler, but that's a workplace-level operation, and the `DOPPLER_TOKEN` used in CI is a project/config-scoped Service Token, a token type that cannot perform workplace-level operations.

This switches `plan.yaml` and `deploy-ecr.yaml` to Doppler's OIDC identity auth instead: each job fetches a GitHub Actions OIDC token and exchanges it (via `DOPPLER_OIDC_IDENTITY`) for a short-lived Doppler token, with no long-lived credential stored for this purpose. Mirrors the pattern already in use in [data-science-metabase-infra](https://github.com/codeforamerica/data-science-metabase-infra/blob/main/.github/workflows/apply.yaml#L70-L74). `DOPPLER_OIDC_IDENTITY` has been added as a secret on the `dev-dc`/`dev-co` GitHub Environments (not secret-sensitive itself, just a config identifier, but stored alongside the other CI credentials for consistency).

#### ✅ Completion tasks
- [x] Added relevant tests — N/A, workflow-only change
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [x] If new environment variables are added, update in Tofu — N/A, `DOPPLER_OIDC_IDENTITY` is a CI-only credential set directly as a GitHub Environment secret, not an app-level Tofu variable
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — N/A, same reason
  - [x] If you're adding an appsetting — N/A
  - [x] If appsettings are changed — N/A
