### PR TITLE
[DC-159] Share a single Doppler provider instance across dev-dc/dev-co

### DIFF
--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -7,7 +7,14 @@ terraform {
   }
 }
 
-# Create an S3 bucket and KMS key for logging.                                                                                                    
+# Values (doppler_token, or oidc_identity + oidc_token) are read from the
+# environment (DOPPLER_TOKEN or DOPPLER_OIDC_IDENTITY/DOPPLER_OIDC_TOKEN) —
+# this block just declares the provider explicitly so it's authenticated
+# once and shared by every module below, rather than each module implicitly
+# configuring its own instance and re-using a single-use OIDC token.
+provider "doppler" {}
+
+# Create an S3 bucket and KMS key for logging.
 module "logging" {
   source = "github.com/codeforamerica/tofu-modules-aws-logging?ref=2.1.0"
 
@@ -127,7 +134,8 @@ data "aws_route53_zone" "enrollment_checker" {
 
 # Deploy the application services (API + Web) using the shared wrapper module.
 module "app" {
-  source = "../../modules/sebt_application"
+  source    = "../../modules/sebt_application"
+  providers = { doppler = doppler }
 
   apply_immediately          = true
   domain                     = var.domain

--- a/tofu/config/dev-co/versions.tf
+++ b/tofu/config/dev-co/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    doppler = {
+      source  = "dopplerhq/doppler"
+      version = "~> 1.20"
+    }
   }
 }

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -7,7 +7,14 @@ terraform {
   }
 }
 
-# Create an S3 bucket and KMS key for logging.                                                                                                    
+# Values (doppler_token, or oidc_identity + oidc_token) are read from the
+# environment (DOPPLER_TOKEN or DOPPLER_OIDC_IDENTITY/DOPPLER_OIDC_TOKEN) —
+# this block just declares the provider explicitly so it's authenticated
+# once and shared by every module below, rather than each module implicitly
+# configuring its own instance and re-using a single-use OIDC token.
+provider "doppler" {}
+
+# Create an S3 bucket and KMS key for logging.
 module "logging" {
   source = "github.com/codeforamerica/tofu-modules-aws-logging?ref=2.1.0"
 
@@ -110,7 +117,8 @@ module "state_secrets_doppler" {
 
 # Deploy the application services (API + Web) using the shared wrapper module.
 module "app" {
-  source = "../../modules/sebt_application"
+  source    = "../../modules/sebt_application"
+  providers = { doppler = doppler }
 
   apply_immediately          = true
   domain                     = var.domain

--- a/tofu/config/dev-dc/versions.tf
+++ b/tofu/config/dev-dc/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    doppler = {
+      source  = "dopplerhq/doppler"
+      version = "~> 1.20"
+    }
   }
 }

--- a/tofu/modules/sebt_application/versions.tf
+++ b/tofu/modules/sebt_application/versions.tf
@@ -1,3 +1,10 @@
 terraform {
   required_version = ">= 1.6.0"
+
+  required_providers {
+    doppler = {
+      source  = "dopplerhq/doppler"
+      version = "~> 1.20"
+    }
+  }
 }


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-159

#### ✍️ Description
The apply that ran after #557 merged failed on both dev-dc and dev-co with a Doppler provider error: `This OIDC token was used previously`.

Root cause: our tofu code configures the Doppler provider from two separate places per state (once for state-specific secrets, once for the shared app secrets), and without an explicit shared configuration, each one tried to authenticate independently. That was harmless with the old static token (reusable), but OIDC tokens are single-use — the second authentication attempt failed outright.

Fix: declare the Doppler provider once per state and share that single instance across the modules that need it, so there's exactly one authentication per apply.

Verified with `tofu init`/`tofu validate` locally for both states — clean on both. A full local `tofu plan` isn't possible since the OIDC token can only be minted inside a GitHub Actions runner; the real test is CI's plan jobs.

No outage: the failed apply left both dev-dc and dev-co APIs running on their previous, stable task definitions.

#### 🔗 Links to related PRs
Follow-up to #557 and #509
