### PR TITLE
[DC-159] Fetch a fresh OIDC token for each Doppler plan and apply step

### DIFF
--- a/.github/workflows/deploy-ecr.yaml
+++ b/.github/workflows/deploy-ecr.yaml
@@ -295,12 +295,6 @@ jobs:
           docker push ${API_REPO}:${IMAGE_TAG}
           docker push ${WEB_REPO}:${IMAGE_TAG}
 
-      - name: Get an OIDC token for Doppler
-        run: |
-          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
-          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
-
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -318,11 +312,31 @@ jobs:
         working-directory: tofu/config/dev-dc
         run: tofu init -upgrade
 
-      - name: OpenTofu Apply
+      # Doppler OIDC tokens are single-use. Plan and apply each need their own
+      # provider authentication, so each gets its own freshly-fetched token —
+      # reusing one token for both fails with "This OIDC token was used
+      # previously".
+      - name: Get an OIDC token for Doppler (plan)
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
+
+      - name: OpenTofu Plan
         working-directory: tofu/config/dev-dc
         run: |
-          tofu apply -auto-approve \
+          tofu plan -input=false -out=tfplan \
             -var="image_tag=${{ needs.build.outputs.image_tag }}"
+
+      - name: Get an OIDC token for Doppler (apply)
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
+
+      - name: OpenTofu Apply
+        working-directory: tofu/config/dev-dc
+        run: tofu apply tfplan
 
       - name: Get deployment URL
         id: deploy-url
@@ -398,12 +412,6 @@ jobs:
           docker push ${API_REPO}:${IMAGE_TAG}
           docker push ${WEB_REPO}:${IMAGE_TAG}
 
-      - name: Get an OIDC token for Doppler
-        run: |
-          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
-          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
-
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
@@ -421,11 +429,31 @@ jobs:
         working-directory: tofu/config/dev-co
         run: tofu init -upgrade
 
-      - name: OpenTofu Apply
+      # Doppler OIDC tokens are single-use. Plan and apply each need their own
+      # provider authentication, so each gets its own freshly-fetched token —
+      # reusing one token for both fails with "This OIDC token was used
+      # previously".
+      - name: Get an OIDC token for Doppler (plan)
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
+
+      - name: OpenTofu Plan
         working-directory: tofu/config/dev-co
         run: |
-          tofu apply -auto-approve \
+          tofu plan -input=false -out=tfplan \
             -var="image_tag=${{ needs.build.outputs.image_tag }}"
+
+      - name: Get an OIDC token for Doppler (apply)
+        run: |
+          DOPPLER_OIDC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://github.com/$GITHUB_REPOSITORY_OWNER" | jq -r '.value')
+          echo "DOPPLER_OIDC_TOKEN=$DOPPLER_OIDC_TOKEN" >> $GITHUB_ENV
+
+      - name: OpenTofu Apply
+        working-directory: tofu/config/dev-co
+        run: tofu apply tfplan
 
       - name: Get deployment URL
         id: deploy-url

--- a/.gitignore
+++ b/.gitignore
@@ -466,6 +466,7 @@ output
 **/*.tfstate
 **/*.tfstate.*
 **/*.tfplan
+**/tfplan
 **/crash.log
 **/crash.*.log
 # Lambda zip artifacts created by the archive_file data source during tofu plan/apply


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-159

#### ✍️ Description
The apply after #558 merged failed again on both dev-dc and dev-co with the same `This OIDC token was used previously` error, even with a single shared provider instance.

Root cause (confirmed with James Armes): `tofu apply` without a saved plan file isn't one operation — it computes a fresh plan internally and then executes it, and the Doppler provider re-authenticates between those two phases. We were only fetching one OIDC token per job, so the first phase's exchange succeeded and burned the token before the second phase could use it.

Fix: split `deploy-dc`/`deploy-co` into an explicit `tofu plan -out=tfplan`, then a freshly-fetched OIDC token, then `tofu apply tfplan`. Applying a saved plan file only needs one provider authentication, so two separately-fetched tokens each satisfy exactly one exchange.