### PR TITLE
Task/dc 159 doppler secret naming fix

### DIFF
--- a/tofu/config/dev-co/main.tf
+++ b/tofu/config/dev-co/main.tf
@@ -72,40 +72,47 @@ module "state_secrets" {
   environment = var.environment
   service     = "state-secrets"
 
+  # Doppler's AWS Secrets Manager sync creates its own target secret named
+  # "{path}/{DOPPLER_KEY}" (uppercase, exact match) rather than writing into
+  # a pre-existing ARN — so these keys and add_suffix=false must make our
+  # secret's name match exactly what Doppler will create, or Doppler ends up
+  # populating an entirely separate, unreferenced secret.
+  add_suffix = false
+
   secrets = {
-    "jwt_secret_key" = {
+    "JWT_SECRET_KEY" = {
       description     = "JWT signing secret for the SEBT Portal API."
       recovery_window = 7
     }
-    "identifier_hasher_secret_key" = {
+    "IDENTIFIER_HASHER_SECRET_KEY" = {
       description     = "Identifier hashing secret for the SEBT Portal API."
       recovery_window = 7
     }
-    "cbms_client_id" = {
+    "CBMS_CLIENT_ID" = {
       description     = "OAuth 2.0 client ID for the Colorado CBMS SEBT API."
       recovery_window = 7
     }
-    "cbms_client_secret" = {
+    "CBMS_CLIENT_SECRET" = {
       description     = "OAuth 2.0 client secret for the Colorado CBMS SEBT API."
       recovery_window = 7
     }
-    "oidc_client_id" = {
+    "OIDC_CLIENT_ID" = {
       description     = "MyColorado OIDC client ID for authentication."
       recovery_window = 7
     }
-    "oidc_client_secret" = {
+    "OIDC_CLIENT_SECRET" = {
       description     = "MyColorado OIDC client secret for authentication."
       recovery_window = 7
     }
-    "oidc_step_up_client_id" = {
+    "OIDC_STEP_UP_CLIENT_ID" = {
       description     = "MyColorado OIDC step-up client ID for authentication."
       recovery_window = 7
     }
-    "oidc_step_up_client_secret" = {
+    "OIDC_STEP_UP_CLIENT_SECRET" = {
       description     = "MyColorado OIDC step-up client secret for authentication."
       recovery_window = 7
     }
-    "oidc_complete_login_signing_key" = {
+    "OIDC_COMPLETE_LOGIN_SIGNING_KEY" = {
       description     = "Signing key for completing MyColorado OIDC login."
       recovery_window = 7
     }
@@ -187,15 +194,15 @@ module "app" {
   }
 
   state_api_environment_secrets = {
-    "JwtSettings__SecretKey"        = module.state_secrets.secrets["jwt_secret_key"].secret_arn
-    "IdentifierHasher__SecretKey"   = module.state_secrets.secrets["identifier_hasher_secret_key"].secret_arn
-    "Cbms__ClientId"                = module.state_secrets.secrets["cbms_client_id"].secret_arn
-    "Cbms__ClientSecret"            = module.state_secrets.secrets["cbms_client_secret"].secret_arn
-    "Oidc__ClientId"                = module.state_secrets.secrets["oidc_client_id"].secret_arn
-    "Oidc__ClientSecret"            = module.state_secrets.secrets["oidc_client_secret"].secret_arn
-    "Oidc__StepUp__ClientId"        = module.state_secrets.secrets["oidc_step_up_client_id"].secret_arn
-    "Oidc__StepUp__ClientSecret"    = module.state_secrets.secrets["oidc_step_up_client_secret"].secret_arn
-    "Oidc__CompleteLoginSigningKey" = module.state_secrets.secrets["oidc_complete_login_signing_key"].secret_arn
+    "JwtSettings__SecretKey"        = module.state_secrets.secrets["JWT_SECRET_KEY"].secret_arn
+    "IdentifierHasher__SecretKey"   = module.state_secrets.secrets["IDENTIFIER_HASHER_SECRET_KEY"].secret_arn
+    "Cbms__ClientId"                = module.state_secrets.secrets["CBMS_CLIENT_ID"].secret_arn
+    "Cbms__ClientSecret"            = module.state_secrets.secrets["CBMS_CLIENT_SECRET"].secret_arn
+    "Oidc__ClientId"                = module.state_secrets.secrets["OIDC_CLIENT_ID"].secret_arn
+    "Oidc__ClientSecret"            = module.state_secrets.secrets["OIDC_CLIENT_SECRET"].secret_arn
+    "Oidc__StepUp__ClientId"        = module.state_secrets.secrets["OIDC_STEP_UP_CLIENT_ID"].secret_arn
+    "Oidc__StepUp__ClientSecret"    = module.state_secrets.secrets["OIDC_STEP_UP_CLIENT_SECRET"].secret_arn
+    "Oidc__CompleteLoginSigningKey" = module.state_secrets.secrets["OIDC_COMPLETE_LOGIN_SIGNING_KEY"].secret_arn
   }
 
   state_web_environment_variables = {
@@ -206,9 +213,9 @@ module "app" {
   }
 
   state_web_environment_secrets = {
-    OIDC_CLIENT_ID                  = module.state_secrets.secrets["oidc_client_id"].secret_arn
-    OIDC_CLIENT_SECRET              = module.state_secrets.secrets["oidc_client_secret"].secret_arn
-    OIDC_COMPLETE_LOGIN_SIGNING_KEY = module.state_secrets.secrets["oidc_complete_login_signing_key"].secret_arn
+    OIDC_CLIENT_ID                  = module.state_secrets.secrets["OIDC_CLIENT_ID"].secret_arn
+    OIDC_CLIENT_SECRET              = module.state_secrets.secrets["OIDC_CLIENT_SECRET"].secret_arn
+    OIDC_COMPLETE_LOGIN_SIGNING_KEY = module.state_secrets.secrets["OIDC_COMPLETE_LOGIN_SIGNING_KEY"].secret_arn
   }
 }
 

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -72,28 +72,35 @@ module "state_secrets" {
   environment = var.environment
   service     = "state-secrets"
 
+  # Doppler's AWS Secrets Manager sync creates its own target secret named
+  # "{path}/{DOPPLER_KEY}" (uppercase, exact match) rather than writing into
+  # a pre-existing ARN — so these keys and add_suffix=false must make our
+  # secret's name match exactly what Doppler will create, or Doppler ends up
+  # populating an entirely separate, unreferenced secret.
+  add_suffix = false
+
   secrets = {
-    "jwt_secret_key" = {
+    "JWT_SECRET_KEY" = {
       description     = "JWT signing secret for the SEBT Portal API."
       recovery_window = 7
     }
-    "identifier_hasher_secret_key" = {
+    "IDENTIFIER_HASHER_SECRET_KEY" = {
       description     = "Identifier hashing secret for the SEBT Portal API."
       recovery_window = 7
     }
-    "socure_api_key" = {
+    "SOCURE_API_KEY" = {
       description     = "Socure API key for identity verification."
       recovery_window = 7
     }
-    "socure_webhook_secret" = {
+    "SOCURE_WEBHOOK_SECRET" = {
       description     = "Socure webhook signing secret for identity verification."
       recovery_window = 7
     }
-    "pii_encryption_key_id" = {
+    "PII_ENCRYPTION_KEY_ID" = {
       description     = "Active PII encryption key ID for the SEBT Portal API (AES-256-GCM)."
       recovery_window = 7
     }
-    "pii_encryption_key_material_base64" = {
+    "PII_ENCRYPTION_KEY_MATERIAL_BASE64" = {
       description     = "Active PII encryption key material for the SEBT Portal API (AES-256-GCM)."
       recovery_window = 7
     }
@@ -161,12 +168,12 @@ module "app" {
   }
 
   state_api_environment_secrets = {
-    "JwtSettings__SecretKey"                    = module.state_secrets.secrets["jwt_secret_key"].secret_arn
-    "IdentifierHasher__SecretKey"               = module.state_secrets.secrets["identifier_hasher_secret_key"].secret_arn
-    "Socure__ApiKey"                            = module.state_secrets.secrets["socure_api_key"].secret_arn
-    "Socure__WebhookSecret"                     = module.state_secrets.secrets["socure_webhook_secret"].secret_arn
-    "PiiEncryption__Keys__0__KeyId"             = module.state_secrets.secrets["pii_encryption_key_id"].secret_arn
-    "PiiEncryption__Keys__0__KeyMaterialBase64" = module.state_secrets.secrets["pii_encryption_key_material_base64"].secret_arn
+    "JwtSettings__SecretKey"                    = module.state_secrets.secrets["JWT_SECRET_KEY"].secret_arn
+    "IdentifierHasher__SecretKey"               = module.state_secrets.secrets["IDENTIFIER_HASHER_SECRET_KEY"].secret_arn
+    "Socure__ApiKey"                            = module.state_secrets.secrets["SOCURE_API_KEY"].secret_arn
+    "Socure__WebhookSecret"                     = module.state_secrets.secrets["SOCURE_WEBHOOK_SECRET"].secret_arn
+    "PiiEncryption__Keys__0__KeyId"             = module.state_secrets.secrets["PII_ENCRYPTION_KEY_ID"].secret_arn
+    "PiiEncryption__Keys__0__KeyMaterialBase64" = module.state_secrets.secrets["PII_ENCRYPTION_KEY_MATERIAL_BASE64"].secret_arn
   }
 
   state_web_environment_variables = {}

--- a/tofu/modules/sebt_application/main.tf
+++ b/tofu/modules/sebt_application/main.tf
@@ -91,8 +91,8 @@ module "api" {
     "Redis__Password"              = "${module.redis.auth_token_secret_arn}:auth_token"
     "SmtpClientSettings__UserName" = "${module.ses.secret_arn}:username"
     "SmtpClientSettings__Password" = "${module.ses.secret_arn}:password"
-    "Smarty__AuthId"               = module.secrets.secrets["smarty_auth_id"].secret_arn
-    "Smarty__AuthToken"            = module.secrets.secrets["smarty_auth_token"].secret_arn
+    "Smarty__AuthId"               = module.secrets.secrets["SMARTY_AUTH_ID"].secret_arn
+    "Smarty__AuthToken"            = module.secrets.secrets["SMARTY_AUTH_TOKEN"].secret_arn
   }, var.state_api_environment_secrets)
 
   # Forward application traces to Datadog APM when the integration API key is
@@ -176,12 +176,19 @@ module "secrets" {
   environment = var.environment
   service     = "api"
 
+  # Doppler's AWS Secrets Manager sync creates its own target secret named
+  # "{path}/{DOPPLER_KEY}" (uppercase, exact match) rather than writing into
+  # a pre-existing ARN — so these keys and add_suffix=false must make our
+  # secret's name match exactly what Doppler will create, or Doppler ends up
+  # populating an entirely separate, unreferenced secret.
+  add_suffix = false
+
   secrets = {
-    "smarty_auth_id" = {
+    "SMARTY_AUTH_ID" = {
       description     = "Smarty address validation API auth ID."
       recovery_window = var.secret_recovery_period
     }
-    "smarty_auth_token" = {
+    "SMARTY_AUTH_TOKEN" = {
       description     = "Smarty address validation API auth token."
       recovery_window = var.secret_recovery_period
     }
@@ -189,8 +196,7 @@ module "secrets" {
 }
 
 # Sync the API's secrets to Doppler so they can be managed from a single
-# place instead of the AWS console. Doppler pushes to this existing secret's
-# ARN; it doesn't create its own. Smarty's credentials are a single shared
+# place instead of the AWS console. Smarty's credentials are a single shared
 # vendor account used by every state, so both DC and CO read from the same
 # root "dev" config instead of a per-state branch.
 module "doppler" {


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-159

#### ✍️ Description
Removes the suffix from AWS Secrets Manager secrets that was being added by tofu and refactors secret names to use the Doppler matching capitalized SECRET_NAME_FORMATTING.