### PR TITLE
fix(tests): serialize EmailSenderServiceTests with Integration collection

### DIFF
--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Services/EmailSenderServiceTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Services/EmailSenderServiceTests.cs
@@ -8,6 +8,10 @@ using SEBT.Portal.Kernel.Results;
 
 namespace SEBT.Portal.Tests.Unit.Services;
 
+// Shares the "Integration" collection so this test's STATE env var mutation can't
+// race with PortalWebApplicationFactory-based tests, which mutate the same
+// process-global var — see IntegrationTestCollection.cs.
+[Collection("Integration")]
 public class EmailSenderServiceTests : IDisposable
 {
     private readonly string? _previousState;


### PR DESCRIPTION
#### 🔗 Jira ticket
No ticket — found while investigating an intermittently failing `dc - Build & Test` check on PR #578.

#### ✍️ Description
`EmailSenderServiceTests` mutates the process-global `STATE` env var in its constructor/`Dispose` (needed because `EmailOtpSenderService.LoadTranslations()` reads `STATE` to pick which embedded email-content resource to load). Since this test class wasn't part of the existing `"Integration"` xUnit collection, xUnit could run it in parallel with `PortalWebApplicationFactory`-based integration tests, which mutate the same `STATE` variable — causing an intermittent `STATE environment variable is not set` failure (observed on `SendOtpAsync_WithSupportedLocale_ShouldSetCorrectLangAttribute(locale: "am")`).

The codebase already has a `[CollectionDefinition("Integration")]` (see `IntegrationTestCollection.cs`) specifically to serialize test classes that share process-global env vars — every other `STATE`-mutating integration test class already opts into it. This PR adds `EmailSenderServiceTests` to that same collection so it can no longer race with them.

No production code changes.

#### 🔗 Links to related PRs
None

#### ✅ Completion tasks
- [x] Added relevant tests (n/a — fixes test isolation, no new behavior)
- [ ] Meets acceptance criteria in ticket (no ticket)
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig
