### PR TITLE
DC-726(Chore): Group Dependabot minor and patch updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "nuget"
     directory: "/"
@@ -13,6 +20,13 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      nuget-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,6 +34,13 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
     directory: "tofu/modules/sebt_database/lambda"


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-726

#### ✍️ Description
This PR updates `.github/dependabot.yml` to batch minor and patch dependency updates into grouped pull requests for npm (via `pnpm`), NuGet, and GitHub Actions. Major version bumps are not included in any group, so they continue to open as individual PRs for separate review.

Three new groups were added, one per ecosystem:

- `npm-minor-patch` for JavaScript and TypeScript workspace dependencies
- `nuget-minor-patch` for .NET package updates
- `github-actions-minor-patch` for workflow action version bumps

Each group uses `patterns: ["*"]` with `update-types` limited to `minor` and `patch`. Pip lambda and Terraform configurations are unchanged.

Grouped PRs will appear on Dependabot's next scheduled weekly run after this merges, so don't expect changes right away.  We can try manually triggering Dependabot to run

#### 🔗 Links to related PRs
None

#### ✅ Completion tasks

- [x] Added relevant tests (not applicable: Dependabot config only)
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [x] If new environment variables are added, update in Tofu (not applicable)
  - [x] If new environment secrets are added, update in Tofu and set in AWS Secret Manager (not applicable)
  - [x] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig (not applicable)
  - [x] If appsetttings are changed, update in AWS AppConfig (not applicable)