### PR TITLE
[DC-704] Migrate raw OIDC config reads to typed settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ This is a .NET 10 + Next.js 16 application following Clean Architecture. For det
 - **Web** — Next.js 16 frontend (React 19, USWDS 3.13, i18next)
 - **EnrollmentChecker.Web** — Next.js enrollment-check standalone app (separate pnpm workspace member)
 - **TestUtilities** — Shared test helpers (Bogus factories, builders)
-- **Tests** / **UseCases.Tests** — xUnit + NSubstitute + Bogus + Testcontainers (MSSQL)
+- **Tests** — xUnit + NSubstitute + Bogus + Testcontainers (MSSQL); one portal test project covering all layers incl. UseCases handler tests (no separate UseCases.Tests project post-monorepo)
 
 #### Workspace Packages (`packages/`)
 - **design-system** — USWDS design tokens, locale generation scripts, shared content

--- a/apps/portal/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Controllers/Auth/AuthController.cs
@@ -1,8 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Api.Models;
 using SEBT.Portal.Api.Services;
@@ -10,7 +8,6 @@ using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Kernel;
-using SEBT.Portal.Kernel.AspNetCore;
 using SEBT.Portal.Kernel.Results;
 using SEBT.Portal.UseCases.Auth;
 
@@ -75,7 +72,7 @@ public class AuthController(
     [AllowAnonymous]
     [ProducesResponseType(StatusCodes.Status302Found)]
     public async Task<IActionResult> Logout(
-        [FromServices] IConfiguration config,
+        [FromServices] IOptionsSnapshot<OidcSettings> oidcSettings,
         [FromServices] IOidcExchangeService oidcExchangeService,
         [FromServices] ITokenDenylist tokenDenylist,
         CancellationToken cancellationToken = default)
@@ -84,9 +81,9 @@ public class AuthController(
 
         AuthCookies.ClearAuthCookie(Response);
 
-        var discoveryEndpoint = config["Oidc:DiscoveryEndpoint"];
-        var clientId = config["Oidc:ClientId"];
-        var callbackRedirectUri = config["Oidc:CallbackRedirectUri"];
+        var discoveryEndpoint = oidcSettings.Value.DiscoveryEndpoint;
+        var clientId = oidcSettings.Value.ClientId;
+        var callbackRedirectUri = oidcSettings.Value.CallbackRedirectUri;
 
         if (!string.IsNullOrEmpty(discoveryEndpoint) && !string.IsNullOrEmpty(clientId)
             && !string.IsNullOrEmpty(callbackRedirectUri))

--- a/apps/portal/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -10,9 +10,6 @@ using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
-using SEBT.Portal.Core.Utilities;
-using SEBT.Portal.Kernel;
-
 using static SEBT.Portal.Core.Utilities.PiiMasker;
 
 namespace SEBT.Portal.Api.Controllers.Auth;
@@ -25,7 +22,8 @@ namespace SEBT.Portal.Api.Controllers.Auth;
 [ApiController]
 [Route("api/auth/oidc")]
 public class OidcController(
-    IConfiguration config,
+    IOptionsSnapshot<OidcSettings> oidcSettings,
+    IOptionsSnapshot<OidcStepUpSettings> oidcStepUpSettings,
     ILogger<OidcController> logger,
     IOidcCallbackFailureLogger callbackFailureLogger,
     IUserRepository userRepository,
@@ -64,10 +62,10 @@ public class OidcController(
             return BadRequest(new ErrorResponse("Unknown or unsupported stateCode."));
         }
 
-        var clientId = stepUp ? config["Oidc:StepUp:ClientId"] : config["Oidc:ClientId"];
+        var clientId = GetOidcSettings(stepUp).ClientId;
         var redirectUri = stepUp
-            ? (config["Oidc:StepUp:RedirectUri"] ?? config["Oidc:CallbackRedirectUri"])
-            : config["Oidc:CallbackRedirectUri"];
+            ? GetOidcSettings(stepUp).RedirectUri ?? oidcSettings.Value.CallbackRedirectUri
+            : oidcSettings.Value.CallbackRedirectUri;
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(redirectUri))
         {
             logger.LogError(
@@ -151,10 +149,9 @@ public class OidcController(
             return LocalRedirect(safeReturnUrl ?? "/dashboard");
         }
 
-        var clientId = stepUp ? config["Oidc:StepUp:ClientId"] : config["Oidc:ClientId"];
-        var redirectUri = stepUp
-            ? (config["Oidc:StepUp:RedirectUri"] ?? config["Oidc:CallbackRedirectUri"])
-            : config["Oidc:CallbackRedirectUri"];
+        var clientId = GetOidcSettings(stepUp).ClientId;
+        var redirectUri = GetOidcSettings(stepUp).RedirectUri ?? oidcSettings.Value.CallbackRedirectUri;
+        
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(redirectUri))
         {
             logger.LogError(
@@ -194,8 +191,8 @@ public class OidcController(
 
         // Build the authorization URL server-side (mirrors the frontend's buildAuthorizationUrl).
         // Use the language from the query param (set by the frontend based on user choice),
-        // falling back to the configured default.
-        var languageParam = language ?? config["Oidc:LanguageParam"] ?? "en";
+        // falling back to the default.
+        var languageParam = language ?? "en";
         var authUrl = BuildAuthorizationUrl(
             oidcConfig.AuthorizationEndpoint, clientId, redirectUri,
             state, codeChallenge, languageParam);
@@ -469,8 +466,7 @@ public class OidcController(
         OidcSessionCookie.Clear(Response);
         await sessionStore.RemoveAsync(sessionId, cancellationToken);
 
-        var stateKey = session.StateCode.ToLowerInvariant();
-        var signingKey = config["Oidc:CompleteLoginSigningKey"];
+        var signingKey = oidcSettings.Value.CompleteLoginSigningKey;
         if (string.IsNullOrEmpty(signingKey))
         {
             callbackFailureLogger.Log(new OidcCallbackFailureLogEntry
@@ -485,7 +481,7 @@ public class OidcController(
             return StatusCode(StatusCodes.Status503ServiceUnavailable, new { error = "Complete-login not configured.", hint });
         }
 
-        var portalOrigin = config["Oidc:CallbackRedirectUri"]?.TrimEnd('/') ?? "sebt-portal";
+        var portalOrigin = oidcSettings.Value.PortalOrigin;
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
         var validationParams = new TokenValidationParameters
         {
@@ -499,10 +495,12 @@ public class OidcController(
             // Use resolver instead of IssuerSigningKey to bypass kid-matching;
             // the callback token is signed without a kid header, which causes IDX10517
             // when JwtSecurityTokenHandler tries to match by kid.
-            IssuerSigningKeyResolver = (token, securityToken, kid, parameters) => [key]
+            IssuerSigningKeyResolver = (_, _, _, _) => [key]
         };
-        var handler = new JwtSecurityTokenHandler();
-        handler.MapInboundClaims = false; // Preserve original JWT claim names (sub, email)
+        var handler = new JwtSecurityTokenHandler 
+        { 
+            MapInboundClaims = false // Preserve original JWT claim names (sub, email)
+        };
         ClaimsPrincipal principal;
         try
         {
@@ -683,18 +681,6 @@ public class OidcController(
     }
 
     /// <summary>
-    /// Removes newline/control-friendly breaks from values logged from user input.
-    /// </summary>
-    private static string SanitizeForLog(string? value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return string.Empty;
-        return value
-            .Replace("\r", string.Empty, StringComparison.Ordinal)
-            .Replace("\n", string.Empty, StringComparison.Ordinal);
-    }
-
-    /// <summary>
     /// Gets the email (or subject) from the callback token claims for portal user lookup.
     /// </summary>
     private static string? GetEmailFromClaims(ClaimsPrincipal principal)
@@ -706,4 +692,6 @@ public class OidcController(
         return subClaim?.Value;
     }
 
+    private IOidcCoreSettings GetOidcSettings(bool stepUp) => 
+        stepUp ? oidcStepUpSettings.Value : oidcSettings.Value;
 }

--- a/apps/portal/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Controllers/Auth/OidcController.cs
@@ -151,7 +151,7 @@ public class OidcController(
 
         var clientId = GetOidcSettings(stepUp).ClientId;
         var redirectUri = GetOidcSettings(stepUp).RedirectUri ?? oidcSettings.Value.CallbackRedirectUri;
-        
+
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(redirectUri))
         {
             logger.LogError(
@@ -497,8 +497,8 @@ public class OidcController(
             // when JwtSecurityTokenHandler tries to match by kid.
             IssuerSigningKeyResolver = (_, _, _, _) => [key]
         };
-        var handler = new JwtSecurityTokenHandler 
-        { 
+        var handler = new JwtSecurityTokenHandler
+        {
             MapInboundClaims = false // Preserve original JWT claim names (sub, email)
         };
         ClaimsPrincipal principal;
@@ -692,6 +692,6 @@ public class OidcController(
         return subClaim?.Value;
     }
 
-    private IOidcCoreSettings GetOidcSettings(bool stepUp) => 
+    private IOidcCoreSettings GetOidcSettings(bool stepUp) =>
         stepUp ? oidcStepUpSettings.Value : oidcSettings.Value;
 }

--- a/apps/portal/src/SEBT.Portal.Api/Middleware/OidcOriginValidationMiddleware.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Middleware/OidcOriginValidationMiddleware.cs
@@ -1,3 +1,6 @@
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
+
 namespace SEBT.Portal.Api.Middleware;
 
 /// <summary>
@@ -32,7 +35,8 @@ public class OidcOriginValidationMiddleware
     public OidcOriginValidationMiddleware(
         RequestDelegate next,
         ILogger<OidcOriginValidationMiddleware> logger,
-        IConfiguration configuration)
+        IOptions<OidcSettings> oidcSettings,
+        IOptions<OidcStepUpSettings> stepUpSettings)
     {
         _next = next;
         _logger = logger;
@@ -40,13 +44,13 @@ public class OidcOriginValidationMiddleware
         // Build the allowed-origins set from CallbackRedirectUri (which contains the portal origin).
         // In production this is e.g. "https://sunbucks.co.gov"; in dev "http://localhost:3000".
         _allowedOrigins = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var callbackUri = configuration["Oidc:CallbackRedirectUri"];
+        var callbackUri = oidcSettings.Value.CallbackRedirectUri;
         if (!string.IsNullOrEmpty(callbackUri) && Uri.TryCreate(callbackUri, UriKind.Absolute, out var uri))
         {
             _allowedOrigins.Add(uri.GetLeftPart(UriPartial.Authority));
         }
         // Step-up may have a different redirect URI (though it rarely has a different origin).
-        var stepUpUri = configuration["Oidc:StepUp:RedirectUri"];
+        var stepUpUri = stepUpSettings.Value.RedirectUri;
         if (!string.IsNullOrEmpty(stepUpUri) && Uri.TryCreate(stepUpUri, UriKind.Absolute, out var su))
         {
             _allowedOrigins.Add(su.GetLeftPart(UriPartial.Authority));

--- a/apps/portal/src/SEBT.Portal.Api/Program.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Program.cs
@@ -27,9 +27,7 @@ builder.Services.AddCaching(builder.Configuration, builder.Environment);
 // Registers plugins and allows them to be constructor injected into ASP.NET controllers
 builder.Services.AddPlugins(builder.Configuration, builder.Environment.ContentRootPath);
 
-// Add services to the container.
 builder.Services.AddControllers();
-
 builder.Services.Configure<RouteOptions>(options =>
 {
     options.LowercaseUrls = true;
@@ -59,15 +57,6 @@ builder.Services.AddDatabaseSeeder();
 builder.Services.AddDevelopmentOverrides();
 
 var app = builder.Build();
-
-// HMAC-SHA256 requires ≥256-bit (32-byte) key. Fail fast if configured but too short.
-var oidcSigningKey = app.Configuration["Oidc:CompleteLoginSigningKey"];
-if (!string.IsNullOrEmpty(oidcSigningKey) && oidcSigningKey.Length < 32)
-{
-    throw new InvalidOperationException(
-        $"Oidc:CompleteLoginSigningKey must be at least 32 characters (got {oidcSigningKey.Length}). " +
-        "HMAC-SHA256 requires a 256-bit key for full security.");
-}
 
 await app.MigrateAndSeedDatabaseAsync();
 

--- a/apps/portal/src/SEBT.Portal.Api/Services/IOidcExchangeService.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Services/IOidcExchangeService.cs
@@ -1,0 +1,42 @@
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using SEBT.Portal.Core.Models.Auth;
+
+namespace SEBT.Portal.Api.Services;
+
+/// <summary>
+/// Performs the OIDC token exchange and id_token verification at the API layer.
+///
+/// The service is stateless between requests (all flow state lives in the pre-auth session store).
+/// </summary>
+public interface IOidcExchangeService
+{
+    /// <summary>
+    /// Exchanges an authorization code for an id_token, verifies it, and signs a short-lived
+    /// callback token containing the IdP claims. Returns the callback token on success.
+    /// </summary>
+    /// <param name="code">Authorization code from PingOne redirect.</param>
+    /// <param name="codeVerifier">PKCE code_verifier (from the pre-auth session, never from the browser).</param>
+    /// <param name="redirectUri">redirect_uri that was sent in the authorization request.</param>
+    /// <param name="isStepUp">True when this is a step-up (IAL1+) flow.</param>
+    /// <param name="sessionId">Pre-auth session id for correlated off-boarding logs.</param>
+    /// <param name="cancellationToken">Cancellation.</param>
+    /// <returns>Signed callback token (short-lived JWT) on success.</returns>
+    Task<OidcExchangeResult> ExchangeCodeAsync(
+        string code,
+        string codeVerifier,
+        string redirectUri,
+        bool isStepUp,
+        string? sessionId = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the cached OIDC discovery document for the configured IdP. Returns the
+    /// <see cref="OpenIdConnectConfiguration"/> containing endpoint URLs (authorization,
+    /// token, userinfo), signing keys, and issuer metadata.
+    /// </summary>
+    /// <param name="isStepUp">True to use the step-up IdP configuration.</param>
+    /// <param name="cancellationToken">Cancellation.</param>
+    Task<OpenIdConnectConfiguration> GetDiscoveryConfigAsync(
+        bool isStepUp,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/portal/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
@@ -471,7 +471,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
             _logger.LogInformation(ex, "OIDC exchange: userinfo fetch failed (non-fatal)");
         }
     }
-    
+
     private IOidcCoreSettings GetSettings(bool isStepUp) =>
         isStepUp ? _oidcStepUpSettings.Value : _oidcSettings.Value;
 }

--- a/apps/portal/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
+++ b/apps/portal/src/SEBT.Portal.Api/Services/OidcExchangeService.cs
@@ -3,94 +3,20 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
-using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Models.Auth;
 
 namespace SEBT.Portal.Api.Services;
-
-/// <summary>
-/// performs the OIDC token exchange and id_token verification entirely server-side.
-/// Replaces the Next.js <c>/api/auth/oidc/callback/route.ts</c> — the client secret, JWKS
-/// validation, and callback-token signing all happen in .NET now.
-///
-/// The service is stateless between requests (all flow state lives in the pre-auth session
-/// store). Inject as scoped or transient.
-/// </summary>
-public interface IOidcExchangeService
-{
-    /// <summary>
-    /// Exchanges an authorization code for an id_token, verifies it, and signs a short-lived
-    /// callback token containing the IdP claims. Returns the callback token on success.
-    /// </summary>
-    /// <param name="code">Authorization code from PingOne redirect.</param>
-    /// <param name="codeVerifier">PKCE code_verifier (from the pre-auth session, never from the browser).</param>
-    /// <param name="redirectUri">redirect_uri that was sent in the authorization request.</param>
-    /// <param name="isStepUp">True when this is a step-up (IAL1+) flow.</param>
-    /// <param name="sessionId">Pre-auth session id for correlated off-boarding logs.</param>
-    /// <param name="cancellationToken">Cancellation.</param>
-    /// <returns>Signed callback token (short-lived JWT) on success.</returns>
-    Task<OidcExchangeResult> ExchangeCodeAsync(
-        string code,
-        string codeVerifier,
-        string redirectUri,
-        bool isStepUp,
-        string? sessionId = null,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Fetches the cached OIDC discovery document for the configured IdP. Returns the
-    /// <see cref="OpenIdConnectConfiguration"/> containing endpoint URLs (authorization,
-    /// token, userinfo), signing keys, and issuer metadata.
-    /// </summary>
-    /// <param name="isStepUp">True to use the step-up IdP configuration.</param>
-    /// <param name="cancellationToken">Cancellation.</param>
-    Task<OpenIdConnectConfiguration> GetDiscoveryConfigAsync(
-        bool isStepUp,
-        CancellationToken cancellationToken = default);
-}
-
-/// <summary>Result of the OIDC code exchange.</summary>
-public sealed record OidcExchangeResult
-{
-    /// <summary>True when exchange + verification succeeded.</summary>
-    public bool Success { get; init; }
-
-    /// <summary>Signed callback token (short-lived JWT containing IdP claims). Null on failure.</summary>
-    public string? CallbackToken { get; init; }
-
-    /// <summary>Phone claim value extracted during the exchange (for diagnostic logging). Null when absent or on failure.</summary>
-    public string? PhoneClaim { get; init; }
-
-    /// <summary>Human-readable error message for the client. Null on success.</summary>
-    public string? Error { get; init; }
-
-    /// <summary>HTTP status code to return to the client. 200 on success.</summary>
-    public int StatusCode { get; init; } = 200;
-
-    /// <summary>Creates a successful result with the given callback token.</summary>
-    public static OidcExchangeResult Ok(string callbackToken, string? phoneClaim = null) => new()
-    {
-        Success = true,
-        CallbackToken = callbackToken,
-        PhoneClaim = phoneClaim,
-        StatusCode = 200
-    };
-
-    /// <summary>Creates a failed result with the given error message and HTTP status code.</summary>
-    public static OidcExchangeResult Fail(string error, int statusCode = 400) => new()
-    {
-        Success = false,
-        Error = error,
-        StatusCode = statusCode
-    };
-}
 
 /// <inheritdoc cref="IOidcExchangeService"/>
 public sealed class OidcExchangeService : IOidcExchangeService
 {
-    private readonly IConfiguration _config;
+    private readonly IOptionsSnapshot<OidcSettings> _oidcSettings;
+    private readonly IOptionsSnapshot<OidcStepUpSettings> _oidcStepUpSettings;
     private readonly IHttpClientFactory _httpFactory;
     private readonly ILogger<OidcExchangeService> _logger;
     private readonly IOidcCallbackFailureLogger _callbackFailureLogger;
@@ -105,7 +31,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
     /// claims into the callback token or portal JWT. Single source of truth — the
     /// controller's <c>CompleteLogin</c> references this same set.
     /// </summary>
-    public static readonly HashSet<string> CommonOidcInfrastructureClaims = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly HashSet<string> CommonOidcInfrastructureClaims = new(StringComparer.OrdinalIgnoreCase)
     {
         "iss", "aud", "iat", "exp", "nbf", "nonce", "at_hash", "c_hash",
         "auth_time", "acr", "amr", "azp", "sid", "jti",
@@ -130,12 +56,14 @@ public sealed class OidcExchangeService : IOidcExchangeService
 
     /// <inheritdoc cref="OidcExchangeService"/>
     public OidcExchangeService(
-        IConfiguration config,
+        IOptionsSnapshot<OidcSettings> oidcSettings,
+        IOptionsSnapshot<OidcStepUpSettings> oidcStepUpSettings,
         IHttpClientFactory httpFactory,
         ILogger<OidcExchangeService> logger,
         IOidcCallbackFailureLogger callbackFailureLogger)
     {
-        _config = config;
+        _oidcSettings = oidcSettings;
+        _oidcStepUpSettings = oidcStepUpSettings;
         _httpFactory = httpFactory;
         _logger = logger;
         _callbackFailureLogger = callbackFailureLogger;
@@ -146,9 +74,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
         bool isStepUp,
         CancellationToken cancellationToken = default)
     {
-        var discoveryEndpoint = isStepUp
-            ? _config["Oidc:StepUp:DiscoveryEndpoint"]
-            : _config["Oidc:DiscoveryEndpoint"];
+        var discoveryEndpoint = GetSettings(isStepUp).DiscoveryEndpoint;
 
         if (string.IsNullOrEmpty(discoveryEndpoint))
         {
@@ -192,9 +118,12 @@ public sealed class OidcExchangeService : IOidcExchangeService
         CancellationToken cancellationToken = default)
     {
         // --- Resolve per-flow config ---
-        var clientId = isStepUp ? _config["Oidc:StepUp:ClientId"] : _config["Oidc:ClientId"];
-        var clientSecret = isStepUp ? _config["Oidc:StepUp:ClientSecret"] : _config["Oidc:ClientSecret"];
-        var signingKey = _config["Oidc:CompleteLoginSigningKey"];
+        var settings = GetSettings(isStepUp);
+        var clientId = settings.ClientId;
+        var clientSecret = settings.ClientSecret;
+
+        // Signing key is portal-level (not IdP-per-flow) — always read from the base Oidc section.
+        var signingKey = _oidcSettings.Value.CompleteLoginSigningKey;
 
         if (string.IsNullOrEmpty(clientId)
             || string.IsNullOrEmpty(clientSecret) || string.IsNullOrEmpty(signingKey))
@@ -348,10 +277,10 @@ public sealed class OidcExchangeService : IOidcExchangeService
             ValidateIssuer = true,
             ValidIssuer = oidcConfig.Issuer,
             ValidateAudience = true,
-            ValidAudiences = new[] { clientId },
+            ValidAudiences = [clientId],
             ValidateLifetime = true,
             ClockSkew = IdTokenClockSkew,
-            ValidAlgorithms = new[] { SecurityAlgorithms.RsaSha256 },
+            ValidAlgorithms = [SecurityAlgorithms.RsaSha256],
             RequireExpirationTime = true,
             RequireSignedTokens = true
         };
@@ -451,7 +380,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
 
         // --- Sign the callback token with deployment-specific issuer/audience ---
         // Prevents cross-environment token confusion if the signing key were shared.
-        var portalOrigin = _config["Oidc:CallbackRedirectUri"]?.TrimEnd('/') ?? "sebt-portal";
+        var portalOrigin = _oidcSettings.Value.PortalOrigin;
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
         var jwtClaims = claims.Select(c => new Claim(c.Key, c.Value)).ToList();
@@ -542,4 +471,7 @@ public sealed class OidcExchangeService : IOidcExchangeService
             _logger.LogInformation(ex, "OIDC exchange: userinfo fetch failed (non-fatal)");
         }
     }
+    
+    private IOidcCoreSettings GetSettings(bool isStepUp) =>
+        isStepUp ? _oidcStepUpSettings.Value : _oidcSettings.Value;
 }

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/IOidcCoreSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/IOidcCoreSettings.cs
@@ -3,10 +3,10 @@ namespace SEBT.Portal.Core.AppSettings;
 public interface IOidcCoreSettings
 {
     string? DiscoveryEndpoint { get; }
-    
+
     string? ClientId { get; }
-    
+
     string? ClientSecret { get; }
-    
+
     string? RedirectUri { get; }
 }

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/IOidcCoreSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/IOidcCoreSettings.cs
@@ -1,0 +1,10 @@
+namespace SEBT.Portal.Core.AppSettings;
+
+public interface IOidcCoreSettings
+{
+    string? DiscoveryEndpoint { get; }
+    
+    string? ClientId { get; }
+    
+    string? ClientSecret { get; }
+}

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/IOidcCoreSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/IOidcCoreSettings.cs
@@ -7,4 +7,6 @@ public interface IOidcCoreSettings
     string? ClientId { get; }
     
     string? ClientSecret { get; }
+    
+    string? RedirectUri { get; }
 }

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
@@ -16,4 +16,6 @@ public class OidcSettings : IOidcCoreSettings, IHaveConfigSectionName
     
     // Deployment-specific JWT issuer/audience; symmetric on sign + validate.
     public string PortalOrigin => CallbackRedirectUri?.TrimEnd('/') ?? "sebt-portal";
+
+    string? IOidcCoreSettings.RedirectUri => CallbackRedirectUri;
 }

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
@@ -3,17 +3,17 @@ namespace SEBT.Portal.Core.AppSettings;
 public class OidcSettings : IOidcCoreSettings, IHaveConfigSectionName
 {
     public static string SectionName => "Oidc";
-    
+
     public string? DiscoveryEndpoint { get; set; }
-    
+
     public string? ClientId { get; set; }
-    
+
     public string? ClientSecret { get; set; }
-    
+
     public string? CallbackRedirectUri { get; set; }
-    
+
     public string? CompleteLoginSigningKey { get; set; }
-    
+
     // Deployment-specific JWT issuer/audience; symmetric on sign + validate.
     public string PortalOrigin => CallbackRedirectUri?.TrimEnd('/') ?? "sebt-portal";
 

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
@@ -1,6 +1,6 @@
 namespace SEBT.Portal.Core.AppSettings;
 
-public class OidcSettings : IHaveConfigSectionName
+public class OidcSettings : IOidcCoreSettings, IHaveConfigSectionName
 {
     public static string SectionName => "Oidc";
     

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcSettings.cs
@@ -1,0 +1,19 @@
+namespace SEBT.Portal.Core.AppSettings;
+
+public class OidcSettings : IHaveConfigSectionName
+{
+    public static string SectionName => "Oidc";
+    
+    public string? DiscoveryEndpoint { get; set; }
+    
+    public string? ClientId { get; set; }
+    
+    public string? ClientSecret { get; set; }
+    
+    public string? CallbackRedirectUri { get; set; }
+    
+    public string? CompleteLoginSigningKey { get; set; }
+    
+    // Deployment-specific JWT issuer/audience; symmetric on sign + validate.
+    public string PortalOrigin => CallbackRedirectUri?.TrimEnd('/') ?? "sebt-portal";
+}

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcStepUpSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcStepUpSettings.cs
@@ -4,7 +4,7 @@ namespace SEBT.Portal.Core.AppSettings;
 /// OIDC client used for elevated verification (IAL1+ step-up). Public values only; secrets belong on the Next.js server.
 /// Binds to <c>Oidc:StepUp</c> in configuration.
 /// </summary>
-public class OidcStepUpSettings : IHaveConfigSectionName
+public class OidcStepUpSettings : IOidcCoreSettings, IHaveConfigSectionName
 {
     public static string SectionName => "Oidc:StepUp";
 
@@ -13,6 +13,9 @@ public class OidcStepUpSettings : IHaveConfigSectionName
 
     /// <summary>OAuth2 client id registered with the IdP for step-up.</summary>
     public string? ClientId { get; set; }
+    
+    /// <summary>OAuth2 client secret registered with the IdP for step-up</summary>
+    public string? ClientSecret { get; set; }
 
     /// <summary>Optional redirect URI; when unset, <c>Oidc:CallbackRedirectUri</c> is used.</summary>
     public string? RedirectUri { get; set; }

--- a/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcStepUpSettings.cs
+++ b/apps/portal/src/SEBT.Portal.Core/AppSettings/OidcStepUpSettings.cs
@@ -13,7 +13,7 @@ public class OidcStepUpSettings : IOidcCoreSettings, IHaveConfigSectionName
 
     /// <summary>OAuth2 client id registered with the IdP for step-up.</summary>
     public string? ClientId { get; set; }
-    
+
     /// <summary>OAuth2 client secret registered with the IdP for step-up</summary>
     public string? ClientSecret { get; set; }
 

--- a/apps/portal/src/SEBT.Portal.Core/Models/Auth/OidcExchangeResult.cs
+++ b/apps/portal/src/SEBT.Portal.Core/Models/Auth/OidcExchangeResult.cs
@@ -1,0 +1,37 @@
+namespace SEBT.Portal.Core.Models.Auth;
+
+/// <summary>Result of the OIDC code exchange.</summary>
+public sealed record OidcExchangeResult
+{
+    /// <summary>True when exchange + verification succeeded.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>Signed callback token (short-lived JWT containing IdP claims). Null on failure.</summary>
+    public string? CallbackToken { get; init; }
+
+    /// <summary>Phone claim value extracted during the exchange (for diagnostic logging). Null when absent or on failure.</summary>
+    public string? PhoneClaim { get; init; }
+
+    /// <summary>Human-readable error message for the client. Null on success.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>HTTP status code to return to the client. 200 on success.</summary>
+    public int StatusCode { get; init; } = 200;
+
+    /// <summary>Creates a successful result with the given callback token.</summary>
+    public static OidcExchangeResult Ok(string callbackToken, string? phoneClaim = null) => new()
+    {
+        Success = true,
+        CallbackToken = callbackToken,
+        PhoneClaim = phoneClaim,
+        StatusCode = 200
+    };
+
+    /// <summary>Creates a failed result with the given error message and HTTP status code.</summary>
+    public static OidcExchangeResult Fail(string error, int statusCode = 400) => new()
+    {
+        Success = false,
+        Error = error,
+        StatusCode = statusCode
+    };
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Dependencies.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Dependencies.cs
@@ -22,6 +22,7 @@ internal static class Dependencies
         services.AddPortalOptions<IdProofingRequirementsSettings, ConfigureIdProofingRequirements>(configuration);
         services.AddPortalOptions<IdProofingValiditySettings>();
         services.AddPortalOptions<JwtSettings>();
+        services.AddPortalOptions<OidcSettings>();
         services.AddPortalOptions<OidcStepUpSettings>();
         services.AddPortalOptions<OidcVerificationClaimSettings>();
         services.AddPortalOptions<OtpRateLimitSettings>();

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/IdProofingRequirementsCoherenceValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/IdProofingRequirementsCoherenceValidator.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// Validates IdProofingRequirements coherence at startup and on every config reload.

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/JwtSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/JwtSettingsValidator.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// Validates cross-field invariants on <see cref="JwtSettings"/> that data annotations

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/OidcSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/OidcSettingsValidator.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Options;
+using SEBT.Portal.Core.AppSettings;
+
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
+
+public class OidcSettingsValidator : IValidateOptions<OidcSettings>
+{
+    public ValidateOptionsResult Validate(string? name, OidcSettings options)
+    {
+        var key = options.CompleteLoginSigningKey;
+
+        if (!string.IsNullOrEmpty(key) && key.Length < 32)
+        {
+            return ValidateOptionsResult.Fail(
+                $"Oidc:CompleteLoginSigningKey must be at least 32 characters (got {key.Length}). " +
+                "HMAC-SHA256 requires a 256-bit key for full security.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/OidcStepUpSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/OidcStepUpSettingsValidator.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// When any step-up value is set, requires a complete step-up client (and a redirect via step-up or primary callback URI).

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/OutageScheduleSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/OutageScheduleSettingsValidator.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// Rejects a malformed outage schedule at startup rather than letting the evaluator skip windows it

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/PiiEncryptionSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/PiiEncryptionSettingsValidator.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// Ensures <see cref="PiiEncryptionSettings"/> binds coherently: key ring parses, 256-bit key lengths, and ActiveKeyId resolves.

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/SelfServiceRulesSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/SelfServiceRulesSettingsValidator.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// Validates SelfServiceRulesSettings at startup.

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/SmartySettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/SmartySettingsValidator.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// When Smarty is enabled, embedded keys are required at startup.

--- a/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/SocureSettingsValidator.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Configuration/Validators/SocureSettingsValidator.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 
-namespace SEBT.Portal.Infrastructure.Configuration;
+namespace SEBT.Portal.Infrastructure.Configuration.Validators;
 
 /// <summary>
 /// Validates SocureSettings at startup.

--- a/apps/portal/test/SEBT.Portal.Tests/Helpers/TestOptions.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Helpers/TestOptions.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Options;
+
+namespace SEBT.Portal.Tests.Helpers;
+
+/// <summary>
+/// Test analog to <see cref="Options.Create{TOptions}(TOptions)"/> for
+/// <see cref="IOptionsSnapshot{TOptions}"/>, which has no framework factory. Wraps a fixed
+/// value; both <see cref="IOptionsSnapshot{TOptions}.Get"/> and the inherited
+/// <see cref="IOptions{TOptions}.Value"/> return it.
+/// </summary>
+public static class TestOptions
+{
+    /// <summary>Creates an <see cref="IOptionsSnapshot{T}"/> that always yields <paramref name="value"/>.</summary>
+    public static IOptionsSnapshot<T> Snapshot<T>(T value) where T : class => new StaticSnapshot<T>(value);
+
+    private sealed class StaticSnapshot<T>(T value) : IOptionsSnapshot<T> where T : class
+    {
+        public T Value { get; } = value;
+
+        public T Get(string? name) => Value;
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Integration/StartupValidation/OidcSettingsStartupValidationTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Integration/StartupValidation/OidcSettingsStartupValidationTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+
+namespace SEBT.Portal.Tests.Integration.StartupValidation;
+
+/// <summary>
+/// Proves the app fails to start when Oidc:CompleteLoginSigningKey is present
+/// but less than 32 chars.
+/// </summary>
+/// <remarks>Empty/absent is deliberately allowed for states without OIDC.</remarks>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public class OidcSettingsStartupValidationTests : StartupValidationTestBase
+{
+    [Fact]
+    public void Startup_WithTooShortOidcSigningKey_ThrowsOptionsValidationException()
+    {
+        Environment.SetEnvironmentVariable("Oidc__CompleteLoginSigningKey", "too-short");
+        using var factory = CreateFactory();
+
+        var ex = Assert.Throws<OptionsValidationException>(factory.CreateClient);
+        Assert.Contains("CompleteLoginSigningKey", ex.Message);
+    }
+    
+    [Fact]
+    public void Startup_WithEmptyOidcSigningKey_DoesNotThrow()
+    {
+        Environment.SetEnvironmentVariable("Oidc__CompleteLoginSigningKey", "");
+        using var factory = CreateFactory();
+
+        factory.CreateClient(); // empty is allowed → boot succeeds
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Integration/StartupValidation/OidcSettingsStartupValidationTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Integration/StartupValidation/OidcSettingsStartupValidationTests.cs
@@ -20,7 +20,7 @@ public class OidcSettingsStartupValidationTests : StartupValidationTestBase
         var ex = Assert.Throws<OptionsValidationException>(factory.CreateClient);
         Assert.Contains("CompleteLoginSigningKey", ex.Message);
     }
-    
+
     [Fact]
     public void Startup_WithEmptyOidcSigningKey_DoesNotThrow()
     {

--- a/apps/portal/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
+++ b/apps/portal/test/SEBT.Portal.Tests/SEBT.Portal.Tests.csproj
@@ -32,6 +32,10 @@
         <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
         <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
+        <!-- Transitive dependency of Testcontainers; pinned directly so NuGetAudit
+             restores clean after GHSA-q939-rpr3-3284 (fixed in 2026.0.0). Remove the
+             pin once Testcontainers depends on a patched version. -->
+        <PackageReference Include="SSH.NET" Version="2026.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
         <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
         <PackageReference Include="Testcontainers.Redis" Version="4.12.0" />

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/IdProofingRequirementsCoherenceValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/IdProofingRequirementsCoherenceValidatorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 
 namespace SEBT.Portal.Tests.Unit.Configuration;
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/JwtSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/JwtSettingsValidatorTests.cs
@@ -1,5 +1,6 @@
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 
 namespace SEBT.Portal.Tests.Unit.Configuration;
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/OidcStepUpSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/OidcStepUpSettingsValidatorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 
 namespace SEBT.Portal.Tests.Unit.Configuration;
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/PiiEncryptionSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/PiiEncryptionSettingsValidatorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 using Xunit;
 
 namespace SEBT.Portal.Tests.Unit.Configuration;

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/SelfServiceRulesSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/SelfServiceRulesSettingsValidatorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Configuration;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Household;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 
 namespace SEBT.Portal.Tests.Unit.Configuration;
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/SocureSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Configuration/SocureSettingsValidatorTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Hosting;
 using NSubstitute;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 
 namespace SEBT.Portal.Tests.Unit.Configuration;
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Controllers/AuthControllerTests.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -17,6 +16,7 @@ using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Utilities;
 using SEBT.Portal.Kernel;
 using SEBT.Portal.Kernel.Results;
+using SEBT.Portal.Tests.Helpers;
 using SEBT.Portal.UseCases.Auth;
 
 namespace SEBT.Portal.Tests.Unit.Controllers;
@@ -297,14 +297,12 @@ public class AuthControllerTests
     public async Task Logout_WithOidcConfigured_ClearsCookieAndRedirectsToIdpEndSessionEndpoint()
     {
         // Arrange
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Oidc:DiscoveryEndpoint"] = "https://auth.pingone.com/.well-known/openid-configuration",
-                ["Oidc:ClientId"] = "test-client-id",
-                ["Oidc:CallbackRedirectUri"] = "https://portal.co.gov/callback"
-            })
-            .Build();
+        var settings = TestOptions.Snapshot(new OidcSettings
+        {
+            DiscoveryEndpoint = "https://auth.pingone.com/.well-known/openid-configuration",
+            ClientId = "test-client-id",
+            CallbackRedirectUri = "https://portal.co.gov/callback"
+        });
 
         var oidcExchangeService = Substitute.For<IOidcExchangeService>();
         var oidcConfig = new Microsoft.IdentityModel.Protocols.OpenIdConnect.OpenIdConnectConfiguration
@@ -321,7 +319,7 @@ public class AuthControllerTests
         };
 
         // Act
-        var result = await _controller.Logout(config, oidcExchangeService, tokenDenylist);
+        var result = await _controller.Logout(settings, oidcExchangeService, tokenDenylist);
 
         // Assert
         var redirectResult = Assert.IsType<RedirectResult>(result);
@@ -339,9 +337,7 @@ public class AuthControllerTests
     public async Task Logout_WithoutOidcConfigured_ClearsCookieAndRedirectsToLogin()
     {
         // Arrange
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>())
-            .Build();
+        var settings = TestOptions.Snapshot(new OidcSettings());
 
         var oidcExchangeService = Substitute.For<IOidcExchangeService>();
         var tokenDenylist = Substitute.For<ITokenDenylist>();
@@ -352,7 +348,7 @@ public class AuthControllerTests
         };
 
         // Act
-        var result = await _controller.Logout(config, oidcExchangeService, tokenDenylist);
+        var result = await _controller.Logout(settings, oidcExchangeService, tokenDenylist);
 
         // Assert
         var redirectResult = Assert.IsType<RedirectResult>(result);
@@ -367,14 +363,12 @@ public class AuthControllerTests
     public async Task Logout_WhenDiscoveryFails_ClearsCookieAndRedirectsToLogin()
     {
         // Arrange
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Oidc:DiscoveryEndpoint"] = "https://auth.pingone.com/.well-known/openid-configuration",
-                ["Oidc:ClientId"] = "test-client-id",
-                ["Oidc:CallbackRedirectUri"] = "https://portal.co.gov/callback"
-            })
-            .Build();
+        var settings = TestOptions.Snapshot(new OidcSettings
+        {
+            DiscoveryEndpoint = "https://auth.pingone.com/.well-known/openid-configuration",
+            ClientId = "test-client-id",
+            CallbackRedirectUri = "https://portal.co.gov/callback"
+        });
 
         var oidcExchangeService = Substitute.For<IOidcExchangeService>();
         oidcExchangeService.GetDiscoveryConfigAsync(false, Arg.Any<CancellationToken>())
@@ -387,7 +381,7 @@ public class AuthControllerTests
         };
 
         // Act
-        var result = await _controller.Logout(config, oidcExchangeService, tokenDenylist);
+        var result = await _controller.Logout(settings, oidcExchangeService, tokenDenylist);
 
         // Assert — graceful fallback, don't strand the user
         var redirectResult = Assert.IsType<RedirectResult>(result);
@@ -406,9 +400,7 @@ public class AuthControllerTests
         // JwtTokenService mints only Guid jtis, so a non-Guid value must be skipped rather
         // than denylisted — otherwise a forged, arbitrarily large jti could be written to
         // the shared cache by an unauthenticated caller.
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>())
-            .Build();
+        var settings = TestOptions.Snapshot(new OidcSettings());
 
         var oidcExchangeService = Substitute.For<IOidcExchangeService>();
         var tokenDenylist = Substitute.For<ITokenDenylist>();
@@ -421,7 +413,7 @@ public class AuthControllerTests
             $"{AuthCookies.AuthCookieName}={CreateJwtWithJti("not-a-guid")}";
 
         // Act
-        var result = await _controller.Logout(config, oidcExchangeService, tokenDenylist);
+        var result = await _controller.Logout(settings, oidcExchangeService, tokenDenylist);
 
         // Assert
         Assert.IsType<RedirectResult>(result);
@@ -433,9 +425,7 @@ public class AuthControllerTests
     public async Task Logout_WithPortalIssuedJti_DenylistsTokenUntilItsExpiry()
     {
         // Arrange
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>())
-            .Build();
+        var settings = TestOptions.Snapshot(new OidcSettings());
 
         var oidcExchangeService = Substitute.For<IOidcExchangeService>();
         var tokenDenylist = Substitute.For<ITokenDenylist>();
@@ -455,7 +445,7 @@ public class AuthControllerTests
             $"{AuthCookies.AuthCookieName}={rawToken}";
 
         // Act
-        var result = await _controller.Logout(config, oidcExchangeService, tokenDenylist);
+        var result = await _controller.Logout(settings, oidcExchangeService, tokenDenylist);
 
         // Assert
         Assert.IsType<RedirectResult>(result);

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Controllers/OidcControllerTests.cs
@@ -4,7 +4,6 @@ using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -18,6 +17,7 @@ using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Repositories;
 using SEBT.Portal.Core.Services;
 using SEBT.Portal.Kernel;
+using SEBT.Portal.Tests.Helpers;
 
 namespace SEBT.Portal.Tests.Unit.Controllers;
 
@@ -25,7 +25,8 @@ public class OidcControllerTests
 {
     private const string CoStateKey = "co";
     private const string TestSessionId = "test-session-id";
-    private readonly IConfiguration _config;
+    private readonly IOptionsSnapshot<OidcSettings> _oidcSettings;
+    private readonly IOptionsSnapshot<OidcStepUpSettings> _oidcStepUpSettings;
     private readonly IUserRepository _userRepository;
     private readonly IOidcTokenService _oidcTokenService;
     private readonly IPreAuthSessionStore _sessionStore;
@@ -34,8 +35,9 @@ public class OidcControllerTests
 
     public OidcControllerTests()
     {
-        _config = Substitute.For<IConfiguration>();
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings =
+            TestOptions.Snapshot(new OidcSettings { CallbackRedirectUri = "http://localhost:3000/callback" });
+        _oidcStepUpSettings = TestOptions.Snapshot(new OidcStepUpSettings());
         _userRepository = Substitute.For<IUserRepository>();
         _oidcTokenService = Substitute.For<IOidcTokenService>();
         var jwtSettings = Options.Create(new JwtSettings
@@ -72,7 +74,8 @@ public class OidcControllerTests
             new HttpContextAccessor());
 
         _controller = new OidcController(
-            _config,
+            _oidcSettings,
+            _oidcStepUpSettings,
             NullLogger<OidcController>.Instance,
             _callbackFailureLogger,
             _userRepository,
@@ -119,8 +122,7 @@ public class OidcControllerTests
     [Fact]
     public async Task GetConfig_WhenClientIdMissing_Returns503()
     {
-        _config["Oidc:ClientId"].Returns((string?)null);
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = null;
 
         var result = await _controller.GetConfig(CoStateKey);
 
@@ -136,8 +138,7 @@ public class OidcControllerTests
     [Fact]
     public async Task GetConfig_WhenConfigSet_ReturnsSessionStateWithoutAuthorizationEndpoint()
     {
-        _config["Oidc:ClientId"].Returns("client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = "client-id";
 
         var result = await _controller.GetConfig(CoStateKey);
 
@@ -174,7 +175,8 @@ public class OidcControllerTests
         var testEnv = Substitute.For<IWebHostEnvironment>();
         testEnv.EnvironmentName.Returns("Development");
         var controller = new OidcController(
-            _config,
+            _oidcSettings,
+            _oidcStepUpSettings,
             NullLogger<OidcController>.Instance,
             _callbackFailureLogger,
             _userRepository,
@@ -200,7 +202,7 @@ public class OidcControllerTests
     {
         // No config mocked — we only care that we get past the allowlist into the
         // "no config" 503 path, which proves the check itself accepted the input.
-        _config["Oidc:ClientId"].Returns((string?)null);
+        _oidcSettings.Value.ClientId = null;
 
         var result = await _controller.GetConfig("CO");
 
@@ -223,7 +225,7 @@ public class OidcControllerTests
     public async Task CompleteLogin_WhenSigningKeyNotConfigured_Returns503()
     {
         SetupPreAuthSession();
-        _config["Oidc:CompleteLoginSigningKey"].Returns((string?)null);
+        _oidcSettings.Value.CompleteLoginSigningKey = null;
         var body = new CompleteLoginRequest(CoStateKey, "some.jwt.token");
 
         var result = await _controller.CompleteLogin(body, CancellationToken.None);
@@ -237,7 +239,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession();
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateCallbackTokenWithClaims(signingKey, new Claim("given_name", "Pat"));
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -254,7 +256,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession();
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -289,7 +291,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession(isStepUp: true);
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "new-user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken, IsStepUp: true);
@@ -317,7 +319,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession(isStepUp: true, returnUrl: "/profile/address?q=1");
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         // Step-up requires verification claims from the IdP — step-up exists to obtain them
         var verificationDate = DateTime.UtcNow.AddDays(-1).ToString("o");
@@ -355,7 +357,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession(isStepUp: true, returnUrl: null);
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var verificationDate = DateTime.UtcNow.AddDays(-1).ToString("o");
         var callbackToken = CreateCallbackTokenWithClaims(signingKey,
@@ -388,7 +390,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession(isStepUp: true);
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -414,7 +416,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession(isStepUp: true);
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -462,7 +464,7 @@ public class OidcControllerTests
             .Returns(true);
 
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
 
         // Body lies: says IsStepUp=true, but session says false
@@ -498,7 +500,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession();
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -523,7 +525,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession(isStepUp: true);
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -548,7 +550,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession();
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateCallbackTokenWithClaims(signingKey,
             new Claim("email", "user@example.com"),
@@ -586,7 +588,7 @@ public class OidcControllerTests
     {
         SetupPreAuthSession();
         const string signingKey = "complete-login-signing-key-at-least-32-characters-long";
-        _config["Oidc:CompleteLoginSigningKey"].Returns(signingKey);
+        _oidcSettings.Value.CompleteLoginSigningKey = signingKey;
 
         var callbackToken = CreateValidCallbackToken(signingKey, email: "user@example.com");
         var body = new CompleteLoginRequest(CoStateKey, callbackToken);
@@ -680,8 +682,7 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenClientIdMissing_RedirectsToLogin()
     {
-        _config["Oidc:ClientId"].Returns((string?)null);
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = null;
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
 
         var result = await _controller.Authorize(CoStateKey, exchangeService: exchangeService);
@@ -693,8 +694,7 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenDiscoveryFails_RedirectsToLogin()
     {
-        _config["Oidc:ClientId"].Returns("client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = "client-id";
         var exchangeService = Substitute.For<IOidcExchangeService>();
         exchangeService.GetDiscoveryConfigAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns<OpenIdConnectConfiguration>(_ => throw new InvalidOperationException("discovery endpoint not configured"));
@@ -708,8 +708,7 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenDiscoveryMissingAuthorizationEndpoint_RedirectsToLogin()
     {
-        _config["Oidc:ClientId"].Returns("client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = "client-id";
         var exchangeService = MockExchangeServiceWithDiscovery(authorizationEndpoint: "");
 
         var result = await _controller.Authorize(CoStateKey, exchangeService: exchangeService);
@@ -722,9 +721,7 @@ public class OidcControllerTests
     public async Task Authorize_WhenConfigured_Returns302WithCorrectUrlAndSetsCookie()
     {
         const string authEndpoint = "https://auth.pingone.com/env-id/as/authorize";
-        _config["Oidc:ClientId"].Returns("test-client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
-        _config["Oidc:LanguageParam"].Returns("en");
+        _oidcSettings.Value.ClientId = "test-client-id";
         var exchangeService = MockExchangeServiceWithDiscovery(authEndpoint);
 
         var result = await _controller.Authorize(CoStateKey, exchangeService: exchangeService);
@@ -756,8 +753,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenConfigured_CreatesPreAuthSessionWithCorrectValues()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
 
         await _controller.Authorize(CoStateKey, stepUp: true, returnUrl: "/profile/address",
@@ -776,8 +773,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpWithUnsafeReturnUrl_StoresNullReturnUrl()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
 
         await _controller.Authorize(CoStateKey, stepUp: true, returnUrl: "https://evil.example/phish",
@@ -796,8 +793,7 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenNotStepUp_IgnoresReturnUrl()
     {
-        _config["Oidc:ClientId"].Returns("test-client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = "test-client-id";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
 
         await _controller.Authorize(CoStateKey, stepUp: false, returnUrl: "/profile/address",
@@ -820,8 +816,7 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_RedirectUrl_NeverContainsCodeVerifier()
     {
-        _config["Oidc:ClientId"].Returns("test-client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = "test-client-id";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
 
         var result = await _controller.Authorize(CoStateKey, exchangeService: exchangeService);
@@ -838,8 +833,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndUserAlreadyIal1Plus_ShortCircuitsToReturnUrl()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
 
@@ -861,8 +856,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndUserAlreadyIal2_ShortCircuits()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "2", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
 
@@ -877,8 +872,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndIal1Plus_WithNoReturnUrl_ShortCircuitsToDashboard()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
 
@@ -896,8 +891,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndIal1Plus_WithUnsafeReturnUrl_ShortCircuitsToDashboard()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
 
@@ -912,8 +907,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndIal1PlusButExpired_ProceedsToIdp()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddSeconds(-60));
 
@@ -928,8 +923,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndIal1_ProceedsToIdp()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "1", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
 
@@ -944,8 +939,8 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenStepUpAndNoJwt_ProceedsToIdp()
     {
-        _config["Oidc:StepUp:ClientId"].Returns("step-up-client-id");
-        _config["Oidc:StepUp:RedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcStepUpSettings.Value.ClientId = "step-up-client-id";
+        _oidcStepUpSettings.Value.RedirectUri = "http://localhost:3000/callback";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         // HttpContext.User is a default unauthenticated principal — no claims set.
 
@@ -964,8 +959,7 @@ public class OidcControllerTests
     [Fact]
     public async Task Authorize_WhenNotStepUpAndUserAlreadyIal1Plus_StillProceedsToIdp()
     {
-        _config["Oidc:ClientId"].Returns("test-client-id");
-        _config["Oidc:CallbackRedirectUri"].Returns("http://localhost:3000/callback");
+        _oidcSettings.Value.ClientId = "test-client-id";
         var exchangeService = MockExchangeServiceWithDiscovery("https://auth.example.com/authorize");
         SetUser(_controller, ial: "1plus", idProofingExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Configuration/OutageScheduleSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Configuration/OutageScheduleSettingsValidatorTests.cs
@@ -1,5 +1,6 @@
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 
 namespace SEBT.Portal.Tests.Unit.Infrastructure.Configuration;
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Configuration/Validators/OidcSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Configuration/Validators/OidcSettingsValidatorTests.cs
@@ -1,0 +1,69 @@
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Configuration.Validators;
+
+public class OidcSettingsValidatorTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Validate_PassesForNullOrEmptyKeys(string? value)
+    {
+        // Arrange
+        var validator = new OidcSettingsValidator();
+        var settings = CreateTestSettings(value);
+        
+        // Act
+        var result = validator.Validate(name: null, options: settings);
+        
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+    
+    [Theory]
+    [InlineData(1)]
+    [InlineData(31)]
+    public void Validate_FailsForTooShortSigningKey(int charCount)
+    {
+        // Arrange
+        var validator = new OidcSettingsValidator();
+        var settings = CreateTestSettings(new string('x', charCount));
+
+        // Act
+        var result = validator.Validate(name: null, options: settings);
+
+        // Assert
+        Assert.True(result.Failed);
+    }
+
+    [Theory]
+    [InlineData(32)]
+    [InlineData(64)]
+    [InlineData(128)]
+    public void Validate_PassesFor32CharOrGreaterKey(int charCount)
+    {
+        // Arrange
+        var validator = new OidcSettingsValidator();
+        var key = new string('x', charCount);
+        var settings = CreateTestSettings(key);
+        
+        // Act
+        var result = validator.Validate(name: null, options: settings);
+        
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    private static OidcSettings CreateTestSettings(string? key)
+    {
+        return new OidcSettings
+        {
+            DiscoveryEndpoint = "https://example.com/.well-known/openid-configuration",
+            ClientId = "TEST_CLIENT_ID",
+            ClientSecret = "TEST_CLIENT_SECRET",
+            CallbackRedirectUri = "https://example.com/oidc-callback",
+            CompleteLoginSigningKey = key
+        };
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Configuration/Validators/OidcSettingsValidatorTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Configuration/Validators/OidcSettingsValidatorTests.cs
@@ -13,14 +13,14 @@ public class OidcSettingsValidatorTests
         // Arrange
         var validator = new OidcSettingsValidator();
         var settings = CreateTestSettings(value);
-        
+
         // Act
         var result = validator.Validate(name: null, options: settings);
-        
+
         // Assert
         Assert.True(result.Succeeded);
     }
-    
+
     [Theory]
     [InlineData(1)]
     [InlineData(31)]
@@ -47,10 +47,10 @@ public class OidcSettingsValidatorTests
         var validator = new OidcSettingsValidator();
         var key = new string('x', charCount);
         var settings = CreateTestSettings(key);
-        
+
         // Act
         var result = validator.Validate(name: null, options: settings);
-        
+
         // Assert
         Assert.True(result.Succeeded);
     }

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Middleware/OidcOriginValidationMiddlewareTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Middleware/OidcOriginValidationMiddlewareTests.cs
@@ -1,7 +1,8 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using SEBT.Portal.Api.Middleware;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Tests.Helpers;
 
 namespace SEBT.Portal.Tests.Unit.Middleware;
 
@@ -21,14 +22,17 @@ public class OidcOriginValidationMiddlewareTests
         RequestDelegate next,
         string? callbackRedirectUri = AllowedOrigin + "/callback")
     {
-        var configData = new Dictionary<string, string?>();
+        var settings = new OidcSettings();
         if (callbackRedirectUri != null)
-            configData["Oidc:CallbackRedirectUri"] = callbackRedirectUri;
-        var config = new ConfigurationBuilder().AddInMemoryCollection(configData).Build();
+        {
+            settings.CallbackRedirectUri = callbackRedirectUri;
+        }
+
         return new OidcOriginValidationMiddleware(
             next,
             NullLogger<OidcOriginValidationMiddleware>.Instance,
-            config);
+            TestOptions.Snapshot(settings),
+            TestOptions.Snapshot(new OidcStepUpSettings()));
     }
 
     private static DefaultHttpContext CreateContext(string method, string path, string? origin = null)

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Security/IdProofingFailOpenTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Security/IdProofingFailOpenTests.cs
@@ -6,6 +6,7 @@ using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
 using SEBT.Portal.Core.Models.Household;
 using SEBT.Portal.Infrastructure.Configuration;
+using SEBT.Portal.Infrastructure.Configuration.Validators;
 using SEBT.Portal.Infrastructure.Services;
 
 namespace SEBT.Portal.Tests.Unit.Security;

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Services/EmailSenderServiceTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Services/EmailSenderServiceTests.cs
@@ -8,6 +8,11 @@ using SEBT.Portal.Kernel.Results;
 
 namespace SEBT.Portal.Tests.Unit.Services;
 
+// Shares the "Integration" collection so this class — which mutates the process-global
+// STATE env var — never runs in parallel with WebApplicationFactory tests that read STATE
+// at host build (otherwise they intermittently load the wrong appsettings.{state}.json).
+// Root cause (EmailOtpSenderService reading STATE from the environment) is tracked separately.
+[Collection("Integration")]
 public class EmailSenderServiceTests : IDisposable
 {
     private readonly string? _previousState;

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Services/OidcExchangeServiceTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Services/OidcExchangeServiceTests.cs
@@ -1,9 +1,10 @@
 using System.Net;
 using System.Text;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using SEBT.Portal.Api.Services;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Tests.Helpers;
 
 namespace SEBT.Portal.Tests.Unit.Services;
 
@@ -24,15 +25,12 @@ public class OidcExchangeServiceTests
     {
         await using var idp = await LocalOidcDiscoveryServer.StartAsync();
 
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Oidc:DiscoveryEndpoint"] = idp.DiscoveryUrl
-            })
-            .Build();
-
+        var oidcSettings = TestOptions.Snapshot(new OidcSettings { DiscoveryEndpoint = idp.DiscoveryUrl });
+        var oidcStepUpSettings = TestOptions.Snapshot(new OidcStepUpSettings());
+        
         var service = new OidcExchangeService(
-            config,
+            oidcSettings,
+            oidcStepUpSettings,
             Substitute.For<IHttpClientFactory>(),
             NullLogger<OidcExchangeService>.Instance,
             Substitute.For<IOidcCallbackFailureLogger>());
@@ -46,9 +44,12 @@ public class OidcExchangeServiceTests
     [Fact]
     public async Task GetDiscoveryConfigAsync_throws_when_discovery_endpoint_missing()
     {
-        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        var oidcSettings = TestOptions.Snapshot(new OidcSettings());
+        var oidcStepUpSettings = TestOptions.Snapshot(new OidcStepUpSettings());
+        
         var service = new OidcExchangeService(
-            config,
+            oidcSettings,
+            oidcStepUpSettings,
             Substitute.For<IHttpClientFactory>(),
             NullLogger<OidcExchangeService>.Instance,
             Substitute.For<IOidcCallbackFailureLogger>());

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Services/OidcExchangeServiceTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Services/OidcExchangeServiceTests.cs
@@ -27,7 +27,7 @@ public class OidcExchangeServiceTests
 
         var oidcSettings = TestOptions.Snapshot(new OidcSettings { DiscoveryEndpoint = idp.DiscoveryUrl });
         var oidcStepUpSettings = TestOptions.Snapshot(new OidcStepUpSettings());
-        
+
         var service = new OidcExchangeService(
             oidcSettings,
             oidcStepUpSettings,
@@ -46,7 +46,7 @@ public class OidcExchangeServiceTests
     {
         var oidcSettings = TestOptions.Snapshot(new OidcSettings());
         var oidcStepUpSettings = TestOptions.Snapshot(new OidcStepUpSettings());
-        
+
         var service = new OidcExchangeService(
             oidcSettings,
             oidcStepUpSettings,


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-704](https://codeforamerica.atlassian.net/browse/DC-704) — Refactor / break up Program.cs

#### ✍️ Description
Fourth in the DC-704 stack, on #587. Migrates the raw `Oidc:*` config reads to typed options and moves the last inline Program.cs guard into a validator. Behavior-preserving.

**Typed OIDC settings.** New `OidcSettings` (flat, nullable keys — the `?? fallback` chains must survive) plus a small `IOidcCoreSettings` interface that both `OidcSettings` and the existing `OidcStepUpSettings` implement. Consumers now branch once on `stepUp` (`GetSettings(stepUp)`) instead of re-reading string keys at every site. ~15 raw `IConfiguration["Oidc:…"]` reads across `OidcController`, `OidcExchangeService`, `AuthController`, and `OidcOriginValidationMiddleware` become `IOptionsSnapshot<OidcSettings>` / `IOptionsSnapshot<OidcStepUpSettings>`.

**Signing-key check → validator.** The inline `Oidc:CompleteLoginSigningKey` length check in `Program.cs` moves to `OidcSettingsValidator` (`IValidateOptions<OidcSettings>`) with `ValidateOnStart`. Same contract, faithfully ported: length is **chars not bytes**, empty/absent is allowed (states without OIDC still boot), present-and-<32 fails. Runs in **all environments**, not prod-gated — matches the original.

**Included cleanups.** `OidcStepUpSettings` gains a `ClientSecret` property (previously read raw as `Oidc:StepUp:ClientSecret` with no backing prop). Dropped the dead `Oidc:LanguageParam` read (configured nowhere → always `"en"`). Grouped the 8 settings validators under `Configuration/Validators/`. New `TestOptions.Snapshot<T>` test helper — a dependency-free `IOptionsSnapshot<T>` wrapper (the framework has no `Options.Create` analog for snapshots).

**Also rides along.** Closes a pre-existing STATE-env test race by enrolling `EmailSenderServiceTests` in the `Integration` collection (root cause — `EmailOtpSenderService` reading `STATE` from the process env — tracked separately). Pins `SSH.NET` to clear the `NuGetAudit` advisory blocking restore (team fix, cherry-picked).

Tests green. No new config keys, secrets, or env vars.

#### 🔍 Where to look
- **Behavior preservation is the bar** — the whole PR is a raw-string → typed swap, so the question at every site is "does the typed read return exactly what the string key did, including null/empty edges."
- **`OidcController.cs`** — the step-up `redirectUri` branch collapsed to `GetOidcSettings(stepUp).RedirectUri ?? CallbackRedirectUri`. Equivalent *only because* `OidcSettings` maps `IOidcCoreSettings.RedirectUri => CallbackRedirectUri`; confirm that mapping.
- **`OidcExchangeService.cs`** — `signingKey` is deliberately read portal-level (not per-flow); step-up `clientSecret` now sources from the new `OidcStepUpSettings.ClientSecret`. `PortalOrigin` preserves the `?? "sebt-portal"` symmetric-issuer fallback.
- **Dropped `Oidc:LanguageParam`** — verified dead in repo config; worth a second set of eyes that no deployed env sets `Oidc__LanguageParam`.
- OIDC callback deep-path coverage lives in the Docker/CI integration suite; the unit tests here cover the discovery / config-missing edges.

#### 🔗 Links to related PRs
- Stacked on #587 (PR 3). Merge order: #581 → #584 → #587 → this.

#### ✅ Completion tasks
- [x] Added relevant tests — new validator unit tests + startup-validation integration test; consumer tests migrated to typed options
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes: **none** — no new env vars, secrets, or appsettings (typed `OidcSettings` binds the existing `Oidc` section)


[DC-704]: https://codeforamerica.atlassian.net/browse/DC-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ