### PR TITLE
DC-709(Chore): Add unit coverage for database user and doc-verification repositories

### DIFF
--- a/apps/portal/src/SEBT.Portal.Infrastructure/Repositories/UserEncryptedFieldMapper.cs
+++ b/apps/portal/src/SEBT.Portal.Infrastructure/Repositories/UserEncryptedFieldMapper.cs
@@ -6,6 +6,9 @@ using SEBT.Portal.Infrastructure.Data.Entities;
 
 namespace SEBT.Portal.Infrastructure.Repositories;
 
+/// <summary>
+/// Maps encrypted <see cref="UserEntity"/> columns to and from the <see cref="User"/> domain model.
+/// </summary>
 internal static class UserEncryptedFieldMapper
 {
     internal static User ToDomain(UserEntity entity, IPiiSymmetricEncryption crypto)

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/DatabaseDocVerificationChallengeRepositoryUnitTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/DatabaseDocVerificationChallengeRepositoryUnitTests.cs
@@ -1,0 +1,255 @@
+using Microsoft.EntityFrameworkCore;
+using SEBT.Portal.Core.Models.DocVerification;
+using SEBT.Portal.Infrastructure.Data;
+using SEBT.Portal.Infrastructure.Data.Entities;
+using SEBT.Portal.Infrastructure.Repositories;
+using SEBT.Portal.Tests.Unit.TestSupport;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Repositories;
+
+/// <summary>
+/// InMemory unit tests for <see cref="DatabaseDocVerificationChallengeRepository"/>.
+/// </summary>
+public class DatabaseDocVerificationChallengeRepositoryUnitTests
+{
+    private static PortalDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new PortalDbContext(options);
+    }
+
+    private static DatabaseDocVerificationChallengeRepository CreateRepository(PortalDbContext context) =>
+        new(context, TestPortalCryptography.PiiSymmetricEncryption);
+
+    private static async Task<UserEntity> SeedUserAsync(PortalDbContext context)
+    {
+        var user = new UserEntity();
+        context.Users.Add(user);
+        await context.SaveChangesAsync();
+        return user;
+    }
+
+    private static async Task<DocVerificationChallengeEntity> SeedChallengeAsync(
+        PortalDbContext context,
+        Guid userId,
+        Action<DocVerificationChallengeEntity>? customize = null)
+    {
+        var entity = new DocVerificationChallengeEntity
+        {
+            PublicId = Guid.NewGuid(),
+            UserId = userId,
+            Status = (int)DocVerificationStatus.Pending,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30)
+        };
+        customize?.Invoke(entity);
+        context.DocVerificationChallenges.Add(entity);
+        await context.SaveChangesAsync();
+        return entity;
+    }
+
+    [Fact]
+    public async Task GetByPublicIdAsync_whenOwnedByUser_returnsChallenge()
+    {
+        using var context = CreateContext();
+        var user = await SeedUserAsync(context);
+        var entity = await SeedChallengeAsync(context, user.Id, c =>
+        {
+            c.ProofingIdType = TestPortalCryptography.PiiSymmetricEncryption.Encrypt("ssn");
+        });
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetByPublicIdAsync(entity.PublicId, user.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(entity.Id, result!.Id);
+        Assert.Equal("ssn", result.ProofingIdType);
+    }
+
+    [Fact]
+    public async Task GetByPublicIdAsync_whenDifferentUser_returnsNull()
+    {
+        using var context = CreateContext();
+        var owner = await SeedUserAsync(context);
+        var other = await SeedUserAsync(context);
+        var entity = await SeedChallengeAsync(context, owner.Id);
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetByPublicIdAsync(entity.PublicId, other.Id);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetBySocureReferenceIdAsync_whenExists_returnsChallenge()
+    {
+        using var context = CreateContext();
+        var user = await SeedUserAsync(context);
+        await SeedChallengeAsync(context, user.Id, c => c.SocureReferenceId = "ref-1");
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetBySocureReferenceIdAsync("ref-1");
+
+        Assert.NotNull(result);
+        Assert.Equal("ref-1", result!.SocureReferenceId);
+    }
+
+    [Fact]
+    public async Task GetBySocureReferenceIdAsync_whenMissingOrBlank_returnsNull()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        Assert.Null(await repo.GetBySocureReferenceIdAsync("missing"));
+        Assert.Null(await repo.GetBySocureReferenceIdAsync("  "));
+        Assert.Null(await repo.GetBySocureReferenceIdAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetByEvalIdAsync_whenExists_returnsChallenge()
+    {
+        using var context = CreateContext();
+        var user = await SeedUserAsync(context);
+        await SeedChallengeAsync(context, user.Id, c => c.EvalId = "eval-1");
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetByEvalIdAsync("eval-1");
+
+        Assert.NotNull(result);
+        Assert.Equal("eval-1", result!.EvalId);
+    }
+
+    [Fact]
+    public async Task GetByEvalIdAsync_whenMissingOrBlank_returnsNull()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        Assert.Null(await repo.GetByEvalIdAsync("missing"));
+        Assert.Null(await repo.GetByEvalIdAsync("  "));
+    }
+
+    [Fact]
+    public async Task GetActiveByUserIdAsync_whenPendingAndUnexpired_returnsChallenge()
+    {
+        using var context = CreateContext();
+        var user = await SeedUserAsync(context);
+        var entity = await SeedChallengeAsync(context, user.Id);
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetActiveByUserIdAsync(user.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(entity.Id, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetLatestSocureReferenceIdByUserIdAsync_returnsMostRecent()
+    {
+        using var context = CreateContext();
+        var user = await SeedUserAsync(context);
+        var older = DateTime.UtcNow.AddHours(-2);
+        var newer = DateTime.UtcNow.AddHours(-1);
+        await SeedChallengeAsync(context, user.Id, c =>
+        {
+            c.SocureReferenceId = "ref-old";
+            c.CreatedAt = older;
+            c.Status = (int)DocVerificationStatus.Rejected;
+        });
+        await SeedChallengeAsync(context, user.Id, c =>
+        {
+            c.SocureReferenceId = "ref-new";
+            c.CreatedAt = newer;
+            c.Status = (int)DocVerificationStatus.Verified;
+        });
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetLatestSocureReferenceIdByUserIdAsync(user.Id);
+
+        Assert.Equal("ref-new", result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_whenChallengeIsNull_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => repo.CreateAsync(null!));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_whenChallengeIsNull_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => repo.UpdateAsync(null!));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_whenMissing_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+        var challenge = new DocVerificationChallenge { UserId = Guid.NewGuid() };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => repo.UpdateAsync(challenge));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_persistsFieldsAndEncryptsProofingPii()
+    {
+        using var context = CreateContext();
+        var user = await SeedUserAsync(context);
+        var entity = await SeedChallengeAsync(context, user.Id);
+        var repo = CreateRepository(context);
+        var issuedAt = DateTime.UtcNow.AddMinutes(-5);
+        var challenge = DocVerificationChallenge.Reconstitute(
+            id: entity.Id,
+            publicId: entity.PublicId,
+            userId: user.Id,
+            status: DocVerificationStatus.Pending,
+            socureReferenceId: "ref-updated",
+            evalId: "eval-updated",
+            socureEventId: "event-1",
+            docvTransactionToken: "token-1",
+            docvUrl: "https://example.test/docv",
+            offboardingReason: null,
+            allowIdRetry: false,
+            createdAt: entity.CreatedAt,
+            updatedAt: entity.UpdatedAt,
+            expiresAt: entity.ExpiresAt,
+            proofingDateOfBirth: "1990-04-15",
+            proofingIdType: "ssn",
+            proofingIdValue: "last4",
+            docvTokenIssuedAt: issuedAt);
+
+        await repo.UpdateAsync(challenge);
+
+        var stored = await context.DocVerificationChallenges.AsNoTracking()
+            .SingleAsync(c => c.Id == entity.Id);
+        Assert.Equal("ref-updated", stored.SocureReferenceId);
+        Assert.Equal("eval-updated", stored.EvalId);
+        Assert.Equal("event-1", stored.SocureEventId);
+        Assert.Equal("token-1", stored.DocvTransactionToken);
+        Assert.Equal("https://example.test/docv", stored.DocvUrl);
+        Assert.False(stored.AllowIdRetry);
+        Assert.Equal(issuedAt, stored.DocvTokenIssuedAt);
+        Assert.Equal(
+            "1990-04-15",
+            TestPortalCryptography.PiiSymmetricEncryption.DecryptOrPassThroughLegacy(
+                stored.ProofingDateOfBirth));
+        Assert.Equal(
+            "ssn",
+            TestPortalCryptography.PiiSymmetricEncryption.DecryptOrPassThroughLegacy(
+                stored.ProofingIdType));
+        Assert.Equal(
+            "last4",
+            TestPortalCryptography.PiiSymmetricEncryption.DecryptOrPassThroughLegacy(
+                stored.ProofingIdValue));
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/DatabaseUserRepositoryUnitTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/DatabaseUserRepositoryUnitTests.cs
@@ -246,6 +246,33 @@ public class DatabaseUserRepositoryUnitTests
     }
 
     [Fact]
+    public async Task UpdateUserAsync_whenEmailCollidesWithEnvelopeOrphan_throws()
+    {
+        using var context = CreateContext();
+        var takenEmail = "taken@example.com";
+        context.Users.Add(new UserEntity
+        {
+            Email = TestPortalCryptography.PiiSymmetricEncryption.Encrypt(takenEmail),
+            EmailHash = null
+        });
+        var updater = new UserEntity
+        {
+            Email = "other@example.com",
+            EmailHash = TestPortalCryptography.EmailLookupHasher.HashNormalized("other@example.com")
+        };
+        context.Users.Add(updater);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => repo.UpdateUserAsync(new User { Id = updater.Id, Email = takenEmail }));
+
+        Assert.Equal("A user with this email address already exists.", ex.Message);
+        var stored = await context.Users.SingleAsync(u => u.Id == updater.Id);
+        Assert.Equal("other@example.com", stored.Email);
+    }
+
+    [Fact]
     public async Task GetUserByEmailAsync_whenLookupHashIsNull_returnsNull()
     {
         using var context = CreateContext();

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/DatabaseUserRepositoryUnitTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/DatabaseUserRepositoryUnitTests.cs
@@ -1,0 +1,376 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using SEBT.Portal.Core.AppSettings;
+using SEBT.Portal.Core.Exceptions;
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Services;
+using SEBT.Portal.Infrastructure.Data;
+using SEBT.Portal.Infrastructure.Data.Entities;
+using SEBT.Portal.Infrastructure.Repositories;
+using SEBT.Portal.Infrastructure.Services;
+using SEBT.Portal.Tests.Unit.TestSupport;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Repositories;
+
+/// <summary>
+/// InMemory unit tests for <see cref="DatabaseUserRepository"/>.
+/// </summary>
+public class DatabaseUserRepositoryUnitTests
+{
+    private static readonly IIdentifierHasher Hasher = new IdentifierHasher(
+        Options.Create(new IdentifierHasherSettings
+        {
+            SecretKey = TestPortalCryptography.TestIdentifierHasherSecretKey
+        }));
+
+    private static PortalDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new PortalDbContext(options);
+    }
+
+    private static DatabaseUserRepository CreateRepository(
+        PortalDbContext context,
+        IEmailLookupHasher? lookup = null,
+        IPiiSymmetricEncryption? crypto = null) =>
+        new(
+            context,
+            Hasher,
+            crypto ?? TestPortalCryptography.PiiSymmetricEncryption,
+            lookup ?? TestPortalCryptography.EmailLookupHasher);
+
+    [Fact]
+    public async Task GetUserByIdAsync_whenUserExists_returnsUser()
+    {
+        using var context = CreateContext();
+        var entity = new UserEntity { ExternalProviderId = "sub-1" };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetUserByIdAsync(entity.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(entity.Id, result!.Id);
+        Assert.Equal("sub-1", result.ExternalProviderId);
+    }
+
+    [Fact]
+    public async Task GetUserByIdAsync_whenMissingOrEmpty_returnsNull()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        Assert.Null(await repo.GetUserByIdAsync(Guid.NewGuid()));
+        Assert.Null(await repo.GetUserByIdAsync(Guid.Empty));
+    }
+
+    [Fact]
+    public async Task GetUserByExternalIdAsync_whenUserExists_returnsUser()
+    {
+        using var context = CreateContext();
+        var entity = new UserEntity { ExternalProviderId = "oidc-sub" };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetUserByExternalIdAsync("oidc-sub");
+
+        Assert.NotNull(result);
+        Assert.Equal(entity.Id, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetUserByExternalIdAsync_whenMissingOrBlank_returnsNull()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        Assert.Null(await repo.GetUserByExternalIdAsync("missing"));
+        Assert.Null(await repo.GetUserByExternalIdAsync("  "));
+        Assert.Null(await repo.GetUserByExternalIdAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserByExternalIdAsync_whenMissing_createsUser()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        var (user, isNew) = await repo.GetOrCreateUserByExternalIdAsync("new-sub");
+
+        Assert.True(isNew);
+        Assert.Equal("new-sub", user.ExternalProviderId);
+        Assert.NotNull(await context.Users.SingleAsync(u => u.ExternalProviderId == "new-sub"));
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserByExternalIdAsync_whenExists_returnsExisting()
+    {
+        using var context = CreateContext();
+        var entity = new UserEntity { ExternalProviderId = "existing-sub" };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var (user, isNew) = await repo.GetOrCreateUserByExternalIdAsync("existing-sub");
+
+        Assert.False(isNew);
+        Assert.Equal(entity.Id, user.Id);
+        Assert.Equal(1, await context.Users.CountAsync());
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserByExternalIdAsync_whenLegacyEmailUser_adoptsRecord()
+    {
+        using var context = CreateContext();
+        var email = "legacy@example.com";
+        var entity = new UserEntity
+        {
+            Email = email,
+            EmailHash = TestPortalCryptography.EmailLookupHasher.HashNormalized(email),
+            ExternalProviderId = null
+        };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var (user, isNew) = await repo.GetOrCreateUserByExternalIdAsync("oidc-sub", email);
+
+        Assert.False(isNew);
+        Assert.Equal(entity.Id, user.Id);
+        var stored = await context.Users.SingleAsync(u => u.Id == entity.Id);
+        Assert.Equal("oidc-sub", stored.ExternalProviderId);
+        Assert.Null(stored.Email);
+        Assert.Null(stored.EmailHash);
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserByExternalIdAsync_whenLegacyAlreadyHasExternalId_createsNew()
+    {
+        using var context = CreateContext();
+        var email = "taken@example.com";
+        context.Users.Add(new UserEntity
+        {
+            Email = email,
+            EmailHash = TestPortalCryptography.EmailLookupHasher.HashNormalized(email),
+            ExternalProviderId = "already-bound"
+        });
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var (user, isNew) = await repo.GetOrCreateUserByExternalIdAsync("new-sub", email);
+
+        Assert.True(isNew);
+        Assert.Equal("new-sub", user.ExternalProviderId);
+        Assert.Equal(2, await context.Users.CountAsync());
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserByExternalIdAsync_whenExternalIdBlank_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => repo.GetOrCreateUserByExternalIdAsync("  "));
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_whenOnlyExternalProviderId_persists()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+        var user = new User { ExternalProviderId = "oidc-only" };
+
+        await repo.CreateUserAsync(user);
+
+        var stored = await context.Users.SingleAsync(u => u.Id == user.Id);
+        Assert.Equal("oidc-only", stored.ExternalProviderId);
+        Assert.Null(stored.Email);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_whenEmailAndExternalIdMissing_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => repo.CreateUserAsync(new User()));
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_whenIdEmpty_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => repo.UpdateUserAsync(new User { Id = Guid.Empty, Email = "a@example.com" }));
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_whenEmailIsNull_leavesEmailColumns()
+    {
+        using var context = CreateContext();
+        var email = "keep@example.com";
+        var hash = TestPortalCryptography.EmailLookupHasher.HashNormalized(email);
+        var entity = new UserEntity
+        {
+            Email = email,
+            EmailHash = hash,
+            Phone = "old"
+        };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        await repo.UpdateUserAsync(new User
+        {
+            Id = entity.Id,
+            Email = null,
+            Phone = "phone-ext",
+            CreatedAt = entity.CreatedAt
+        });
+
+        var stored = await context.Users.SingleAsync(u => u.Id == entity.Id);
+        Assert.Equal(email, stored.Email);
+        Assert.Equal(hash, stored.EmailHash);
+        Assert.Equal(
+            "phone-ext",
+            TestPortalCryptography.PiiSymmetricEncryption.DecryptOrPassThroughLegacy(stored.Phone));
+    }
+
+    [Fact]
+    public async Task GetUserByEmailAsync_whenLookupHashIsNull_returnsNull()
+    {
+        using var context = CreateContext();
+        var lookup = Substitute.For<IEmailLookupHasher>();
+        lookup.HashNormalized(Arg.Any<string?>()).Returns((string?)null);
+        var repo = CreateRepository(context, lookup);
+
+        var result = await repo.GetUserByEmailAsync("person@example.com");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetUserByEmailAsync_whenEnvelopeOrphanDecryptFails_returnsNull()
+    {
+        using var context = CreateContext();
+        var crypto = Substitute.For<IPiiSymmetricEncryption>();
+        crypto.DecryptOrPassThroughLegacy(Arg.Any<string?>())
+            .Returns(_ => throw new PiiDecryptException("tampered"));
+        context.Users.Add(new UserEntity
+        {
+            Email = PiiAesGcmSymmetricEncryption.EnvelopePrefix + "orphan",
+            EmailHash = null
+        });
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context, crypto: crypto);
+
+        var result = await repo.GetUserByEmailAsync("person@example.com");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetUserByEmailAsync_whenUserExistsByHash_returnsUser()
+    {
+        using var context = CreateContext();
+        var email = "hashed@example.com";
+        context.Users.Add(new UserEntity
+        {
+            Email = TestPortalCryptography.PiiSymmetricEncryption.Encrypt(email),
+            EmailHash = TestPortalCryptography.EmailLookupHasher.HashNormalized(email)
+        });
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetUserByEmailAsync(email);
+
+        Assert.NotNull(result);
+        Assert.Equal(email, result!.Email);
+    }
+
+    [Fact]
+    public async Task GetUserByEmailAsync_whenEmailBlank_returnsNull()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        Assert.Null(await repo.GetUserByEmailAsync(null!));
+        Assert.Null(await repo.GetUserByEmailAsync("  "));
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserAsync_whenMissing_createsUser()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        var (user, isNew) = await repo.GetOrCreateUserAsync("new@example.com");
+
+        Assert.True(isNew);
+        Assert.Equal("new@example.com", user.Email);
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserAsync_whenExists_returnsExisting()
+    {
+        using var context = CreateContext();
+        var email = "existing@example.com";
+        var entity = new UserEntity
+        {
+            Email = email,
+            EmailHash = TestPortalCryptography.EmailLookupHasher.HashNormalized(email)
+        };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var (user, isNew) = await repo.GetOrCreateUserAsync(email);
+
+        Assert.False(isNew);
+        Assert.Equal(entity.Id, user.Id);
+        Assert.Equal(1, await context.Users.CountAsync());
+    }
+
+    [Fact]
+    public async Task GetOrCreateUserAsync_whenEmailBlank_throws()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => repo.GetOrCreateUserAsync("  "));
+    }
+
+    [Fact]
+    public async Task GetUserBySessionIdAsync_whenExists_returnsUser()
+    {
+        using var context = CreateContext();
+        var entity = new UserEntity { IdProofingSessionId = "session-abc" };
+        context.Users.Add(entity);
+        await context.SaveChangesAsync();
+        var repo = CreateRepository(context);
+
+        var result = await repo.GetUserBySessionIdAsync("session-abc");
+
+        Assert.NotNull(result);
+        Assert.Equal(entity.Id, result!.Id);
+    }
+
+    [Fact]
+    public async Task GetUserBySessionIdAsync_whenMissingOrBlank_returnsNull()
+    {
+        using var context = CreateContext();
+        var repo = CreateRepository(context);
+
+        Assert.Null(await repo.GetUserBySessionIdAsync("missing"));
+        Assert.Null(await repo.GetUserBySessionIdAsync("  "));
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/UserEncryptedFieldMapperTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Infrastructure/Repositories/UserEncryptedFieldMapperTests.cs
@@ -1,0 +1,216 @@
+using NSubstitute;
+using SEBT.Portal.Core.Models.Auth;
+using SEBT.Portal.Core.Services;
+using SEBT.Portal.Infrastructure.Data.Entities;
+using SEBT.Portal.Infrastructure.Repositories;
+using SEBT.Portal.Tests.Unit.TestSupport;
+
+namespace SEBT.Portal.Tests.Unit.Infrastructure.Repositories;
+
+/// <summary>
+/// Unit tests for <see cref="UserEncryptedFieldMapper"/>. No database required.
+/// </summary>
+public class UserEncryptedFieldMapperTests
+{
+    private static readonly IPiiSymmetricEncryption Crypto =
+        TestPortalCryptography.PiiSymmetricEncryption;
+
+    private static readonly IEmailLookupHasher Lookup =
+        TestPortalCryptography.EmailLookupHasher;
+
+    [Fact]
+    public void ToDomain_roundTripsEncryptedFields()
+    {
+        var id = Guid.CreateVersion7();
+        var createdAt = DateTime.UtcNow.AddDays(-2);
+        var updatedAt = DateTime.UtcNow.AddDays(-1);
+        var completedAt = DateTime.UtcNow.AddHours(-3);
+        var coLoadedAt = DateTime.UtcNow.AddDays(-5);
+        var dob = new DateOnly(1990, 4, 15);
+
+        var entity = new UserEntity
+        {
+            Id = id,
+            Email = Crypto.Encrypt("person@example.com"),
+            EmailHash = Lookup.NormalizeAndHash("person@example.com"),
+            ExternalProviderId = "oidc-sub",
+            IdProofingStatus = (int)IdProofingStatus.Completed,
+            IalLevel = (int)UserIalLevel.IAL1plus,
+            IdProofingSessionId = "session-1",
+            IdProofingCompletedAt = completedAt,
+            DateOfBirth = Crypto.Encrypt("1990-04-15"),
+            IsCoLoaded = true,
+            CoLoadedLastUpdated = coLoadedAt,
+            Phone = Crypto.Encrypt("phone-ext"),
+            SnapId = Crypto.Encrypt("SNAP1"),
+            TanfId = Crypto.Encrypt("TANF1"),
+            Ssn = "stored-hash",
+            IdProofingAttemptCount = 2,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt
+        };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, Crypto);
+
+        Assert.Equal(id, user.Id);
+        Assert.Equal("person@example.com", user.Email);
+        Assert.Equal("oidc-sub", user.ExternalProviderId);
+        Assert.Equal(IdProofingStatus.Completed, user.IdProofingStatus);
+        Assert.Equal(UserIalLevel.IAL1plus, user.IalLevel);
+        Assert.Equal("session-1", user.IdProofingSessionId);
+        Assert.Equal(completedAt, user.IdProofingCompletedAt);
+        Assert.Equal(dob, user.DateOfBirth);
+        Assert.True(user.IsCoLoaded);
+        Assert.Equal(coLoadedAt, user.CoLoadedLastUpdated);
+        Assert.Equal("phone-ext", user.Phone);
+        Assert.Equal("SNAP1", user.SnapId);
+        Assert.Equal("TANF1", user.TanfId);
+        Assert.Equal("stored-hash", user.Ssn);
+        Assert.Equal(2, user.IdProofingAttemptCount);
+        Assert.Equal(createdAt, user.CreatedAt);
+        Assert.Equal(updatedAt, user.UpdatedAt);
+    }
+
+    [Fact]
+    public void ToDomain_whenEmailIsEmpty_returnsNullEmail()
+    {
+        var entity = new UserEntity { Email = null };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, Crypto);
+
+        Assert.Null(user.Email);
+    }
+
+    [Fact]
+    public void ToDomain_normalizesDecryptedEmail()
+    {
+        var entity = new UserEntity { Email = Crypto.Encrypt("  Person@Example.COM  ") };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, Crypto);
+
+        Assert.Equal("person@example.com", user.Email);
+    }
+
+    [Fact]
+    public void ToDomain_whenDateOfBirthIsEmpty_returnsNull()
+    {
+        var entity = new UserEntity { DateOfBirth = null };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, Crypto);
+
+        Assert.Null(user.DateOfBirth);
+    }
+
+    [Fact]
+    public void ToDomain_parsesNonExactDateOfBirth()
+    {
+        var entity = new UserEntity { DateOfBirth = Crypto.Encrypt("1990/04/15") };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, Crypto);
+
+        Assert.Equal(new DateOnly(1990, 4, 15), user.DateOfBirth);
+    }
+
+    [Fact]
+    public void ToDomain_whenDateOfBirthIsUnparseable_returnsNull()
+    {
+        var entity = new UserEntity { DateOfBirth = Crypto.Encrypt("not-a-date") };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, Crypto);
+
+        Assert.Null(user.DateOfBirth);
+    }
+
+    [Fact]
+    public void ToDomain_whenDecryptedDateOfBirthIsWhitespace_returnsNull()
+    {
+        var crypto = Substitute.For<IPiiSymmetricEncryption>();
+        crypto.DecryptOrPassThroughLegacy("stored").Returns("   ");
+
+        var entity = new UserEntity { DateOfBirth = "stored" };
+
+        var user = UserEncryptedFieldMapper.ToDomain(entity, crypto);
+
+        Assert.Null(user.DateOfBirth);
+    }
+
+    [Fact]
+    public void EncryptIdentifiers_whenIncludeEmailColumns_writesEmailAndHash()
+    {
+        var entity = new UserEntity();
+        var user = new User
+        {
+            Email = "Person@Example.COM",
+            Phone = "phone-ext",
+            SnapId = "SNAP1",
+            TanfId = "TANF1",
+            DateOfBirth = new DateOnly(1990, 4, 15)
+        };
+
+        UserEncryptedFieldMapper.EncryptIdentifiers(
+            entity, user, Crypto, Lookup, includeEmailColumns: true);
+
+        Assert.Equal("person@example.com", Crypto.DecryptOrPassThroughLegacy(entity.Email));
+        Assert.Equal(Lookup.NormalizeAndHash("Person@Example.COM"), entity.EmailHash);
+        Assert.Equal("phone-ext", Crypto.DecryptOrPassThroughLegacy(entity.Phone));
+        Assert.Equal("SNAP1", Crypto.DecryptOrPassThroughLegacy(entity.SnapId));
+        Assert.Equal("TANF1", Crypto.DecryptOrPassThroughLegacy(entity.TanfId));
+        Assert.Equal("1990-04-15", Crypto.DecryptOrPassThroughLegacy(entity.DateOfBirth));
+    }
+
+    [Fact]
+    public void EncryptIdentifiers_whenEmailMissing_clearsEmailColumns()
+    {
+        var entity = new UserEntity
+        {
+            Email = "leftover",
+            EmailHash = "leftover-hash"
+        };
+        var user = new User { Email = null };
+
+        UserEncryptedFieldMapper.EncryptIdentifiers(
+            entity, user, Crypto, Lookup, includeEmailColumns: true);
+
+        Assert.Null(entity.Email);
+        Assert.Null(entity.EmailHash);
+    }
+
+    [Fact]
+    public void EncryptIdentifiers_whenIncludeEmailColumnsIsFalse_leavesEmailColumns()
+    {
+        var entity = new UserEntity
+        {
+            Email = "keep-me",
+            EmailHash = "keep-hash"
+        };
+        var user = new User
+        {
+            Email = "ignored@example.com",
+            Phone = "phone-ext"
+        };
+
+        UserEncryptedFieldMapper.EncryptIdentifiers(
+            entity, user, Crypto, Lookup, includeEmailColumns: false);
+
+        Assert.Equal("keep-me", entity.Email);
+        Assert.Equal("keep-hash", entity.EmailHash);
+        Assert.Equal("phone-ext", Crypto.DecryptOrPassThroughLegacy(entity.Phone));
+    }
+
+    [Fact]
+    public void ClearEmailColumns_nullsEmailAndHash()
+    {
+        var entity = new UserEntity
+        {
+            Email = "keep-me",
+            EmailHash = "keep-hash",
+            Phone = "unchanged"
+        };
+
+        UserEncryptedFieldMapper.ClearEmailColumns(entity);
+
+        Assert.Null(entity.Email);
+        Assert.Null(entity.EmailHash);
+        Assert.Equal("unchanged", entity.Phone);
+    }
+}

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseDocVerificationChallengeRepositoryTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseDocVerificationChallengeRepositoryTests.cs
@@ -9,6 +9,10 @@ using SEBT.Portal.Tests.Unit.TestSupport;
 
 namespace SEBT.Portal.Tests.Unit.Repositories;
 
+/// <summary>
+/// SQL Server (Testcontainers) tests for <see cref="DatabaseDocVerificationChallengeRepository"/>.
+/// Tagged <c>Category=SqlServer</c> and excluded from unit-only runs. That is intentional.
+/// </summary>
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class DatabaseDocVerificationChallengeRepositoryTests : IClassFixture<SqlServerTestFixture>
@@ -292,7 +296,50 @@ public class DatabaseDocVerificationChallengeRepositoryTests : IClassFixture<Sql
         };
         context.DocVerificationChallenges.Add(newChallenge);
 
-        // Should not throw — terminal challenges don't count
+        // Should not throw. Terminal challenges don't count.
         await context.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenRowVersionChanged_ThrowsConcurrencyConflictException()
+    {
+        using var seedContext = _fixture.CreateContext();
+        var userId = await SeedChallengeAsync(seedContext,
+            status: (int)DocVerificationStatus.Pending,
+            expiresAt: DateTime.UtcNow.AddMinutes(30));
+        var seeded = await seedContext.DocVerificationChallenges
+            .AsNoTracking()
+            .SingleAsync(c => c.UserId == userId);
+
+        using var context1 = _fixture.CreateContext();
+        using var context2 = _fixture.CreateContext();
+        var crypto = TestPortalCryptography.PiiSymmetricEncryption;
+        var repo1 = new DatabaseDocVerificationChallengeRepository(context1, crypto);
+        var repo2 = new DatabaseDocVerificationChallengeRepository(context2, crypto);
+
+        // Track the same row in both contexts so SaveChanges uses stale rowversions.
+        await context1.DocVerificationChallenges.SingleAsync(c => c.Id == seeded.Id);
+        await context2.DocVerificationChallenges.SingleAsync(c => c.Id == seeded.Id);
+
+        DocVerificationChallenge Domain(string referenceId) =>
+            DocVerificationChallenge.Reconstitute(
+                id: seeded.Id,
+                publicId: seeded.PublicId,
+                userId: userId,
+                status: DocVerificationStatus.Pending,
+                socureReferenceId: referenceId,
+                evalId: null,
+                socureEventId: null,
+                docvTransactionToken: null,
+                docvUrl: null,
+                offboardingReason: null,
+                allowIdRetry: true,
+                createdAt: seeded.CreatedAt,
+                updatedAt: seeded.UpdatedAt,
+                expiresAt: seeded.ExpiresAt);
+
+        await repo1.UpdateAsync(Domain("ref-1"));
+
+        await Assert.ThrowsAsync<ConcurrencyConflictException>(() => repo2.UpdateAsync(Domain("ref-2")));
     }
 }

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
@@ -12,6 +12,10 @@ using SEBT.Portal.Tests.Unit.TestSupport;
 
 namespace SEBT.Portal.Tests.Unit.Repositories;
 
+/// <summary>
+/// SQL Server (Testcontainers) tests for DatabaseUserRepository.
+/// Tagged Category=SqlServer and excluded from unit-only runs. That is intentional.
+/// </summary>
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Options;
 using SEBT.Portal.Core.AppSettings;
 using SEBT.Portal.Core.Models.Auth;
@@ -878,6 +879,31 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         Assert.Equal(normalized, user.Email);
     }
 
+    [Fact]
+    public async Task GetOrCreateUserByExternalIdAsync_WhenConcurrentUniqueViolation_ShouldReturnExistingUser()
+    {
+        var externalProviderId = $"oidc-{Guid.NewGuid()}";
+        var interceptor = new InsertCompetingUserOnSaveInterceptor(
+            _fixture.ConnectionString,
+            externalProviderId);
+
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseSqlServer(_fixture.ConnectionString)
+            .AddInterceptors(interceptor)
+            .Options;
+        using var context = new PortalDbContext(options);
+        var repository = CreateRepository(context);
+
+        var (user, isNew) = await repository.GetOrCreateUserByExternalIdAsync(externalProviderId);
+
+        Assert.False(isNew);
+        Assert.Equal(interceptor.CompetingUserId, user.Id);
+        Assert.Equal(externalProviderId, user.ExternalProviderId);
+
+        using var verify = CreateContext();
+        Assert.Equal(1, await verify.Users.CountAsync(u => u.ExternalProviderId == externalProviderId));
+    }
+
     private static async Task<UserEntity?> FindStoredUserWithLegacyPlaintextFallbackAsync(
         PortalDbContext ctx,
         string normalizedEmailPlaintext)
@@ -911,6 +937,50 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
             TestPortalCryptography.PiiSymmetricEncryption.DecryptOrPassThroughLegacy(ciphertextEmail!);
         Assert.False(string.IsNullOrEmpty(plain));
         Assert.Equal(expectedNormalizedPlaintext, plain);
+    }
+
+    /// <summary>
+    /// InMemory has no unique indexes. Seed the competing row on SavingChanges so the insert
+    /// hits IX_Users_ExternalProviderId instead of relying on a timing-dependent race.
+    /// </summary>
+    private sealed class InsertCompetingUserOnSaveInterceptor : SaveChangesInterceptor
+    {
+        private readonly string _connectionString;
+        private readonly string _externalProviderId;
+
+        public InsertCompetingUserOnSaveInterceptor(string connectionString, string externalProviderId)
+        {
+            _connectionString = connectionString;
+            _externalProviderId = externalProviderId;
+        }
+
+        public Guid CompetingUserId { get; private set; }
+
+        public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (CompetingUserId != Guid.Empty)
+            {
+                return result;
+            }
+
+            var options = new DbContextOptionsBuilder<PortalDbContext>()
+                .UseSqlServer(_connectionString)
+                .Options;
+            using var competing = new PortalDbContext(options);
+            var entity = UserFactory.CreateUserEntity(e =>
+            {
+                e.ExternalProviderId = _externalProviderId;
+                e.Email = null;
+                e.EmailHash = null;
+            });
+            CompetingUserId = entity.Id;
+            competing.Users.Add(entity);
+            await competing.SaveChangesAsync(cancellationToken);
+            return result;
+        }
     }
 }
 

--- a/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
+++ b/apps/portal/test/SEBT.Portal.Tests/Unit/Repositories/DatabaseUserRepositoryTests.cs
@@ -904,6 +904,32 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
         Assert.Equal(1, await verify.Users.CountAsync(u => u.ExternalProviderId == externalProviderId));
     }
 
+    [Fact]
+    public async Task GetOrCreateUserAsync_WhenConcurrentUniqueViolation_ShouldReturnExistingUser()
+    {
+        var email = $"race-{Guid.NewGuid()}@example.com";
+        var interceptor = new InsertCompetingEmailUserOnSaveInterceptor(
+            _fixture.ConnectionString,
+            email.ToLowerInvariant());
+
+        var options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseSqlServer(_fixture.ConnectionString)
+            .AddInterceptors(interceptor)
+            .Options;
+        using var context = new PortalDbContext(options);
+        var repository = CreateRepository(context);
+
+        var (user, isNew) = await repository.GetOrCreateUserAsync(email);
+
+        Assert.False(isNew);
+        Assert.Equal(interceptor.CompetingUserId, user.Id);
+        Assert.Equal(email.ToLowerInvariant(), user.Email);
+
+        using var verify = CreateContext();
+        var hash = TestPortalCryptography.EmailLookupHasher.HashNormalized(email.ToLowerInvariant());
+        Assert.Equal(1, await verify.Users.CountAsync(u => u.EmailHash == hash));
+    }
+
     private static async Task<UserEntity?> FindStoredUserWithLegacyPlaintextFallbackAsync(
         PortalDbContext ctx,
         string normalizedEmailPlaintext)
@@ -975,6 +1001,49 @@ public class DatabaseUserRepositoryTests : IClassFixture<SqlServerTestFixture>
                 e.ExternalProviderId = _externalProviderId;
                 e.Email = null;
                 e.EmailHash = null;
+            });
+            CompetingUserId = entity.Id;
+            competing.Users.Add(entity);
+            await competing.SaveChangesAsync(cancellationToken);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Seed a competing EmailHash row on SavingChanges so the insert hits IX_Users_EmailHash
+    /// instead of relying on a timing-dependent race.
+    /// </summary>
+    private sealed class InsertCompetingEmailUserOnSaveInterceptor : SaveChangesInterceptor
+    {
+        private readonly string _connectionString;
+        private readonly string _normalizedEmail;
+
+        public InsertCompetingEmailUserOnSaveInterceptor(string connectionString, string normalizedEmail)
+        {
+            _connectionString = connectionString;
+            _normalizedEmail = normalizedEmail;
+        }
+
+        public Guid CompetingUserId { get; private set; }
+
+        public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (CompetingUserId != Guid.Empty)
+            {
+                return result;
+            }
+
+            var options = new DbContextOptionsBuilder<PortalDbContext>()
+                .UseSqlServer(_connectionString)
+                .Options;
+            using var competing = new PortalDbContext(options);
+            var entity = UserFactory.CreateUserEntity(e =>
+            {
+                e.Email = TestPortalCryptography.PiiSymmetricEncryption.Encrypt(_normalizedEmail);
+                e.EmailHash = TestPortalCryptography.EmailLookupHasher.HashNormalized(_normalizedEmail);
             });
             CompetingUserId = entity.Id;
             competing.Users.Add(entity);


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-709](https://codeforamerica.atlassian.net/browse/DC-709)

#### ✍️ Description
Unit-only runs reported 0% coverage for `DatabaseUserRepository`, `DatabaseDocVerificationChallengeRepository`, and `UserEncryptedFieldMapper` because their tests are tagged `Category=SqlServer`.

This PR adds "In memory" unit tests for logic that does not need SQL Server, and a SqlServer test for `UpdateAsync` conflicts. Existing Testcontainers tests stay tagged `Category=SqlServer`.

Below are the Coverlet reports showing the before/after and resulting delta between the branches.

------

**SEBT.Portal.Infrastructure**

| | main | branch | delta |
|---|---|---|---|
| Line | 38.8% (4448/11451) | 43.3% (4961/11451) | +4.5 pp |
| Branch | 64.9% (1030/1587) | 71.3% (1132/1587) | +6.4 pp |

**Ticket types (file-level line coverage)**

| Type | main | branch | delta |
|---|---|---|---|
| `DatabaseUserRepository` | 0.0% (0/322) | 70.5% (227/322) | +70.5 pp |
| `DatabaseDocVerificationChallengeRepository` | 0.0% (0/163) | 64.4% (105/163) | +64.4 pp |
| `UserEncryptedFieldMapper` | 0.0% (0/71) | 100.0% (71/71) | +100.0 pp |

**Coverlet class-level (parent type only, not async state machines)**

| Type | main line | branch line | main branch | branch branch |
|---|---|---|---|---|
| `DatabaseUserRepository` | 0.0% | 91.2% | 0.0% | 50.0% |
| `DatabaseDocVerificationChallengeRepository` | 0.0% | 53.1% | 100.0% | 100.0% |
| `UserEncryptedFieldMapper` | 0.0% | 100.0% | 0.0% | 100.0% |

**Other Infrastructure files that moved**

| File | main | branch | delta |
|---|---|---|---|
| `PortalDbContextExtensions.cs` | 0.0% | 100.0% | +100.0 pp |
| `EmailLookupHasher.cs` | 0.0% | 92.0% | +92.0 pp |
| `DocVerificationChallengeEntity.cs` | 0.0% | 90.0% | +90.0 pp |
| `UserEntity.cs` | 50.0% | 100.0% | +50.0 pp |
| `PiiPlaintextEncryptionBackfill.cs` | 0.0% | 25.0% | +25.0 pp |
| `Dependencies.cs` | 75.3% | 84.1% | +8.8 pp |
| `PiiAesGcmSymmetricEncryption.cs` | 74.4% | 76.9% | +2.6 pp |

------

#### 🔗 Links to related PRs
None.

#### ✅ Completion tasks
- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [x] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

[DC-709]: https://codeforamerica.atlassian.net/browse/DC-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ