### PR TITLE
DC-701 - fix raw translation keys; unrendered markdown and checker results

### DIFF
--- a/apps/portal/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/NotEnrolledSection.test.tsx
+++ b/apps/portal/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/NotEnrolledSection.test.tsx
@@ -36,6 +36,14 @@ describe('NotEnrolledSection', () => {
     expect(screen.getByText(/Melinda Smith/i)).toBeInTheDocument()
   })
 
+  it('renders the heading emphasis as strong text, not literal asterisks', () => {
+    const { container } = render(<NotEnrolledSection results={notEnrolled} />)
+
+    const heading = screen.getByRole('heading', { level: 4 })
+    expect(heading.textContent).not.toContain('**')
+    expect(container.querySelector('strong')?.textContent).toBe('were NOT enrolled')
+  })
+
   it('renders nothing when empty', () => {
     const { container } = render(<NotEnrolledSection results={[]} />)
     expect(container.firstChild).toBeNull()

--- a/apps/portal/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/NotEnrolledSection.tsx
+++ b/apps/portal/src/SEBT.EnrollmentChecker.Web/src/features/enrollment/components/NotEnrolledSection.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { RichText } from '@sebt/design-system'
 import { useTranslation } from 'react-i18next'
 import type { ChildCheckApiResponse } from '../schemas/enrollmentSchema'
 import { ChildResultCard } from './ChildResultCard'
@@ -14,17 +15,19 @@ export function NotEnrolledSection({ results }: NotEnrolledSectionProps) {
 
   return (
     <section data-testid="not-enrolled-summary-box">
-      <h4 className="usa-summary-box__heading">{t('applyForSebtBody1')}</h4>
+      <h4 className="usa-summary-box__heading">
+        <RichText inline>{t('applyForSebtBody1')}</RichText>
+      </h4>
       <div className="usa-summary-box__text">
         <ul>
-        {results.map(child => (
-          <ChildResultCard
-            key={child.checkId}
-            firstName={child.firstName}
-            lastName={child.lastName}
-            displayStatus="notEnrolled"
-          />
-        ))}
+          {results.map((child) => (
+            <ChildResultCard
+              key={child.checkId}
+              firstName={child.firstName}
+              lastName={child.lastName}
+              displayStatus="notEnrolled"
+            />
+          ))}
         </ul>
       </div>
     </section>

--- a/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/replace/address/page.test.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/replace/address/page.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CardReplaceAddressPage from './page'
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams('case=case-1')
+}))
+
+vi.mock('@/features/address', () => ({
+  AddressFlowProvider: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/features/address/components/AddressForm', () => ({
+  AddressForm: () => <div data-testid="address-form" />
+}))
+
+let mockIsLoading = true
+vi.mock('@/features/household', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/household')>()
+  return {
+    ...actual,
+    useHouseholdData: () => ({ data: undefined, isLoading: mockIsLoading, isError: false })
+  }
+})
+
+describe('CardReplaceAddressPage', () => {
+  beforeEach(() => {
+    mockIsLoading = true
+  })
+
+  it('renders the loading copy, not a raw translation key, while household data loads', () => {
+    render(<CardReplaceAddressPage />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.queryByText('loading')).not.toBeInTheDocument()
+  })
+})

--- a/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/replace/address/page.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/replace/address/page.tsx
@@ -10,7 +10,7 @@ import { Alert } from '@sebt/design-system'
 
 export default function CardReplaceAddressPage() {
   const { t } = useTranslation('confirmInfo')
-  const { t: tCommon } = useTranslation('common')
+  const { t: tDev } = useTranslation('dev')
 
   const searchParams = useSearchParams()
   const { data, isLoading, isError } = useHouseholdData()
@@ -18,7 +18,7 @@ export default function CardReplaceAddressPage() {
   const caseId = searchParams.get('case')
 
   if (isLoading) {
-    return <p>{tCommon('loading')}</p>
+    return <p>{tDev('loading')}</p>
   }
 
   if (isError || !data || !caseId) {

--- a/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/request/page.test.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/request/page.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import RequestReplacementCardsPage from './page'
+
+const mockReplace = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace, push: vi.fn() })
+}))
+
+vi.mock('@/hooks/useFlowStartAnalytics', () => ({
+  useFlowStartAnalytics: vi.fn()
+}))
+
+vi.mock('@/features/address/components/CardSelection', () => ({
+  CardSelection: () => <div data-testid="card-selection" />
+}))
+
+let mockIsLoading = true
+vi.mock('@/features/household', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/household')>()
+  return {
+    ...actual,
+    useHouseholdData: () => ({ data: undefined, isLoading: mockIsLoading, isError: false })
+  }
+})
+
+describe('RequestReplacementCardsPage', () => {
+  beforeEach(() => {
+    mockIsLoading = true
+  })
+
+  it('announces the loading state with authored copy, not a raw translation key', () => {
+    render(<RequestReplacementCardsPage />)
+
+    const status = screen.getByRole('status')
+    expect(status).toHaveTextContent('Loading...')
+    expect(status).not.toHaveTextContent(/^loading$/)
+  })
+})

--- a/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/request/page.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/(authenticated)/cards/request/page.tsx
@@ -11,7 +11,7 @@ import { AnalyticsEvents } from '@sebt/analytics'
 
 export default function RequestReplacementCardsPage() {
   const { t: tOptional } = useTranslation('optionalId')
-  const { t: tCommon } = useTranslation('common')
+  const { t: tDev } = useTranslation('dev')
   const router = useRouter()
   const { data, isLoading } = useHouseholdData()
   const canRequestReplacementCard = data?.allowedActions?.canRequestReplacementCard ?? true
@@ -31,7 +31,7 @@ export default function RequestReplacementCardsPage() {
         aria-busy="true"
         role="status"
       >
-        <span className="usa-sr-only">{tCommon('loading')}</span>
+        <span className="usa-sr-only">{tDev('loading')}</span>
       </div>
     )
   }

--- a/apps/portal/src/SEBT.Portal.Web/src/app/(public)/login/COLoginPage.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/(public)/login/COLoginPage.tsx
@@ -2,7 +2,7 @@
 
 import { AnalyticsEvents, useDataLayer } from '@sebt/analytics'
 import type { StateCode } from '@sebt/design-system'
-import { TextLink, getStateLinks } from '@sebt/design-system'
+import { RichText, TextLink, getStateLinks } from '@sebt/design-system'
 import { useTranslation } from 'react-i18next'
 import { MyColoradoLogo } from './MyColoradoLogo'
 
@@ -56,7 +56,9 @@ export function COLoginPage({ state }: { state: StateCode }) {
             {t('title')}
           </h1>
 
-          <p className="margin-top-4 font-sans-sm">{t('logInDisclaimerBody1')}</p>
+          <p className="margin-top-4 font-sans-sm">
+            <RichText inline>{t('logInDisclaimerBody1')}</RichText>
+          </p>
 
           <div className="margin-top-4">
             <button
@@ -84,8 +86,7 @@ export function COLoginPage({ state }: { state: StateCode }) {
             </button>
           </div>
 
-          <p className="margin-top-4 margin-bottom-1 font-sans-sm">{t('logInDisclaimerBody2')}</p>
-          <p className="margin-top-0 font-sans-sm">
+          <p className="margin-top-4 font-sans-sm">
             <TextLink
               href={links.external.contactUsAssistance}
               target="_blank"

--- a/apps/portal/src/SEBT.Portal.Web/src/app/(public)/login/page.test.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/app/(public)/login/page.test.tsx
@@ -7,84 +7,44 @@
  */
 import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import enCoCommon from '@/content/locales/en/co/common.json'
+import enCoLogin from '@/content/locales/en/co/login.json'
+import esCoCommon from '@/content/locales/es/co/common.json'
+import esCoLogin from '@/content/locales/es/co/login.json'
+
 import LoginPage from './page'
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace: vi.fn(), push: vi.fn() })
 }))
 
-vi.mock('@sebt/design-system', () => ({
-  getState: vi.fn(),
-  getStateLinks: vi.fn().mockReturnValue({
-    external: {
-      contactUsAssistance: 'https://mycolorado.state.co.us/customer-support'
-    }
-  }),
-  TextLink: ({
-    href,
-    children,
-    target,
-    rel
-  }: {
-    href: string
-    children: React.ReactNode
-    target?: string
-    rel?: string
-  }) => (
-    <a
-      href={href}
-      target={target}
-      rel={rel}
-    >
-      {children}
-    </a>
-  )
-}))
+vi.mock('@sebt/design-system', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sebt/design-system')>()
+  return {
+    ...actual,
+    getState: vi.fn(),
+    getStateLinks: vi.fn().mockReturnValue({
+      external: {
+        contactUsAssistance: 'https://mycolorado.state.co.us/customer-support'
+      }
+    })
+  }
+})
 
-// COLoginPage now uses the client-side useTranslation() hook (DC-187 fix).
-// Mock the hook with state-specific copy so CO/DC tests stay isolated from
-// the project's real i18n init (which boots in DC mode for tests).
+// COLoginPage uses the client-side useTranslation() hook. Mock the hook so the
+// CO/DC cases stay isolated from the project's real i18n init (which boots in
+// DC mode for tests), but feed the CO mock the *generated* CO bundles rather
+// than hand-typed copy. Content-sheet syncs rewrite these strings; a fixture
+// that drifts from the real JSON lets unrendered markdown and dropped keys
+// reach production unnoticed. The `?? key` fallback below mirrors i18next's
+// behavior for a missing key, which is what makes a leaked key assertable.
 //
 // `logIn` resolves to the current UI language's label; `logInEsp` resolves to
-// the other language. Mirrors the real locale files in `content/locales/{en,es}/co/common.json`.
+// the other language.
 const CO_TEST_TRANSLATIONS: Record<string, Record<string, Record<string, string>>> = {
-  en: {
-    login: {
-      title: 'Access your Summer EBT account',
-      body: 'Enter your email to receive a one-time code.',
-      logInDisclaimerBody1:
-        'After tapping "Log in" you\'ll be redirected to log in using your myColorado™ account.',
-      logInDisclaimerBody2: 'Having trouble signing into the portal?',
-      logInDisclaimerBody3: 'Contact myColorado® Support',
-      cardTitle: 'About the Summer EBT portal',
-      cardBody1:
-        "The Summer EBT portal is the fastest way to manage your family's Summer EBT benefits without ever making a phone call.\n\nBy creating a secure account, the main parent or guardian on file can:",
-      cardBody2:
-        "Request a new Summer EBT card if their child's is lost, stolen, or damaged.\nUpdate your mailing address so you don't miss important mail.\nCheck benefits and card status for all enrolled children in your household.\nSee the application status for any applications that you submitted.\nOpt-in to email communications about your benefits."
-    },
-    common: {
-      logIn: 'Log in with myColorado™',
-      logInEsp: 'Iniciar sesión con myColorado™'
-    }
-  },
-  es: {
-    login: {
-      title: 'Accede a tu cuenta de Summer EBT',
-      body: 'Ingresa tu correo electrónico para recibir un código.',
-      logInDisclaimerBody1:
-        'Al tocar "Iniciar sesión" serás redirigido a iniciar sesión con tu cuenta myColorado™.',
-      logInDisclaimerBody2: 'Contáctanos si necesitas ayuda para iniciar sesión.',
-      logInDisclaimerBody3: 'Comunícate con la ayuda de myColorado®',
-      cardTitle: 'Sobre el portal de Summer EBT',
-      cardBody1:
-        'El portal de Summer EBT es la forma más rápida de manejar los beneficios de Summer EBT de tu familia.\n\nAl crear una cuenta segura, el padre, madre o tutor principal registrado puede:',
-      cardBody2: 'Pedir una nueva Tarjeta Summer EBT si la de tu niño/a se perdió.'
-    },
-    common: {
-      logIn: 'Iniciar sesión con myColorado™',
-      logInEsp: 'Log in with myColorado™'
-    }
-  }
+  en: { login: enCoLogin, common: enCoCommon },
+  es: { login: esCoLogin, common: esCoCommon }
 }
 
 const DC_TEST_TRANSLATIONS: Record<string, Record<string, Record<string, string>>> = {
@@ -167,7 +127,7 @@ describe('LoginPage', () => {
       render(<LoginPage />)
       expect(
         screen.getByRole('heading', {
-          name: /Access your Summer EBT account/i
+          name: /Access the Summer EBT portal/i
         })
       ).toBeInTheDocument()
     })
@@ -175,25 +135,52 @@ describe('LoginPage', () => {
     it('applies text-primary class to the title', () => {
       render(<LoginPage />)
       const heading = screen.getByRole('heading', {
-        name: /Access your Summer EBT account/i
+        name: /Access the Summer EBT portal/i
       })
       expect(heading).toHaveClass('text-primary')
     })
 
     it('renders the disclaimer body text', () => {
       render(<LoginPage />)
-      expect(
-        screen.getByText(/you'll be redirected to log in using your myColorado/i)
-      ).toBeInTheDocument()
+      expect(screen.getByText(/you'll be redirected to sign in using/i)).toBeInTheDocument()
     })
 
-    it('renders the myColorado support prompt and link', () => {
-      render(<LoginPage />)
-      expect(screen.getByText('Having trouble signing into the portal?')).toBeInTheDocument()
+    it('renders the disclaimer markdown emphasis as strong text, not literal asterisks', () => {
+      const { container } = render(<LoginPage />)
+      const disclaimer = screen.getByText(/you'll be redirected to sign in using/i)
+      expect(disclaimer.textContent).not.toContain('**')
 
-      const supportLink = screen.getByRole('link', { name: /Contact myColorado/i })
+      const emphasis = Array.from(container.querySelectorAll('strong')).map((el) => el.textContent)
+      expect(emphasis).toContain('your myColorado® account')
+      expect(emphasis).toContain('new one')
+    })
+
+    it('does not render a raw translation key for the unpublished disclaimer body', () => {
+      render(<LoginPage />)
+      expect(screen.queryByText('logInDisclaimerBody2')).not.toBeInTheDocument()
+    })
+
+    it('renders the myColorado support link with the full support sentence', () => {
+      render(<LoginPage />)
+      const supportLink = screen.getByRole('link', {
+        name: /Contact myColorado® support if you are having trouble signing into the portal/i
+      })
       expect(supportLink).toHaveAttribute('href', 'https://mycolorado.state.co.us/customer-support')
       expect(supportLink).toHaveAttribute('target', '_blank')
+    })
+
+    it('renders the Spanish disclaimer emphasis and support link without raw keys', () => {
+      mockLanguage = 'es'
+      const { container } = render(<LoginPage />)
+
+      const emphasis = Array.from(container.querySelectorAll('strong')).map((el) => el.textContent)
+      expect(emphasis).toContain('tu cuenta de myColorado®')
+      expect(screen.queryByText('logInDisclaimerBody2')).not.toBeInTheDocument()
+      expect(
+        screen.getByRole('link', {
+          name: /Comunícate con el equipo de ayuda de myColorado® si tienes problemas/i
+        })
+      ).toBeInTheDocument()
     })
 
     it('renders the about portal card with bullet list', () => {
@@ -205,16 +192,16 @@ describe('LoginPage', () => {
         screen.getByText(/fastest way to manage your family's Summer EBT benefits/i)
       ).toBeInTheDocument()
       expect(
-        screen.getByText(/Request a new Summer EBT card if their child's is lost/i)
+        screen.getByText(/Request a new Summer EBT card if their child’s is lost/i)
       ).toBeInTheDocument()
       expect(
-        screen.getByText(/Opt-in to email communications about your benefits/i)
+        screen.getByText(/Opt-in to email communications about their benefits/i)
       ).toBeInTheDocument()
     })
 
     it('renders the Log in button with myColorado branded styling', () => {
       render(<LoginPage />)
-      const logInButton = screen.getByRole('button', { name: /Log in with myColorado/i })
+      const logInButton = screen.getByRole('button', { name: /Sign in with myColorado/i })
       expect(logInButton).toHaveClass('usa-button')
       expect(logInButton).toHaveClass('usa-button--mycolorado')
       expect(logInButton).not.toHaveClass('usa-button--outline')
@@ -222,7 +209,7 @@ describe('LoginPage', () => {
 
     it('renders the Iniciar sesión button as an outlined myColorado variant', () => {
       render(<LoginPage />)
-      const espButton = screen.getByRole('button', { name: /Iniciar sesión con myColorado/i })
+      const espButton = screen.getByRole('button', { name: /Iniciar con myColorado/i })
       expect(espButton).toHaveAttribute('lang', 'es')
       expect(espButton).toHaveClass('usa-button--mycolorado')
       expect(espButton).toHaveClass('usa-button--outline')
@@ -230,8 +217,8 @@ describe('LoginPage', () => {
 
     it('renders the myColorado logo inside both auth buttons', () => {
       render(<LoginPage />)
-      const logInButton = screen.getByRole('button', { name: /Log in with myColorado/i })
-      const espButton = screen.getByRole('button', { name: /Iniciar sesión con myColorado/i })
+      const logInButton = screen.getByRole('button', { name: /Sign in with myColorado/i })
+      const espButton = screen.getByRole('button', { name: /Iniciar con myColorado/i })
       expect(logInButton.querySelector('[data-testid="mycolorado-logo"]')).toBeInTheDocument()
       expect(espButton.querySelector('[data-testid="mycolorado-logo"]')).toBeInTheDocument()
     })
@@ -244,8 +231,8 @@ describe('LoginPage', () => {
     describe('analytics', () => {
       it('tags both auth buttons with data-analytics-cta for cta_click tracking', () => {
         render(<LoginPage />)
-        const primary = screen.getByRole('button', { name: /Log in with myColorado/i })
-        const secondary = screen.getByRole('button', { name: /Iniciar sesión con myColorado/i })
+        const primary = screen.getByRole('button', { name: /Sign in with myColorado/i })
+        const secondary = screen.getByRole('button', { name: /Iniciar con myColorado/i })
 
         expect(primary).toHaveAttribute('data-analytics-cta', 'login_cta')
         expect(secondary).toHaveAttribute('data-analytics-cta', 'login_cta_alt_lang')
@@ -253,7 +240,7 @@ describe('LoginPage', () => {
 
       it('fires oidc_start when the primary auth button is clicked', () => {
         render(<LoginPage />)
-        const primary = screen.getByRole('button', { name: /Log in with myColorado/i })
+        const primary = screen.getByRole('button', { name: /Sign in with myColorado/i })
 
         primary.click()
 
@@ -262,7 +249,7 @@ describe('LoginPage', () => {
 
       it('fires oidc_start when the secondary auth button is clicked', () => {
         render(<LoginPage />)
-        const secondary = screen.getByRole('button', { name: /Iniciar sesión con myColorado/i })
+        const secondary = screen.getByRole('button', { name: /Iniciar con myColorado/i })
 
         secondary.click()
 
@@ -299,7 +286,7 @@ describe('LoginPage', () => {
       it('routes the primary button to the current UI language in English mode', () => {
         mockLanguage = 'en'
         render(<LoginPage />)
-        const primary = screen.getByRole('button', { name: /Log in with myColorado/i })
+        const primary = screen.getByRole('button', { name: /Sign in with myColorado/i })
 
         primary.click()
 
@@ -310,7 +297,7 @@ describe('LoginPage', () => {
       it('routes the secondary button to the other language in English mode', () => {
         mockLanguage = 'en'
         render(<LoginPage />)
-        const secondary = screen.getByRole('button', { name: /Iniciar sesión con myColorado/i })
+        const secondary = screen.getByRole('button', { name: /Iniciar con myColorado/i })
 
         secondary.click()
 
@@ -323,7 +310,7 @@ describe('LoginPage', () => {
         // should send the user to the Spanish-language MyCO flow, not the English one.
         mockLanguage = 'es'
         render(<LoginPage />)
-        const primary = screen.getByRole('button', { name: /Iniciar sesión con myColorado/i })
+        const primary = screen.getByRole('button', { name: /Iniciar con myColorado/i })
 
         primary.click()
 
@@ -334,7 +321,7 @@ describe('LoginPage', () => {
       it('routes the secondary button to the other language in Spanish mode', () => {
         mockLanguage = 'es'
         render(<LoginPage />)
-        const secondary = screen.getByRole('button', { name: /Log in with myColorado/i })
+        const secondary = screen.getByRole('button', { name: /Sign in with myColorado/i })
 
         secondary.click()
 

--- a/apps/portal/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.test.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.test.tsx
@@ -210,6 +210,22 @@ describe('ApplicationsSection', () => {
     expect(screen.queryByText('CASE-DC-2026-001')).not.toBeInTheDocument()
   })
 
+  it('omits the date heading when the state does not author the label, even with the flag on', () => {
+    // CO enables neither the flag nor the label today. If the flag is turned on before the
+    // content row lands, the heading must degrade away rather than render its key.
+    const bundle = i18n.getResourceBundle('en', 'dashboard') as Record<string, string | undefined>
+    const authoredLabel = bundle.applicationsTableHeadingDateSubmitted
+    delete bundle.applicationsTableHeadingDateSubmitted
+    try {
+      renderWithFlags()
+
+      expect(screen.queryByText('applicationsTableHeadingDateSubmitted')).not.toBeInTheDocument()
+      expect(screen.queryByText('formatted:2026-01-15T00:00:00Z')).not.toBeInTheDocument()
+    } finally {
+      bundle.applicationsTableHeadingDateSubmitted = authoredLabel
+    }
+  })
+
   it('renders application date when show_application_date flag is on', () => {
     renderWithFlags()
 

--- a/apps/portal/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.tsx
+++ b/apps/portal/src/SEBT.Portal.Web/src/features/household/components/ApplicationsSection/ApplicationsSection.tsx
@@ -47,14 +47,18 @@ function ApplicationCard({ application }: { application: Application }) {
     <div className="usa-card__container margin-bottom-2">
       <div className="usa-card__body">
         <dl className="margin-0">
-          {showApplicationDate && application.applicationDate && (
-            <>
-              <dt className="text-bold">{t('applicationsTableHeadingDateSubmitted')}</dt>
-              <dd className="margin-left-0 margin-bottom-2">
-                {formatDate(application.applicationDate, i18n.language)}
-              </dd>
-            </>
-          )}
+          {/* Like the case number below, the date surfaces only where the state's content
+              sheet authors the label, so a flag flip ahead of the content row cannot leak the key. */}
+          {showApplicationDate &&
+            application.applicationDate &&
+            i18n.exists('dashboard:applicationsTableHeadingDateSubmitted') && (
+              <>
+                <dt className="text-bold">{t('applicationsTableHeadingDateSubmitted')}</dt>
+                <dd className="margin-left-0 margin-bottom-2">
+                  {formatDate(application.applicationDate, i18n.language)}
+                </dd>
+              </>
+            )}
 
           {/* States that omit the label in their content sheet do not surface a case number. */}
           {showCaseNumber &&


### PR DESCRIPTION
#### 🔗 Jira ticket
https://codeforamerica.atlassian.net/browse/DC-701

#### ✍️ Description
- CO login disclaimer renders the content sheet's bold emphasis through `RichText` and drops the unpublished second paragraph, so `/login` shows neither literal `**` nor the raw key `logInDisclaimerBody2`.
- Card request and replacement-address pages read their loading label from the `dev` namespace ("Loading..."), which both states author; `common.loading` exists in neither state's bundle.
- The enrollment checker's not-enrolled summary heading renders its markdown emphasis through `RichText` instead of as literal asterisks.
- The dashboard application-date heading renders only where the state's content sheet authors the label, matching the case-number gate, so enabling `show_application_date` ahead of content cannot leak the key.
- Verification: portal 1074 and checker 239 tests pass, tsc and eslint clean; the login page test now reads the generated CO bundles, so a content sync that drops or reshapes a key fails the test.

#### 🔗 Links to related PRs
- #606 (content-sheet sync that landed the new CO login copy this change renders)

#### ✅ Completion tasks
<!-- Remember to add testing instructions to ticket -->

- [x] Added relevant tests
- [x] Meets acceptance criteria in ticket
- [ ] Configuration changes:
  - [ ] If new environment variables are added, update in Tofu
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig
  - [ ] If appsetttings are changed, update in AWS AppConfig

---

## Triage analysis

| Priority | File | Unit | Sec | Cpx | Nov | Notes |
|:---:|---|---|:---:|:---:|:---:|---|
| 🟡 | `ApplicationsSection.tsx` | `ApplicationCard` date row | Low | Med | Low | flag now also needs authored label |

🟢 9 units: `address/page.test.tsx`, `ApplicationsSection.test.tsx`, `COLoginPage.tsx`, `cards/replace/address/page.tsx`, `cards/request/page.tsx`, `login/page.test.tsx`, `NotEnrolledSection.test.tsx`, `NotEnrolledSection.tsx`, `request/page.test.tsx`
