### PR TITLE
Stand up DC enrollment checker static-site infra and CORS origin

### DIFF
--- a/tofu/config/dev-dc/bootstrap/main.tf
+++ b/tofu/config/dev-dc/bootstrap/main.tf
@@ -59,6 +59,14 @@ resource "aws_iam_access_key" "github_actions" {
   user = aws_iam_user.github_actions.name
 }
 
+# Route53 hosted zone for the enrollment checker static site.
+# Created here (not in the main config) because NS delegation to the
+# parent codeforamerica.app zone is an out-of-band step that must
+# complete before ACM certificate validation can succeed.
+resource "aws_route53_zone" "enrollment_checker" {
+  name = "${var.state}.sebt-enrollment.codeforamerica.app"
+}
+
 # ECR repositories for container images.
 resource "aws_ecr_repository" "api" {
   name                 = "${var.project}-${var.state}-${var.environment}-api"

--- a/tofu/config/dev-dc/bootstrap/outputs.tf
+++ b/tofu/config/dev-dc/bootstrap/outputs.tf
@@ -19,6 +19,11 @@ output "github_actions_secret_access_key" {
   sensitive   = true
 }
 
+output "enrollment_checker_nameservers" {
+  description = "NS records for the enrollment checker hosted zone. Send these to the CfA DNS maintainer for delegation."
+  value       = aws_route53_zone.enrollment_checker.name_servers
+}
+
 output "ecr_api_repository_url" {
   description = "ECR repository URL for the API image."
   value       = aws_ecr_repository.api.repository_url

--- a/tofu/config/dev-dc/main.tf
+++ b/tofu/config/dev-dc/main.tf
@@ -63,6 +63,11 @@ data "aws_route53_zone" "main" {
   name = "dc.sebt-portal.codeforamerica.app"
 }
 
+# Look up the enrollment checker hosted zone (created by bootstrap).
+data "aws_route53_zone" "enrollment_checker" {
+  name = "dc.sebt-enrollment.codeforamerica.app"
+}
+
 # Store DC-specific secrets in Secrets Manager. Each key represents a
 # separate secret for a specific service or integration.
 module "state_secrets" {
@@ -176,8 +181,10 @@ module "app" {
     "PiiEncryption__Keys__0__KeyMaterialBase64" = module.state_secrets.secrets["PII_ENCRYPTION_KEY_MATERIAL_BASE64"].secret_arn
   }
 
-  state_web_environment_variables = {}
-  state_web_environment_secrets   = {}
+  state_web_environment_variables = {
+    ENROLLMENT_CHECKER_ORIGIN = "https://dev.dc.sebt-enrollment.codeforamerica.app"
+  }
+  state_web_environment_secrets = {}
 }
 
 # SSM bastion for developer DB access. Uses pure-SSM port forwarding;
@@ -207,4 +214,18 @@ module "dc_source_seed" {
   db_endpoint       = module.app.database_endpoint
   db_secret_arn     = module.app.database_secret_arn
   logging_key_arn   = module.logging.kms_key_arn
+}
+
+# Deploy the enrollment checker as a static site behind CloudFront.
+module "enrollment_checker" {
+  source = "../../modules/sebt_enrollment_checker"
+
+  project                    = var.project
+  state                      = var.state
+  environment                = var.environment
+  domain                     = "dev.dc.sebt-enrollment.codeforamerica.app"
+  hosted_zone_id             = data.aws_route53_zone.enrollment_checker.zone_id
+  logging_bucket_domain_name = module.logging.bucket_domain_name
+  logging_bucket_name        = module.logging.bucket
+  force_delete               = true
 }

--- a/tofu/config/dev-dc/outputs.tf
+++ b/tofu/config/dev-dc/outputs.tf
@@ -8,6 +8,26 @@ output "api_repository_url" {
   value       = module.app.api_repository_url
 }
 
+output "enrollment_checker_distribution_id" {
+  description = "CloudFront distribution ID for the enrollment checker (used for cache invalidation)."
+  value       = module.enrollment_checker.cloudfront_distribution_id
+}
+
+output "enrollment_checker_nameservers" {
+  description = "NS records for the enrollment checker hosted zone."
+  value       = data.aws_route53_zone.enrollment_checker.name_servers
+}
+
+output "enrollment_checker_s3_bucket" {
+  description = "S3 bucket name for the enrollment checker static site."
+  value       = module.enrollment_checker.s3_bucket_id
+}
+
+output "enrollment_checker_url" {
+  description = "Public URL of the enrollment checker."
+  value       = module.enrollment_checker.site_url
+}
+
 output "web_endpoint_url" {
   description = "URL of the Web service endpoint."
   value       = module.app.web_endpoint_url


### PR DESCRIPTION
#### 🔗 Jira ticket
[DC-729](https://<your-jira-domain>/browse/DC-729)

#### ✍️ Description
Stands up the DC enrollment checker's static-site infrastructure, mirroring the existing Colorado setup:

- `tofu/config/dev-dc/bootstrap`: creates a Route53 hosted zone for `dc.sebt-enrollment.codeforamerica.app` and outputs its NS records for delegation.
- `tofu/config/dev-dc`: instantiates the `sebt_enrollment_checker` module (private S3 bucket, CloudFront, ACM cert, Route53 A record) at `dev.dc.sebt-enrollment.codeforamerica.app`, and adds four outputs (S3 bucket, CloudFront distribution ID, nameservers, site URL) so a later CI job can publish files there.
- Sets `ENROLLMENT_CHECKER_ORIGIN` on the DC Web ECS task, so `/api/enrollment/*` returns CORS headers for the checker origin (the CORS logic itself already exists and is state-agnostic — `apps/portal/src/SEBT.Portal.Web/src/proxy.ts` — this just wires the env var for DC).

Out of scope (per ticket): the DCConnector `CheckEligibilityProcName`/stored-proc work, and tearing down the old DC enrollment checker (kept running during the transition).

The new bootstrap zone has already been applied in `dev-dc` and its NS records handed off for delegation under the parent `codeforamerica.app` zone. The main `dev-dc` apply step and this PR (ACM cert validation) are blocked on that delegation propagating.

#### ✅ Completion tasks
- [x] Added relevant tests — N/A, this is OpenTofu configuration; validated with `tofu fmt -check` and `tofu validate` in both `dev-dc/bootstrap` and `dev-dc`, and reviewed the `tofu plan` output for `bootstrap` before applying.
- [X] Meets acceptance criteria in ticket
- [X] Configuration changes:
  - [x] If new environment variables are added, update in Tofu — done (`ENROLLMENT_CHECKER_ORIGIN`)
  - [ ] If new environment secrets are added, update in Tofu and set in AWS Secret Manager — N/A, no new secrets
  - [ ] If you're adding an appsetting, add it to the requisite example file, and update it in the AWS AppConfig — N/A
  - [ ] If appsettings are changed, update in AWS AppConfig — N/A


[DC-729]: https://codeforamerica.atlassian.net/browse/DC-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ