### PR TITLE
[DC-306] Add manual start/end SHA overrides to push-button-release

### DIFF
--- a/.github/workflows/push-button-release.yaml
+++ b/.github/workflows/push-button-release.yaml
@@ -4,12 +4,28 @@ on:
   workflow_dispatch:
     inputs:
       state:
-        description: 'Which state to cut a formal release for. Dispatch this against main — the release tag is created at whatever ref this workflow runs on.'
+        description: 'Which state to cut a formal release for. Dispatch this against main — the release tag is created at end_sha if set, otherwise at whatever ref this workflow runs on.'
         required: true
         type: choice
         options:
           - dc
           - co
+      start_sha:
+        description: 'Optional: manually specify the starting commit SHA for the portal range, instead of auto-resolving it from the live /api/build-info endpoint. Use this when that endpoint is unreachable (e.g. blocked by state WAF/network rules). Leave blank to auto-resolve.'
+        required: false
+        type: string
+      end_sha:
+        description: 'Optional: commit SHA to end the portal range at. Leave blank to use the latest commit on main.'
+        required: false
+        type: string
+      connector_start_sha:
+        description: '(DC only) Optional: manually specify the starting commit SHA for the dc-connector range, instead of auto-resolving it from the live endpoint. Ignored (must be blank) when state is not dc.'
+        required: false
+        type: string
+      connector_end_sha:
+        description: '(DC only) Optional: commit SHA to end the dc-connector range at, instead of auto-resolving the branch/main ref. Ignored (must be blank) when state is not dc.'
+        required: false
+        type: string
       include_chores:
         description: 'Include Chores in this release (normally excluded)'
         required: false
@@ -29,6 +45,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.end_sha || 'main' }}
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -46,8 +63,15 @@ jobs:
             *) echo "::error::Unknown state: $STATE"; exit 1 ;;
           esac
 
+      - name: Validate connector SHA overrides are DC-only
+        if: inputs.state != 'dc' && (inputs.connector_start_sha != '' || inputs.connector_end_sha != '')
+        run: |
+          echo "::error::connector_start_sha/connector_end_sha only apply when state=dc — leave them blank for a co release."
+          exit 1
+
       - name: Resolve live portal SHA
         id: old-portal-sha
+        if: inputs.start_sha == ''
         run: |
           SHA="$(./scripts/release-notes/resolve-live-sha.sh --url "${{ steps.prod-url.outputs.url }}" --field buildSha)"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
@@ -68,7 +92,7 @@ jobs:
 
       - name: Determine dc-connector ref
         id: dc-connector-ref
-        if: inputs.state == 'dc'
+        if: inputs.state == 'dc' && inputs.connector_end_sha == ''
         env:
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
@@ -119,13 +143,13 @@ jobs:
         with:
           repository: codeforamerica/sebt-self-service-portal-dc-connector
           token: ${{ steps.dc-connector-token.outputs.token }}
-          ref: ${{ steps.dc-connector-ref.outputs.ref }}
+          ref: ${{ inputs.connector_end_sha || steps.dc-connector-ref.outputs.ref }}
           path: dc-connector
           fetch-depth: 0
 
       - name: Resolve live dc-connector SHA
         id: old-connector-sha
-        if: inputs.state == 'dc'
+        if: inputs.state == 'dc' && inputs.connector_start_sha == ''
         run: |
           SHA="$(./scripts/release-notes/resolve-live-sha.sh --url "${{ steps.prod-url.outputs.url }}" --field dcConnectorSha --git-dir dc-connector)"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
@@ -142,7 +166,7 @@ jobs:
           mv "scripts/release-notes/output/$(date +%Y-%m-%d).md" "$RUNNER_TEMP/portal-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SINCE_SHA: ${{ steps.old-portal-sha.outputs.sha }}
+          SINCE_SHA: ${{ inputs.start_sha || steps.old-portal-sha.outputs.sha }}
           STATE_FILTER: ${{ inputs.state }}
           INCLUDE_CHORES: ${{ inputs.include_chores }}
 
@@ -164,7 +188,7 @@ jobs:
           mv "scripts/release-notes/output/$(date +%Y-%m-%d).md" "$RUNNER_TEMP/connector-notes.md"
         env:
           GH_TOKEN: ${{ steps.dc-connector-token.outputs.token }}
-          SINCE_SHA: ${{ steps.old-connector-sha.outputs.sha }}
+          SINCE_SHA: ${{ inputs.connector_start_sha || steps.old-connector-sha.outputs.sha }}
           INCLUDE_CHORES: ${{ inputs.include_chores }}
 
       # ─── Compose and publish ─────────────────────────────────────────────────────
@@ -206,6 +230,7 @@ jobs:
           tag_name: ${{ steps.compose.outputs.date }}-${{ steps.compose.outputs.tag_suffix }}
           name: "${{ steps.compose.outputs.date }} ${{ steps.compose.outputs.state_name }} Release"
           body_path: ${{ runner.temp }}/release-body.md
+          target_commitish: ${{ inputs.end_sha || github.sha }}
           draft: true
           prerelease: false
         env:


### PR DESCRIPTION
#### 🔗 Jira ticket
<!-- Add link to the issue -->

#### ✍️ Description
Adds manual override inputs to `push-button-release.yaml` so a release can be cut
without depending on the live `/api/build-info` auto-resolution.

This was prompted by CO releases failing: `resolve-live-sha.sh` reported the
endpoint was returning invalid JSON, even though it demonstrably works when
requested from anywhere except a GitHub-hosted runner. [A diagnostic
run](https://github.com/codeforamerica/sebt-self-service-portal/actions/runs/33097001318/job/98613280165) confirmed the runner's egress IP falls in GitHub's own published Actions
range, and CO's production edge appears to redirect that traffic to `/` instead of serving the route. That's
infrastructure outside this repo's control, so rather than wait on a fix there,
this adds a manual escape hatch.

New inputs:
- `start_sha` / `end_sha` — override the portal's diff range. `end_sha` also
  controls what the checked-out `HEAD` is (so it flows through to
  `generate.ts`'s diffing unmodified) and sets the release tag's
  `target_commitish`, so the tag lands on `end_sha` rather than always the
  ref the workflow was dispatched against.
- `connector_start_sha` / `connector_end_sha` — same idea for the DC-connector
  section, gated to only take effect when `state=dc`. GitHub's
  `workflow_dispatch` form can't conditionally hide inputs based on another
  input's value, so these are always visible in the UI. A new validation step
  fails loudly if they're set while `state=co` instead of silently ignoring them.

All inputs are optional and default to the existing auto-resolved behavior —
no change for a normal run that leaves them blank.

#### 🧪 Testing / UAT
Manually dispatched `push-button-release.yaml` against this branch (`gh workflow
run push-button-release.yaml --ref <branch>`) to exercise every functional path.
All runs produced a draft release with the expected tag, `target_commitish`,
section contents, and `Full Changelog` compare links; unaffected steps
correctly showed as skipped in each case.

1. **CO, start override only, end defaulted**
   `-f state=co -f start_sha=98b013a1 -f include_chores=false`
   Verifies `Resolve live portal SHA` is skipped (the actual CO workaround),
   and `end_sha` left blank correctly defaults to `main`.

2. **CO, full explicit range, chores included**
   `-f state=co -f start_sha=98b013a171b95a5fed067348d4d04085ecfde71e -f end_sha=7c379019e9f90eac0df22a703badff34ac2e2074 -f include_chores=true`
   Verifies the release tag's `target_commitish` lands on `end_sha` (not the
   dispatch ref), the compare link matches the exact range, and `## Chores`
   appears when opted in.

3. **DC, portal + connector start overrides only, both ends defaulted**
   `-f state=dc -f start_sha=98b013a1 -f connector_start_sha=72c4a5435d1a5c84e7a47d60a7c66af54f933685`
   Verifies both auto-resolution steps skip independently, and confirms
   `connector_end_sha` left blank falls back to the *existing* paired-branch-or-main
   resolution (not simply hardcoded to `main`, unlike the portal's `end_sha`).

4. **DC, full explicit range for both portal and connector, chores excluded**
   `-f state=dc -f start_sha=631227fe132813a6b45ad6018f4b2a48e0b02c2e -f end_sha=fd1c907fbba405c3ee4882abe9d724d8aff589fc -f connector_start_sha=1c19b08aea21a7a843dbb7246488b48fe3ec026b -f connector_end_sha=0c01747d8fbba254e786670c13e2ab7832fa798f -f include_chores=false`
   Verifies all four overrides apply together correctly, with independent,
   correct compare links for the portal and connector sections.

5. **CO with a connector override set (invalid combination)**
   `-f state=co -f start_sha=98b013a1 -f connector_start_sha=72c4a5435d1a5c84e7a47d60a7c66af54f933685`
   Verifies the new `Validate connector SHA overrides are DC-only` step fails
   the job immediately with a clear error, before any live-endpoint or checkout
   work runs, instead of silently ignoring the connector input.

Test draft releases created by these runs are not published; delete them from Releases before merging.
